### PR TITLE
Match whitespace after prompt

### DIFF
--- a/handlers/network/src/main/java/orca/handlers/network/router/Ciena8700Device.java
+++ b/handlers/network/src/main/java/orca/handlers/network/router/Ciena8700Device.java
@@ -18,10 +18,10 @@ import orca.handlers.network.core.CommandException;
 
 public class Ciena8700Device extends RouterSSHPromptDevice implements IMappingRouterDevice, RouterConstants {
 
-    /* The prompt consists of a host-like name and an optional access level
-     * symbol, followed by a greater-than sign.
+    /* The prompt consists of a host-like name and an optional symbol, followed
+     * by a greater-than sign and some whitespace.
      */
-    protected static final String promptPatternString = "^[a-zA-Z0-9][a-zA-Z0-9_.-]*.?>";
+    protected static final String promptPatternString = "^[a-zA-Z0-9][a-zA-Z0-9_.-]*.?>\\s*";
 
     protected static final String PropertySubPort = "subPort"; //8700
     protected static final String PropertyQoSSubPort = "qosSubPort"; //8700


### PR DESCRIPTION
Java's Pattern.matcher is stricted than I assumed it was, and does not perform
partial matching.  This means the whitespace after the greater-than sign caused
the matching to fail.
