### PR TITLE
#89 added property container.threads

### DIFF
--- a/core/shirako/src/main/java/orca/shirako/container/api/IOrcaConfiguration.java
+++ b/core/shirako/src/main/java/orca/shirako/container/api/IOrcaConfiguration.java
@@ -24,6 +24,12 @@ public interface IOrcaConfiguration {
      */
     public static final String PropertyContainerManagerClass = "container.manager.class";
 
+    /**
+     * Number of Jetty container threads to start for non-SSL Actor Container connections
+     * See: https://github.com/RENCI-NRIG/orca5/issues/89
+     */
+    public static final String PropertyContainerThreads = "container.threads";
+
     public static final String PropertySoapAxis2Url = "protocols.soapaxis2.url";
 
     public static final String RemoteRegistryCacheClass = "RemoteRegistryCache.class";


### PR DESCRIPTION
Not the cleanest thing to add.  Previously, all of the configuration properties were not loaded until Globals.start().  Moved things around in Globals just enough to allow reading of configuration properties before the rest had been started.

Let me know if this looks alright.