### PR TITLE
122 constraints nodegroup increase

### DIFF
--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
@@ -24,6 +24,10 @@ public class OrcaRegressionModifyTest {
                         5},
                 //NodeGroup modify
                 {"src/test/resources/122_request.rdf",
+                        "src/test/resources/122_nodegroups_increase_modify_request.rdf",
+                        23}, // we don't even have 23, but apparently the controller doesn't check
+                //NodeGroup modify
+                {"src/test/resources/122_request.rdf",
                         "src/test/resources/137_nodegroups_increase_by_two_modify_request.rdf",
                         5},
                 //NodeGroup modify
@@ -134,7 +138,11 @@ public class OrcaRegressionModifyTest {
         if (requestFilename.contains("112_")) {
             System.out.println("Checking Velocity Templating");
             assertBootscriptVelocityTemplating(computedReservations);
-        } else if (requestFilename.contains("122_") || (requestFilename.contains("137_"))) {
+        }  else if (requestFilename.contains("122_")) {
+            // #122
+            System.out.println("Checking for requested Resource Constraints");
+            assertReservationsHaveResourceConstraints(computedReservations);
+        } else if (requestFilename.contains("137_")) {
             System.out.println("Checking for Network Interfaces");
             // Nodes added in NodeGroup Increase need to have a Network interface
             assertReservationsHaveNetworkInterface(computedReservations);

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcAssertions.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcAssertions.java
@@ -21,6 +21,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static orca.controllers.xmlrpc.ReservationConverter.PropertyUnitEC2InstanceType;
+import static orca.shirako.common.meta.RequestProperties.RequestBandwidth;
+import static orca.shirako.common.meta.RequestProperties.RequestNumCPUCores;
 import static orca.shirako.common.meta.UnitProperties.*;
 import static org.junit.Assert.*;
 
@@ -309,6 +311,26 @@ public class OrcaXmlrpcAssertions {
                 final boolean isUnique = interfaceSet.add(interfaceURI);
                 assertTrue("Duplicate clientInterface detected for " + element.getName() + " " + interfaceURI, isUnique);
             }
+        }
+
+    }
+
+
+    /**
+     * Controller needs to assigned Core Resource Constraints to the Reservation
+     *
+     * @param computedReservations
+     */
+    protected static void assertReservationsHaveResourceConstraints(List<TicketReservationMng> computedReservations) {
+        for (TicketReservationMng reservation : computedReservations) {
+            Properties requestProperties = OrcaConverter.fill(reservation.getRequestProperties());
+
+            // Skip any VLAN reservations
+            if (null != requestProperties.getProperty(RequestBandwidth)){
+                continue;
+            }
+            assertNotNull("Reservation UID " + reservation.getReservationID() + " is missing core constraint: " + RequestNumCPUCores,
+                    requestProperties.getProperty(RequestNumCPUCores));
         }
 
     }

--- a/controllers/xmlrpc/src/test/resources/122_nodegroups_increase_modify_request.rdf
+++ b/controllers/xmlrpc/src/test/resources/122_nodegroups_increase_modify_request.rdf
@@ -1,0 +1,37 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:modify="http://geni-orca.renci.org/owl/6dbe6da7-0990-43a2-8cec-87cd6fb375e7#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/6dbe6da7-0990-43a2-8cec-87cd6fb375e7#modifyElement/0afa8660-085e-44ff-94e4-a20dbb4dd7c5">
+    <modify-schema:increaseBy rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</modify-schema:increaseBy>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/04fd3f54-5ee4-4764-92be-1a58adae54ee#NodeGroup0"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/6dbe6da7-0990-43a2-8cec-87cd6fb375e7#6dbe6da7-0990-43a2-8cec-87cd6fb375e7/modify">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/6dbe6da7-0990-43a2-8cec-87cd6fb375e7#modifyElement/0afa8660-085e-44ff-94e4-a20dbb4dd7c5"/>
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6dbe6da7-0990-43a2-8cec-87cd6fb375e7/modify</topology:hasName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyReservation"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/embed/src/main/java/orca/embed/cloudembed/controller/ModifyHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/ModifyHandler.java
@@ -28,7 +28,6 @@ import orca.ndl.INdlModifyModelListener;
 import orca.ndl.INdlModifyModelListener.ModifyType;
 import orca.ndl.NdlCommons;
 import orca.ndl.NdlException;
-import orca.ndl.NdlModel;
 import orca.ndl.NdlRequestParser;
 import orca.ndl.elements.ComputeElement;
 import orca.ndl.elements.Device;
@@ -40,12 +39,10 @@ import orca.ndl.elements.NetworkConnection;
 import orca.ndl.elements.NetworkElement;
 import orca.ndl.elements.RequestSlice;
 import orca.shirako.common.meta.UnitProperties;
-import orca.shirako.container.Globals;
 
 import com.hp.hpl.jena.datatypes.xsd.XSDDatatype;
 import com.hp.hpl.jena.ontology.Individual;
 import com.hp.hpl.jena.ontology.OntModel;
-import com.hp.hpl.jena.ontology.OntModelSpec;
 import com.hp.hpl.jena.ontology.OntResource;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Property;
@@ -136,7 +133,7 @@ public class ModifyHandler extends UnboundRequestHandler {
 				}
 			
 				if(me.getModType().equals(INdlModifyModelListener.ModifyType.INCREASE)){
-					err = addElements(me, manifestOnt, nodeGroupMap, firstGroupElement, requestModel, deviceList);
+					err = addNodeGroupElements(me, manifestOnt, nodeGroupMap, firstGroupElement, requestModel, deviceList);
 				}
 				if(err!=null) {
 					logger.error(err.getMessage());
@@ -389,17 +386,17 @@ public class ModifyHandler extends UnboundRequestHandler {
 		}
 	}
 	
-	protected SystemNativeError  addElements(ModifyElement me,OntModel manifestOntModel, 
-			HashMap <String,Collection <DomainElement>> nodeGroupMap,
-			HashMap <String,DomainElement> firstGroupElement, 
-			OntModel requestModel, LinkedList<NetworkElement> deviceList) throws InetNetworkException, UnknownHostException, Exception{
+	protected SystemNativeError addNodeGroupElements(ModifyElement me, OntModel manifestOntModel,
+													 HashMap <String,Collection <DomainElement>> nodeGroupMap,
+													 HashMap <String,DomainElement> firstGroupElement,
+													 OntModel requestModel, LinkedList<NetworkElement> deviceList) throws InetNetworkException, UnknownHostException, Exception{
 		SystemNativeError error = null;	
 		
 		int units = me.getModifyUnits();
 		String n = me.getSub().getURI();
 		int i = n.lastIndexOf("#");
 		String group = i>=0 ? n.substring(i+1):n;
-		logger.info("addElements() starts, units="+units);
+		logger.info("addNodeGroupElements() starts, units="+units);
 		logger.debug("nodeGroupMap size="+nodeGroupMap.size());
 		Collection <DomainElement> cde = nodeGroupMap.get(group);
 		if((cde==null) || (cde.isEmpty()) ){
@@ -465,13 +462,13 @@ public class ModifyHandler extends UnboundRequestHandler {
 					link_device = entry.getKey();
 					hole = entry.getValue();
 					if(edge_device==null){
-						edge_device=createNewNode(firstElement,hole,link_device,domainName,manifestOntModel, requestModel, deviceList);
+						edge_device= createNewNodeGroupNode(firstElement,hole,link_device,domainName,manifestOntModel, requestModel, deviceList);
 					}
 					createInterface(firstElement, edge_device,hole,link_device);
 				}
 			}else{
 				logger.debug("firstElement has no parent! No interface will be created.");
-				createNewNode(firstElement, -1, null, domainName, manifestOntModel, requestModel, deviceList);
+				createNewNodeGroupNode(firstElement, -1, null, domainName, manifestOntModel, requestModel, deviceList);
 			}
 		}		
 		
@@ -485,8 +482,8 @@ public class ModifyHandler extends UnboundRequestHandler {
 		return error;
 	}	
 	
-	protected DomainElement createNewNode(DomainElement element,int hole,DomainElement link_device, 
-			String domainName,OntModel manifestModel, OntModel requestModel, LinkedList<NetworkElement> deviceList) throws UnknownHostException, InetNetworkException{
+	protected DomainElement createNewNodeGroupNode(DomainElement element, int hole, DomainElement link_device,
+												   String domainName, OntModel manifestModel, OntModel requestModel, LinkedList<NetworkElement> deviceList) throws UnknownHostException, InetNetworkException{
 		
 		ComputeElement ce=null,element_ce=null;
 

--- a/ndl/src/main/java/orca/ndl/elements/ComputeElement.java
+++ b/ndl/src/main/java/orca/ndl/elements/ComputeElement.java
@@ -96,6 +96,11 @@ public class ComputeElement extends NetworkElement {
 		ce.setFSParam(this.getFSParam());
 		ce.setMntPoint(this.getMntPoint());
 		ce.setDoFormat(this.isDoFormat());
+
+		// #122
+		// NodeGroup modify requests don't have Resource Request / Core Constraint information
+		// so they must be copied from the existing nodes in the NodeGroup.
+		ce.setResourcesMap(this.getResourcesMap());
 		
 		return ce;
 	}

--- a/ndl/src/main/java/orca/ndl/elements/NetworkElement.java
+++ b/ndl/src/main/java/orca/ndl/elements/NetworkElement.java
@@ -12,7 +12,6 @@ import orca.ndl.LayerConstant;
 import orca.ndl.NdlCommons;
 import orca.util.persistence.NotPersistent;
 import orca.util.persistence.Persistable;
-import orca.util.persistence.PersistenceUtils;
 import orca.util.persistence.Persistent;
 
 import org.apache.log4j.Logger;
@@ -49,7 +48,7 @@ public class NetworkElement implements LayerConstant, Comparable, Persistable {
 	protected LinkedList<Interface> clientInterface;
 	
 	@Persistent // recursive
-	protected HashMap<String, DomainResource> map;  //interfaces, bandwidth
+	protected HashMap<String, DomainResource> resourcesMap;  //interfaces, bandwidth
 	
 	@Persistent
 	protected String castType;
@@ -232,8 +231,8 @@ public class NetworkElement implements LayerConstant, Comparable, Persistable {
 		}
 		sb.append("\n");
 		sb.append("Interface Bandwidth: ");
-		if (map != null) {
-			for(Entry<String, DomainResource> ee: map.entrySet()) {
+		if (resourcesMap != null) {
+			for(Entry<String, DomainResource> ee: resourcesMap.entrySet()) {
 				sb.append("[ " + ee.getKey() + " <> " + ee.getValue() + " ] ");
 			}
 		}
@@ -347,33 +346,33 @@ public class NetworkElement implements LayerConstant, Comparable, Persistable {
 	
 	//constraints
     public List<DomainResource> getResources() {
-    	if(map==null)
+    	if(resourcesMap ==null)
     		return null;
-        ArrayList<DomainResource> l = new ArrayList<DomainResource>(map.values().size());
-        for (DomainResource r : map.values()) {
+        ArrayList<DomainResource> l = new ArrayList<DomainResource>(resourcesMap.values().size());
+        for (DomainResource r : resourcesMap.values()) {
             l.add(r);
         }
         return l;
     }
     
     public HashMap<String, DomainResource> getResourcesMap(){
-    	return map;
+    	return resourcesMap;
     }
 
     public void setResourcesMap(HashMap<String, DomainResource> m){
-        map=m;
+        resourcesMap =m;
     }
     
     public DomainResource getResource(String iface) {
-    	if(map==null)
+    	if(resourcesMap ==null)
     		return null;
-    	return map.get(iface);
+    	return resourcesMap.get(iface);
     }
     
     public void addResource(DomainResource resource) {
-    	if(map==null)
-    		map = new HashMap<String, DomainResource>();
-        map.put(resource.getInterface(), resource);
+    	if(resourcesMap ==null)
+    		resourcesMap = new HashMap<String, DomainResource>();
+        resourcesMap.put(resource.getInterface(), resource);
     }
 
 	public boolean isModify() {


### PR DESCRIPTION
The simple fix for #122, the Controller adds the (previously missing) core constraints / requested resources (e.g. Num CPU) to the request. This allows the SM to verify the actual availability of resources, producing expected results.

Fixes #122.