### PR TITLE
Docker openjdk

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,6 +6,11 @@ If you have all of the dependencies setup, you should be able to simply do:
 ./docker_build.sh
 ```
 
+Optionally, you can specify the JRE vendor to use (Oracle and OpenJDK are supported) using `-j` or `--jre`
+```
+./docker_build.sh --jre openjdk
+```
+
 Or, you can build individual containers manually using Maven:
 ```
 mvn clean package -Pdocker
@@ -17,7 +22,14 @@ Four runnable Docker images will be created. Use this script to start them all:
 ./docker_run.sh
 ```
 
-Or start them manually in this order:
+You can specify a specific docker image tag using `-t` or `--tag-name`:
+```
+./docker_run.sh --tag-name openjdk
+./docker_run.sh --tag-name 5.1.7-SNAPSHOT-openjdk
+```
+
+### Running the containers manually
+Start them manually in this order:
 
 A MySQL container configured for Orca:
 ```

--- a/docker/docker_build.sh
+++ b/docker/docker_build.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
 
 DOCKER_MVN_CMD="mvn clean package -Pdocker"
+DOCKER_JRE_VENDOR="oracle"
+
+while [[ $# -gt 1 ]]
+do
+key="$1"
+
+case $key in
+    -j|--jre)
+    DOCKER_JRE_VENDOR="$2"
+    shift # past argument
+    ;;
+    *)
+            # unknown option
+    ;;
+esac
+shift # past argument or value
+done
+
+DOCKER_MVN_CMD="${DOCKER_MVN_CMD} -Dorca.docker.jre.vendor=${DOCKER_JRE_VENDOR}"
 
 # start in the docker directory
 cd "$( dirname "$0" )"
@@ -28,7 +47,7 @@ f_mvn_build_dir "orca_base"
 
 # Build rpmbuild docker container and RPMs
 pushd orca-rpmbuild
-./docker_build_rpms.sh
+./docker_build_rpms.sh --jre ${DOCKER_JRE_VENDOR}
 
 # save the return value from rpmbuild
 var_ret=$?

--- a/docker/docker_run.sh
+++ b/docker/docker_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ORCA_CONFIG_DIR="/opt/orca-oracle"
+ORCA_CONFIG_DIR="/opt/orca" # JRE Vendor will be appended later, e.g. -oracle
 
 DOCKER_NAME_MYSQL="orca-mysql"
 DOCKER_NAME_AM_BROKER="orca-am-broker"
@@ -8,7 +8,7 @@ DOCKER_NAME_SM="orca-sm"
 DOCKER_NAME_CONTROLLER="orca-controller"
 
 DOCKER_NET_NAME="orca"
-DOCKER_ORCA_IMAGE_TAG="latest"
+DOCKER_ORCA_IMAGE_TAG="oracle"
 
 while [[ $# -gt 1 ]]
 do
@@ -25,6 +25,13 @@ case $key in
 esac
 shift # past argument or value
 done
+
+# get JRE Vendor from tag name
+# https://stackoverflow.com/a/15988793/2955846
+# ${var##*SubStr} # will drop begin of string upto last occur of `SubStr`
+# JRE Vendor is always after a '-' in tag
+DOCKER_JRE_VENDOR=${DOCKER_ORCA_IMAGE_TAG##*-}
+ORCA_CONFIG_DIR=${ORCA_CONFIG_DIR}-${DOCKER_JRE_VENDOR}
 
 # remove stopped or running containers
 f_rm_f_docker_container ()

--- a/docker/orca-rpmbuild/docker_build_rpms.sh
+++ b/docker/orca-rpmbuild/docker_build_rpms.sh
@@ -6,7 +6,28 @@ export ORCA_BLD="${HOME}/orca-build"
 # Define RPM build directory
 RPM_BUILD_DIR="${ORCA_BLD}/rpmbuild"
 
+DOCKER_MVN_CMD="mvn clean package -Pdocker"
+DOCKER_JRE_VENDOR="oracle"
+
+while [[ $# -gt 1 ]]
+do
+key="$1"
+
+case $key in
+    -j|--jre)
+    DOCKER_JRE_VENDOR="$2"
+    shift # past argument
+    ;;
+    *)
+            # unknown option
+    ;;
+esac
+shift # past argument or value
+done
+
+DOCKER_MVN_CMD="${DOCKER_MVN_CMD} -Dorca.docker.jre.vendor=${DOCKER_JRE_VENDOR}"
 # remove stopped or running containers
+
 f_rm_f_docker_container ()
 {
   #container_name="$1"
@@ -37,7 +58,7 @@ mkdir -p "${RPM_BUILD_DIR}/RPMS"
 cd "$( dirname "$0" )"
 
 # Build new docker container, that contains current sources
-mvn clean package -Pdocker || exit $?
+eval "$DOCKER_MVN_CMD" || exit $?
 
 # Remove any previous docker containers of name
 DOCKER_NAME_RPMBUILD="orca-rpmbuild"

--- a/docker/orca-rpmbuild/pom.xml
+++ b/docker/orca-rpmbuild/pom.xml
@@ -43,6 +43,7 @@
 						<imageName>renci/${project.artifactId}</imageName>
 						<imageTags>
 							<imageTag>${project.version}-${orca.docker.jre.vendor}</imageTag>
+							<imageTag>${orca.docker.jre.vendor}</imageTag>
 						</imageTags>
 
 						<pushImage>false</pushImage>

--- a/docker/orca_am_broker/pom.xml
+++ b/docker/orca_am_broker/pom.xml
@@ -52,6 +52,7 @@
 						<imageTags>
 							<imageTag>${project.version}-${orca.docker.jre.vendor}</imageTag>
 							<imageTag>${git.commit.id.abbrev}-${orca.docker.jre.vendor}</imageTag>
+							<imageTag>${orca.docker.jre.vendor}</imageTag>
 						</imageTags>
 
 						<pushImage>false</pushImage>

--- a/docker/orca_base/pom.xml
+++ b/docker/orca_base/pom.xml
@@ -41,6 +41,7 @@
 						<imageTags>
 							<imageTag>${project.version}-${orca.docker.jre.vendor}</imageTag>
 							<imageTag>${git.commit.id.abbrev}-${orca.docker.jre.vendor}</imageTag>
+							<imageTag>${orca.docker.jre.vendor}</imageTag>
 						</imageTags>
 
 						<pushImage>false</pushImage>

--- a/docker/orca_common/pom.xml
+++ b/docker/orca_common/pom.xml
@@ -53,6 +53,7 @@
 						<imageTags>
 							<imageTag>${project.version}-${orca.docker.jre.vendor}</imageTag>
 							<imageTag>${git.commit.id.abbrev}-${orca.docker.jre.vendor}</imageTag>
+							<imageTag>${orca.docker.jre.vendor}</imageTag>
 						</imageTags>
 
 						<pushImage>false</pushImage>

--- a/docker/orca_controller/pom.xml
+++ b/docker/orca_controller/pom.xml
@@ -49,6 +49,7 @@
 						<imageTags>
 							<imageTag>${project.version}-${orca.docker.jre.vendor}</imageTag>
 							<imageTag>${git.commit.id.abbrev}-${orca.docker.jre.vendor}</imageTag>
+							<imageTag>${orca.docker.jre.vendor}</imageTag>
 						</imageTags>
 
 						<pushImage>false</pushImage>

--- a/docker/orca_sm/pom.xml
+++ b/docker/orca_sm/pom.xml
@@ -49,6 +49,7 @@
 						<imageTags>
 							<imageTag>${project.version}-${orca.docker.jre.vendor}</imageTag>
 							<imageTag>${git.commit.id.abbrev}-${orca.docker.jre.vendor}</imageTag>
+							<imageTag>${orca.docker.jre.vendor}</imageTag>
 						</imageTags>
 
 						<pushImage>false</pushImage>

--- a/redhat/orca-iaas.spec
+++ b/redhat/orca-iaas.spec
@@ -24,7 +24,7 @@ URL: https://github.com/RENCI-NRIG/orca5.git
 # Removing BuildRequires statements, as Ubuntu uses different package naming.
 #BuildRequires:  jdk >= 1.7.0 ant
 #BuildRequires:  jdk >= 1.7.0
-Requires:       jdk >= 1.7.0
+#Requires:       jdk >= 1.7.0 # OpenJDK doesn't match this
 Requires:       orca-iaas-common = %{version}-%{release}
 
 # Set up some useful definitions...
@@ -68,7 +68,7 @@ This package contains configuration shared among all ORCA packages.
 %package controller
 Summary: ORCA XML-RPC Controller
 Group: Applications/System
-Requires: jdk
+#Requires: jdk # OpenJDK doesn't match this
 Requires: orca-iaas-common = %{version}-%{release}
 
 %description controller


### PR DESCRIPTION
Better support for running docker containers based on OpenJDK.

Still tempted to make openjdk (7) the default.  Unfortunately, OpenJDK 8 and Oracle JDK 8 both do not currently work.   And Oracle JDK 7 is no longer available for download.