### PR TITLE
Rpm versioning

### DIFF
--- a/docker/orca-rpmbuild/docker_build_rpms.sh
+++ b/docker/orca-rpmbuild/docker_build_rpms.sh
@@ -33,6 +33,9 @@ echo "done."
 # Create RPM build directories
 mkdir -p "${RPM_BUILD_DIR}/RPMS"
 
+# start in the right directory
+cd "$( dirname "$0" )"
+
 # Build new docker container, that contains current sources
 mvn clean package -Pdocker
 

--- a/docker/orca-rpmbuild/pom.xml
+++ b/docker/orca-rpmbuild/pom.xml
@@ -52,6 +52,9 @@
 							     Ideally, we would only do this on Mac systems,
 							     where the Docker engine is exceptionally slow
 							     at using volume mounted files. -->
+							<!-- normally would want to exclude .git directory,
+							     but it is needed to get the git commit ID.
+							     `git describe` seems to need the full objects dir -->
 							<resource>
 								<targetPath>/orca/</targetPath>
 								<directory>${project.basedir}/../../</directory>
@@ -60,7 +63,6 @@
 									<exclude>**/repo/**/*</exclude>
 									<exclude>**/network/logs/**/*</exclude>
 									<exclude>**/startup/**/*</exclude>
-									<exclude>**/.git/**/*</exclude>
 									<exclude>**/handlers/network/logs/</exclude>
 									<exclude>**/nodeagent/scripts/**/*</exclude>
 									<exclude>**/server/orca/config/runtime/**/*</exclude>
@@ -75,16 +77,6 @@
 									<exclude>**/.project</exclude>
 									<exclude>**/.classpath</exclude>
 									<exclude>**/.settings/**/*</exclude>
-								</excludes>
-							</resource>
-							<!-- normally wouldn't want to include .git directory,
-							     but it is needed to get the git commit ID.
-							     luckily, most of it is small, except for the objects dir. -->
-							<resource>
-								<targetPath>/orca/.git/</targetPath>
-								<directory>${project.basedir}/../../.git/</directory>
-								<excludes>
-									<!--<exclude>objects/**/*</exclude>-->
 								</excludes>
 							</resource>
 						</resources>

--- a/docker/orca-rpmbuild/pom.xml
+++ b/docker/orca-rpmbuild/pom.xml
@@ -84,7 +84,7 @@
 								<targetPath>/orca/.git/</targetPath>
 								<directory>${project.basedir}/../../.git/</directory>
 								<excludes>
-									<exclude>objects/**/*</exclude>
+									<!--<exclude>objects/**/*</exclude>-->
 								</excludes>
 							</resource>
 						</resources>

--- a/redhat/buildrpm.sh
+++ b/redhat/buildrpm.sh
@@ -128,7 +128,7 @@ fi
 if [ -n "${INSTALL_RPM}" ]; then
     echo "Preparing to install RPMs..."
     cd "${RPM_BUILD_DIR}/RPMS/x86_64"
-    sudo rpm -Uvh --force "*${VERSION}*.rpm"
+    sudo rpm -Uvh --force "*${BUILD_NAME}*.rpm"
 fi
 
 echo "Done."

--- a/redhat/buildrpm.sh
+++ b/redhat/buildrpm.sh
@@ -96,7 +96,7 @@ cp -a ../. "${BASE_SRC_DIRPATH}"
 # Post-process source
 export BLD_DATE=`date "+%Y%m%d%H%M"`
 export COMMIT=`git rev-parse HEAD`
-sed -i -e "s;@@DATE@@;${BLD_DATE};" "${BASE_SRC_DIRPATH}/redhat/orca-iaas.spec"
+sed -i -e "s;@@RELEASE@@;${BLD_DATE};" "${BASE_SRC_DIRPATH}/redhat/orca-iaas.spec"
 sed -i -e "s;@@COMMIT@@;${COMMIT};" "${BASE_SRC_DIRPATH}/redhat/orca-iaas.spec"
 sed -i -e "s;@@VERSION@@;${VERSION};" "${BASE_SRC_DIRPATH}/redhat/orca-iaas.spec"
 
@@ -105,7 +105,7 @@ cd "${ORCA_BLD}"
 
 # Create tarball
 BUILD_NAME=${BASE_SRC_DIR}-${BLD_DATE}
-rm -rf ${BASE_SRC_DIR}-*
+rm -rf orca-iaas-*-*
 mv ${BASE_SRC_DIR} ${BUILD_NAME}
 tar -czf ${BUILD_NAME}.tar.gz ${BUILD_NAME}
 echo "Built tarball ${BUILD_NAME}.tar.gz"

--- a/redhat/orca-iaas.spec
+++ b/redhat/orca-iaas.spec
@@ -1,12 +1,11 @@
 %global commit @@COMMIT@@
-%global version @@VERSION@@
 
 Summary: ORCA - An infrastructure-as-a-service control framework
 Name: orca-iaas
 # Version is for software
 # Release is for packaging
-Version: %{version}
-Release: @@DATE@@
+Version: @@VERSION@@
+Release: @@RELEASE@@
 #
 BuildRoot: %{_builddir}/%{name}-root
 Source: https://github.com/RENCI-NRIG/orca5/archive/%{commit}/%{name}-%{version}-%{release}.tar.gz

--- a/redhat/orca-iaas.spec
+++ b/redhat/orca-iaas.spec
@@ -1,17 +1,15 @@
 %global commit @@COMMIT@@
-%global shortcommit @@SHORTCOMMIT@@
+%global version @@VERSION@@
 
 Summary: ORCA - An infrastructure-as-a-service control framework
 Name: orca-iaas
-Version: 5.0.0
-# NOTE:
-# DO NOT MODIFY "Release", UNLESS:
-# 1) We move to a revision structure that isn't based on the subversion GlobalRev.
-# 2) Packaging up a tarball for others to use with "rpmbuild -ta"
-Release: @@DATE@@git%{shortcommit}
+# Version is for software
+# Release is for packaging
+Version: %{version}
+Release: @@DATE@@
 #
 BuildRoot: %{_builddir}/%{name}-root
-Source: https://github.com/RENCI-NRIG/orca5/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
+Source: https://github.com/RENCI-NRIG/orca5/archive/%{commit}/%{name}-%{version}-%{release}.tar.gz
 Group: Applications/System
 Vendor: RENCI/ExoGENI
 Packager: RENCI/ExoGENI
@@ -128,7 +126,7 @@ This package contains the ORCA_HOME directory specific to the
 container housing the SM actor.
 
 %prep
-%setup -q -n %{name}-%{version}-%{shortcommit}
+%setup -q -n %{name}-%{version}-%{release}
 
 %build
 LANG=en_US.UTF-8 MAVEN_OPTS=%{maven_opts} mvn ${MAVEN_ARGS} clean install -DskipTests=true


### PR DESCRIPTION
This code change enables #96.  The rpm building scripts needed to be updated to produce RPMs with the proper release versions from git.

It uses [git describe](http://softwareengineering.stackexchange.com/a/141986) to get a version string that will look something like this:
```
v2.5-0-deadbeef
^    ^ ^
|    | |
|    | SHA of HEAD
|    |
|    number of commits since last tag
|
last tag
```

In Jenkins, the RPM building should always happen on the Tagged version, so the number of commits since last tag should always be 0.  But keeping the rpm building script more versatile for personal builds seemed useful.

I've tested these changes in Jenkins in a [test job](https://ci.exogeni.net:8443/job/test_CentOS6_ORCA_RPM_RELEASE/), and they seem to work correctly.  I've also copied the changes made to two 'production' jobs that will only run with new tagged releases.