### PR TITLE
Make Ciena 8700 prompt detection more liberal + logging

### DIFF
--- a/handlers/network/src/main/java/orca/handlers/network/core/SSHConsolePromptDevice.java
+++ b/handlers/network/src/main/java/orca/handlers/network/core/SSHConsolePromptDevice.java
@@ -3,6 +3,7 @@ package orca.handlers.network.core;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.regex.Pattern;
+import org.apache.commons.lang.StringEscapeUtils;
 
 
 /**
@@ -85,6 +86,7 @@ public abstract class SSHConsolePromptDevice extends SSHConsoleDevice {
 
         while (!found) {
             String read = readOutput(timeout);
+            logger.debug("SSH output: " + StringEscapeUtils.escapeJava(read));
 
             // Stop if no progress
             if (read.equals(""))

--- a/handlers/network/src/main/java/orca/handlers/network/router/Ciena8700Device.java
+++ b/handlers/network/src/main/java/orca/handlers/network/router/Ciena8700Device.java
@@ -18,8 +18,10 @@ import orca.handlers.network.core.CommandException;
 
 public class Ciena8700Device extends RouterSSHPromptDevice implements IMappingRouterDevice, RouterConstants {
 
-    protected static final String promptPatternString = "^[a-zA-Z0-9]+8700.>";
-
+    /* The prompt consists of a host-like name and an optional access level
+     * symbol, followed by a greater-than sign.
+     */
+    protected static final String promptPatternString = "^[a-zA-Z0-9][a-zA-Z0-9_.-]*.?>";
 
     protected static final String PropertySubPort = "subPort"; //8700
     protected static final String PropertyQoSSubPort = "qosSubPort"; //8700


### PR DESCRIPTION
It seems the 8700 prompt can consists of more characters than we currently test for. This pull requests adds some common characters, like underscores, hyphens, and dots.  It also makes the symbol at the end of the prompt optional.

In addition, to make debugging easier, the output of the device is logged so that problems with matching can be more easily resolved in the future.

Related issue: https://github.com/RENCI-NRIG/exogeni/issues/29
