### PR TITLE
mvn clean will delete xmlrpc/modelState directory

### DIFF
--- a/controllers/pom.xml
+++ b/controllers/pom.xml
@@ -28,6 +28,19 @@
 					<skip>true</skip>
 				</configuration>
 			</plugin>
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.0.0</version>
+				<configuration>
+					<filesets>
+						<fileset>
+							<!-- the modelState directory can get huge. -->
+							<directory>xmlrpc/modelState</directory>
+							<followSymlinks>false</followSymlinks>
+						</fileset>
+					</filesets>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
I wouldn't normally do a branch for a simple config change like this.  But I wanted to make sure nobody would mind if these state files got deleted on `mvn clean`.

In my experience, these files get created from running controller tests, and they can quickly fill up hundreds of GB of disk.  And I don't have or know of any reason why I would want to keep them around in my development environment.