### PR TITLE
123 TicketReview AM

### DIFF
--- a/core/policy/src/main/java/orca/policy/core/ServiceManagerTicketReviewPolicy.java
+++ b/core/policy/src/main/java/orca/policy/core/ServiceManagerTicketReviewPolicy.java
@@ -156,7 +156,9 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
                             // Fail the reservation, and remove it from everything
                             logger.info("TicketReview: Closing reservation " + reservation.getReservationID() +
                                     " due to failure in Slice " + slice.getName());
-                            reservation.fail("TicketReview: Closing reservation due to failure in Slice.");
+
+                            // Important: closing a reservation in the SM will also close the reservation in the AM and Broker.
+                            // BUT ONLY if the reservation is not failed.
                             actor.close(reservation); // "perform local close operations and issue close request to authority"
                             calendar.removePending(reservation);
                             pendingNotify.remove(reservation);

--- a/core/policy/src/main/java/orca/policy/core/ServiceManagerTicketReviewPolicy.java
+++ b/core/policy/src/main/java/orca/policy/core/ServiceManagerTicketReviewPolicy.java
@@ -1,6 +1,5 @@
 package orca.policy.core;
 
-import orca.ndl.DomainResourceType;
 import orca.shirako.api.IReservation;
 import orca.shirako.common.SliceID;
 import orca.shirako.kernel.IKernelSlice;
@@ -9,8 +8,6 @@ import orca.util.persistence.NotPersistent;
 
 import java.util.*;
 
-import static orca.manage.OrcaConstants.*;
-
 /**
  * This implementation of a Service Manager policy is almost identical to the parent
  * ServiceManagerSimplePolicy.
@@ -18,6 +15,9 @@ import static orca.manage.OrcaConstants.*;
  * The only real difference is that it addresses the following issue:
  * https://github.com/RENCI-NRIG/orca5/issues/88
  * Tickets should not be redeemed if any reservations are currently Failed or Nascent.
+ *
+ * This effectively acts as a "gate" between the SM and AM.
+ * All reservations must be Ticketed, before any reservations are allowed to be redeemed.
  *
  */
 public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy {
@@ -28,6 +28,17 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
     public ServiceManagerTicketReviewPolicy(){
         super();
         pendingRedeem = new ReservationSet();
+    }
+
+    /**
+     * Redeemable: the default.  No slice reservations have been found that are either Nascent or Failed.
+     * Nascent: occurs when any reservation is Nascent, i.e. not yet Ticketed.  Will take precedence over Failing.
+     * Failing: occurs when a slice reservation is found that is Failed.
+     */
+    public enum TicketReviewSliceState {
+        Nascent,
+        Failing,
+        Redeemable
     }
 
     /**
@@ -48,7 +59,7 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
         ReservationSet myPending = calendar.getPending();
 
         // keep track of status of the slice containing each reservation
-        Map<SliceID, Integer> sliceStatusMap = new HashMap<>();
+        Map<SliceID, TicketReviewSliceState> sliceStatusMap = new HashMap<>();
 
         // keep track of which sites (per slice) had a failure
         // Note: this feature is not currently used
@@ -69,7 +80,7 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
                 // check if we've examined this slice already
                 if (!sliceStatusMap.containsKey(sliceID)) {
                     // set the default status
-                    sliceStatusMap.put(sliceID, ReservationStateActive);
+                    sliceStatusMap.put(sliceID, TicketReviewSliceState.Redeemable);
 
                     // examine every reservation contained within the slice,
                     // looking for either a Failed or Nascent reservation
@@ -79,7 +90,7 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
                         // If any Reservations that are being redeemed, that means the slice has already cleared TicketReview.
                         if (sliceReservation.isRedeeming()){
                             // There shouldn't be any Nascent reservations, if a reservation is being Redeemed.
-                            if (sliceStatusMap.get(sliceID) == ReservationStateNascent){
+                            if (sliceStatusMap.get(sliceID) == TicketReviewSliceState.Nascent){
                                 logger.error("TicketReview: Nascent reservation found while Reservation " +
                                         sliceReservation.getReservationID() +
                                         " in Slice " + slice.getName() +
@@ -90,7 +101,9 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
                             // but if a ticketed reservation is being redeemed,
                             // the failure _should_ be from the AM, not SM,
                             // so it should be ignored by TicketReview
-                            sliceStatusMap.put(sliceID, ReservationStateActive);
+                            sliceStatusMap.put(sliceID, TicketReviewSliceState.Redeemable);
+
+                            // we don't need to look at any other reservations in this slice
                             break;
                         }
 
@@ -107,8 +120,8 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
                             // those Nascent tickets might get redeemed.
                             // we must wait to Close any failed reservations
                             // until all Nascent tickets are either Ticketed or Failed
-                            if (Objects.equals(sliceStatusMap.get(sliceID), ReservationStateActive)) {
-                                sliceStatusMap.put(sliceID, ReservationStateFailed);
+                            if (Objects.equals(sliceStatusMap.get(sliceID), TicketReviewSliceState.Redeemable)) {
+                                sliceStatusMap.put(sliceID, TicketReviewSliceState.Failing);
 
                                 // Keep track of which sites had failures
                                 // Using Authority Name would be better than ResourceType,
@@ -138,7 +151,7 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
                                         " when checkPending() for " + reservation.getReservationID());
                             }
 
-                            sliceStatusMap.put(sliceID, ReservationStateNascent);
+                            sliceStatusMap.put(sliceID, TicketReviewSliceState.Nascent);
 
                             // once we have found a Nascent reservation, that is what we treat the entire slice
                             break;
@@ -147,7 +160,7 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
                 }
 
                 // take action on the current reservation
-                if (sliceStatusMap.get(sliceID) == ReservationStateFailed) {
+                if (sliceStatusMap.get(sliceID) == TicketReviewSliceState.Failing) {
                     if (reservation.getResources() != null && reservation.getResources().getType() != null) {
                         // only fail the reservation if it from the same site as another failed reservation
                         // Note: this feature is not currently used
@@ -164,7 +177,7 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
                             pendingNotify.remove(reservation);
                         //} // sliceFailureSites
                     }
-                } else if (sliceStatusMap.get(sliceID) == ReservationStateNascent) {
+                } else if (sliceStatusMap.get(sliceID) == TicketReviewSliceState.Nascent) {
                     // save this reservation for later
                     logger.info("Moving reservation " + reservation.getReservationID() +
                             " to pendingRedeem list, due to nascent reservation in slice " + slice.getName());

--- a/core/policy/src/main/java/orca/policy/core/ServiceManagerTicketReviewPolicy.java
+++ b/core/policy/src/main/java/orca/policy/core/ServiceManagerTicketReviewPolicy.java
@@ -67,11 +67,7 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
             // only want to do this for 'new' tickets
             if (reservation.isFailed() || reservation.isTicketed()) {
                 // check if we've examined this slice already
-                if (Objects.equals(sliceStatusMap.get(sliceID), ReservationStateActive)) {
-                    // we've looked at all of the reservations for this slice, and they are ok
-                    continue;
-
-                } else if (!sliceStatusMap.containsKey(sliceID)) {
+                if (!sliceStatusMap.containsKey(sliceID)) {
                     // set the default status
                     sliceStatusMap.put(sliceID, ReservationStateActive);
 
@@ -98,7 +94,7 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
                             break;
                         }
 
-                        if (sliceReservation.getState() == ReservationStateFailed) {
+                        if (sliceReservation.isFailed()) {
                             if (logger.isDebugEnabled()) {
                                 logger.debug("Found Failed Reservation " +
                                         sliceReservation.getReservationID() +
@@ -134,7 +130,7 @@ public class ServiceManagerTicketReviewPolicy extends ServiceManagerSimplePolicy
                                     //}
                                 //} // sliceSiteFailure
                             }
-                        } else if (sliceReservation.getState() == ReservationStateNascent) {
+                        } else if (sliceReservation.isNascent()) {
                             if (logger.isDebugEnabled()) {
                                 logger.debug("Found Nascent Reservation " +
                                         sliceReservation.getReservationID() +

--- a/core/policy/src/test/java/orca/policy/core/ServiceManagerTicketReviewPolicyTest.java
+++ b/core/policy/src/test/java/orca/policy/core/ServiceManagerTicketReviewPolicyTest.java
@@ -62,8 +62,8 @@ public class ServiceManagerTicketReviewPolicyTest extends ServiceManagerPolicyTe
             }
 
             if ((i >= start) && (i < (end - 1))) {
-                assertTrue(r1.getState() == ReservationStates.Closed);
-                assertTrue(r2.getState() == ReservationStates.Closed);
+                assertTrue(r1.isClosed());
+                assertTrue(r2.isClosed());
             }
 
         }
@@ -114,20 +114,21 @@ public class ServiceManagerTicketReviewPolicyTest extends ServiceManagerPolicyTe
             }
 
             if ( (i == start-3) && !r2demanded ){
-                assertTrue(r1.getState() == ReservationStates.Ticketed);
-                assertTrue(r2.getState() == ReservationStates.Nascent);
+                assertTrue(r1.isTicketed());
+                assertTrue(r2.isNascent());
                 sm.demand(r2.getReservationID());
                 r2demanded = true;
             }
 
             if ((i >= start) && (i < (end - 1))) {
-                assertTrue(r1.getState() == ReservationStates.Active);
-                assertTrue(r2.getState() == ReservationStates.Active);
+                assertTrue(r1.isActive());
+                assertTrue(r2.isActive());
+                //System.out.println("i: " + i + " r1.getState() = " + r1.getState() + " r2.getState() = " + r2.getState());
             }
 
             if (i > end) {
-                assertTrue(r1.getState() == ReservationStates.Closed);
-                assertTrue(r2.getState() == ReservationStates.Closed);
+                assertTrue(r1.isClosed());
+                assertTrue(r2.isClosed());
             }
         }
 
@@ -188,9 +189,9 @@ public class ServiceManagerTicketReviewPolicyTest extends ServiceManagerPolicyTe
 
             // give plenty of time to make sure the Failed ticket is not closed until Nascent is resolved
             if ( i>2 && !r2demanded ){
-                assertTrue(r1.getState() == ReservationStates.Failed);
-                assertTrue(r2.getState() == ReservationStates.Nascent);
-                assertTrue(r3.getState() == ReservationStates.Ticketed);
+                assertTrue(r1.isFailed());
+                assertTrue(r2.isNascent());
+                assertTrue(r3.isTicketed());
 
                 if (i>6) {
                     sm.demand(r2.getReservationID());
@@ -199,14 +200,16 @@ public class ServiceManagerTicketReviewPolicyTest extends ServiceManagerPolicyTe
             }
 
             if ((i >= start) && (i < (end - 1))) {
-                assertTrue(r1.getState() == ReservationStates.Closed);
-                assertTrue(r2.getState() == ReservationStates.Closed);
-                assertTrue(r3.getState() == ReservationStates.Closed);
+                //System.out.println("i: " + i + " r1.getState() = " + r1.getState() + " r2.getState() = " + r2.getState() + " r3.getState() = " + r3.getState());
+                assertTrue(r1.isClosed());
+                assertTrue(r2.isClosed());
+                assertTrue(r3.isClosed());
             }
 
             if (i > end) {
-                assertTrue(r1.getState() == ReservationStates.Closed);
-                assertTrue(r2.getState() == ReservationStates.Closed);
+                assertTrue(r1.isClosed());
+                assertTrue(r2.isClosed());
+                assertTrue(r3.isClosed());
             }
         }
 


### PR DESCRIPTION
Fixes #123, possibly two ways.

1. Any pending tickets indicates that the Slice has already passed the "gate" of TicketReview, and TicketReview should not modify any reservations.
1. [Closing a reservation](https://github.com/RENCI-NRIG/orca5/blob/orca-5.1.5/core/shirako/src/main/java/orca/shirako/kernel/ReservationClient.java#L763) in the SM (TicketReview) should result in the reservation also being closed in the AM and Broker.  This was not happening, and reservations were being leaked, because the SM only sends the close message to the other Actors if the reservation is not Failed.  TicketReview was previously Failing and then Closing tickets, which resulted in the close message not being sent.

Unfortunately I think this means that TicketReview looses the ability to provide a message indicating why a reservation was closed.  Previously, it was providing the message via the statement `reservation.fail("TicketReview: Closing reservation due to failure in Slice.");`
