### PR TITLE
Commenting out special handling of stitchport interfaces in NDL Path …

### DIFF
--- a/ndl/src/main/java/orca/ndl/elements/NdlPath.java
+++ b/ndl/src/main/java/orca/ndl/elements/NdlPath.java
@@ -112,11 +112,12 @@ public class NdlPath extends NdlCommons {
 		for (Resource endInt: NdlCommons.getResourceInterfaces(end.getResource())) {
 			// if interface leads to compute element or stitchport, skip it. this is a hack dealing with
 			// interface naming in multipoint connections 10/11/16 /ib
-			if (NdlCommons.attachedToCompute(endInt) || (NdlCommons.attachedToStitchPort(endInt))) {
-				if (debug)
-					System.out.println("  Interface " + endInt + " leads to compute element or stitchport, skipping");
-				continue;
-			}
+			// commenting out based on yxin's request 05/09/17 /ib
+			//if (NdlCommons.attachedToCompute(endInt) || (NdlCommons.attachedToStitchPort(endInt))) {
+			//	if (debug)
+			//		System.out.println("  Interface " + endInt + " leads to compute element or stitchport, skipping");
+			//	continue;
+			//}
 			if (endInt.equals(last.getTail())) {
 				end.setHead(endInt);
 				path.add(end);


### PR DESCRIPTION
…identification as per @YufengXin request

New versions of Flukes (the only code that uses NdlPath is in Flukes right now) will use this. 