### PR TITLE
154 renew slice return value

### DIFF
--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/ReservationConverter.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/ReservationConverter.java
@@ -76,8 +76,8 @@ public class ReservationConverter implements LayerConstant {
 	static final String SUDO_YES = "yes";
 	static final String OPENSTACK_MAC_DEFAULT_PREFIX = "fe:16:3e:00:";
 	public static final String UNIT_URL_RES = UnitProperties.UnitURL;
-	private static final long TWO_WEEKS = (14*24*3600*1000);
-	private static final long ONE_DAY = (24*3600*1000);
+	private static final long TWO_WEEKS = TimeUnit.DAYS.toMillis(14);
+	private static final long ONE_DAY = TimeUnit.DAYS.toMillis(1);
 	public static final long DEFAULT_MAX_DURATION = TWO_WEEKS;
 	public static final long DEFAULT_DURATION = ONE_DAY;
 	public static final String NO_SSH_KEY_SPECIFIED_STRING = "NO-SSH-KEY-SPECIFIED";

--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
@@ -52,9 +52,9 @@ public class GeniAmV2Handler extends XmlrpcHandlerHelper implements IGeniAmV2Int
 	public static final String PropertyXmlrpcControllerUrl = "xmlrpc.controller.base.url";
 	public static final String PropertyUseGeniRootLogin = "use.geni.root.login";
 	
-	protected final boolean verifyCredentials;
+	protected boolean verifyCredentials;
 	
-	protected final XmlRpcController controller;
+	protected XmlRpcController controller;
 	protected final OrcaXmlrpcHandler orcaHandler;
 	protected final XmlrpcOrcaState instance;
 

--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
@@ -605,7 +605,8 @@ public class GeniAmV2Handler extends XmlrpcHandlerHelper implements IGeniAmV2Int
 
             // return the response
             // return the newTermEnd also in the output
-            return getStandardApiReturn(ApiReturnCodes.SUCCESS.code, true, newTermEnd);
+            final String returnedTermEnd = (String) rr.getOrDefault(OrcaXmlrpcHandler.TERM_END_FIELD, newTermEnd);
+            return getStandardApiReturn(ApiReturnCodes.SUCCESS.code, true, returnedTermEnd);
         } catch (CredentialException ce) {
             logger.error("GENI RenewSliver: Credential Exception: " + ce);
             return getStandardApiReturn(ApiReturnCodes.FORBIDDEN.code, null, "Credendial Exception: " + ce);

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/MockXmlRpcController.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/MockXmlRpcController.java
@@ -178,4 +178,13 @@ public class MockXmlRpcController extends XmlRpcController {
         }
     }
 
+    /**
+     *
+     * @param p property name
+     * @param value new value
+     */
+    public void setProperty(String p, String value) {
+        controllerProperties.setProperty(p, value);
+    }
+
 }

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.*;
 import static orca.controllers.xmlrpc.OrcaXmlrpcHandler.*;

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -8,7 +8,6 @@ import orca.manage.IOrcaServiceManager;
 import orca.manage.OrcaConstants;
 import orca.manage.OrcaConverter;
 import orca.manage.beans.PropertiesMng;
-import orca.manage.beans.PropertyMng;
 import orca.manage.beans.SliceMng;
 import orca.manage.beans.TicketReservationMng;
 import orca.ndl.NdlCommons;
@@ -18,7 +17,6 @@ import orca.ndl.elements.DomainElement;
 import orca.ndl.elements.NetworkElement;
 import orca.shirako.common.ReservationID;
 import orca.shirako.common.SliceID;
-import orca.shirako.common.meta.UnitProperties;
 import orca.shirako.container.Globals;
 import org.apache.log4j.Logger;
 import org.junit.Test;
@@ -1076,9 +1074,9 @@ public class OrcaXmlrpcHandlerTest {
         String newTermEnd = rfc3339Formatter.format(systemDefaultEndCal.getTime());
         System.out.println(newTermEnd);
 
-        doTestRenewSlice(newTermEnd);
+        final Map<String, Object> result = doTestRenewSlice(newTermEnd);
 
-
+        assertEquals("renewSlice() resulted in non-matching term end", newTermEnd, result.get(TERM_END_FIELD));
     }
 
     /**
@@ -1091,9 +1089,9 @@ public class OrcaXmlrpcHandlerTest {
         String newTermEnd = rfc3339Formatter.format(systemDefaultEndCal.getTime());
         System.out.println(newTermEnd);
 
-        doTestRenewSlice(newTermEnd);
+        final Map<String, Object> result = doTestRenewSlice(newTermEnd);
 
-
+        assertFalse("renewSlice() Over Max should not be resultant end term.", newTermEnd.equals(result.get(TERM_END_FIELD)));
     }
 
     /**
@@ -1102,7 +1100,7 @@ public class OrcaXmlrpcHandlerTest {
      * @param newTermEnd
      * @throws Exception
      */
-    protected void doTestRenewSlice(String newTermEnd) throws Exception {
+    protected Map<String, Object> doTestRenewSlice(String newTermEnd) throws Exception {
         Map<ReservationID, TicketReservationMng> reservationMap = new HashMap<>();
         String requestFile = "../../embed/src/test/resources/orca/embed/CloudHandlerTest/XOXlargeRequest_ok.rdf";
         String resReq = NdlCommons.readFile(requestFile);
@@ -1140,6 +1138,10 @@ public class OrcaXmlrpcHandlerTest {
         // verify results of renewSlice()
         assertNotNull(result);
         assertFalse("renewSlice() returned error: " + result.get(MSG_RET_FIELD), (boolean) result.get(ERR_RET_FIELD));
+
+        assertNotNull(result.get(TERM_END_FIELD));
+
+        return result;
     }
 
     /**

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -108,7 +108,7 @@ public class OrcaXmlrpcHandlerTest {
      * @param ndlFile filename of createSlice() request RDF
      * @param slice_urn slice name
      */
-    protected static XmlrpcControllerSlice doTestCreateSlice(XmlRpcController controller, String ndlFile, String slice_urn, int expectedReservationCount){
+    public static XmlrpcControllerSlice doTestCreateSlice(XmlRpcController controller, String ndlFile, String slice_urn, int expectedReservationCount){
         OrcaXmlrpcHandler orcaXmlrpcHandler = new OrcaXmlrpcHandler();
         assertNotNull(orcaXmlrpcHandler);
         orcaXmlrpcHandler.verifyCredentials = false;

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/ReservationConverterTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/ReservationConverterTest.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Date;
 import java.util.LinkedList;
+import java.util.concurrent.TimeUnit;
 
 import orca.embed.RequestWorkflowTest;
 import orca.embed.policyhelpers.DomainResourcePools;
@@ -80,7 +81,11 @@ public class ReservationConverterTest extends RequestWorkflowTest{
 		ReservationConverter orc = new ReservationConverter();
 		OrcaReservationTerm term = new OrcaReservationTerm();
 		term.setStart(new Date());
-		term.setDuration(14, 0, 0, 0);
+
+		// trying to set to exactly the Maximum can cause discrepancies between Days and Milliseconds
+		// (e.g. near Daylight Savings Time changes)
+		final long maxDays = TimeUnit.MILLISECONDS.toDays(ReservationConverter.getMaxDuration());
+		term.setDuration(Math.toIntExact(maxDays - 1), 0, 0, 0);
 
 		orc.setLeaseTerm(term);
 
@@ -97,7 +102,9 @@ public class ReservationConverterTest extends RequestWorkflowTest{
 		ReservationConverter orc = new ReservationConverter();
 		OrcaReservationTerm term = new OrcaReservationTerm();
 		term.setStart(new Date());
-		term.setDuration(30, 0, 0, 0);
+
+		final long maxDays = TimeUnit.MILLISECONDS.toDays(ReservationConverter.getMaxDuration());
+		term.setDuration(Math.toIntExact(maxDays + 1), 0, 0, 0);
 
 		orc.setLeaseTerm(term);
 

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/geni/GeniAmV2HandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/geni/GeniAmV2HandlerTest.java
@@ -1,0 +1,93 @@
+package orca.controllers.xmlrpc.geni;
+
+import orca.controllers.xmlrpc.*;
+import orca.manage.OrcaConstants;
+import orca.manage.beans.TicketReservationMng;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Map;
+
+import static orca.controllers.xmlrpc.OrcaXmlrpcHandler.MaxReservationDuration;
+import static org.junit.Assert.*;
+
+public class GeniAmV2HandlerTest {
+    protected static final SimpleDateFormat rfc3339Formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+
+    @Test
+    public void renewSliver() throws Exception {
+
+        // setup the renew term
+        Calendar systemDefaultEndCal = Calendar.getInstance();
+        systemDefaultEndCal.add(Calendar.MILLISECOND, (int)MaxReservationDuration / 2);
+        String newTermEnd = rfc3339Formatter.format(systemDefaultEndCal.getTime());
+        System.out.println(newTermEnd);
+
+        final Map<String, Object> geniReturn = doRenewSliver(newTermEnd);
+
+        // check for success
+        final Object output = geniReturn.get(IGeniAmV2Interface.ApiReturnFields.OUTPUT.name);
+        System.out.println(output);
+
+        assertEquals("Geni API renew end did not match expected!", newTermEnd, output);
+
+    }
+
+    @Test
+    public void renewSliverOverMax() throws Exception {
+
+        // setup the renew term
+        Calendar systemDefaultEndCal = Calendar.getInstance();
+        systemDefaultEndCal.add(Calendar.MILLISECOND, Integer.MAX_VALUE);
+        String newTermEnd = rfc3339Formatter.format(systemDefaultEndCal.getTime());
+        System.out.println(newTermEnd);
+
+        final Map<String, Object> geniReturn = doRenewSliver(newTermEnd);
+
+        // check for success
+        final Object output = geniReturn.get(IGeniAmV2Interface.ApiReturnFields.OUTPUT.name);
+        System.out.println(output);
+
+        assertFalse("Geni API renew value Over Max should not be returned as successful end term", newTermEnd.equals(output));
+
+    }
+
+    protected Map<String, Object> doRenewSliver(String newTermEnd) throws Exception {
+        // use our Mock controller
+        final MockXmlRpcController controller = new MockXmlRpcController();
+        controller.setProperty(XmlRpcController.PropertyOrcaCredentialVerification, "false");
+        controller.start();
+
+        // create a slice
+        final XmlrpcControllerSlice slice = OrcaXmlrpcHandlerTest.doTestCreateSlice(
+                controller,
+                "src/test/resources/20_create_with_netmask.rdf",
+                "geniRenewSliver",
+                3);
+
+        // need to force the slice reservations to be active
+        for (TicketReservationMng reservation : slice.getComputedReservations()) {
+            reservation.setState(OrcaConstants.ReservationStateActive);
+        }
+
+        // Start the Renew via Geni API
+        GeniAmV2Handler geniHandler = new GeniAmV2Handler();
+        geniHandler.verifyCredentials = false;
+        geniHandler.controller = controller;
+
+        Object [] credentials = new Object[0];
+
+        final Map<String, Object> geniReturn = geniHandler.RenewSliver(slice.getSliceUrn(), credentials, newTermEnd, null);
+
+        // check for success
+        final Map<String, Object> codes = (Map<String, Object>) geniReturn.get(IGeniAmV2Interface.ApiReturnFields.CODE.name);
+        final int code = (int) codes.get(IGeniAmV2Interface.ApiReturnFields.CODE_GENI_CODE.name);
+        final Object output = geniReturn.get(IGeniAmV2Interface.ApiReturnFields.OUTPUT.name);
+
+        assertEquals("Geni API returned error! " + output, IGeniAmV2Interface.ApiReturnCodes.SUCCESS.code, code);
+
+        return geniReturn;
+    }
+
+}

--- a/ndl/src/main/java/orca/ndl/elements/OrcaReservationTerm.java
+++ b/ndl/src/main/java/orca/ndl/elements/OrcaReservationTerm.java
@@ -66,15 +66,17 @@ public class OrcaReservationTerm {
 	}
 	
 	public int getDurationInMinutes() {
-                return dDays*24*60 + dHours *60 + dMins;
+                return durationInMinutes(dDays, dHours, dMins);
     }
 	
 	public int getDurationInSeconds() {
-        return 60*getDurationInMinutes()+dSecs;
+        return Math.toIntExact(TimeUnit.MINUTES.toSeconds(getDurationInMinutes())) + dSecs;
 	}
 	
 	private int durationInMinutes(int d, int h, int m) {
-		return d*24*60 + h *60 + m;
+		return Math.toIntExact(TimeUnit.DAYS.toMinutes(d))
+				+ Math.toIntExact(TimeUnit.HOURS.toMinutes(h))
+				+ m;
 	}
 	
 	public void setStart(Date s) {
@@ -110,11 +112,12 @@ public class OrcaReservationTerm {
 		Calendar cal = Calendar.getInstance();
 		cal.setTime(start);
 
-		cal.add(Calendar.DAY_OF_YEAR, d);
-		cal.add(Calendar.HOUR, h);
-		cal.add(Calendar.MINUTE, m);
-		cal.add(Calendar.SECOND, s);
-		
+		// valid reservation terms are all calculated in MilliSeconds
+		cal.add(Calendar.MILLISECOND, Math.toIntExact(TimeUnit.DAYS.toMillis(d)));
+		cal.add(Calendar.MILLISECOND, Math.toIntExact(TimeUnit.HOURS.toMillis(h)));
+		cal.add(Calendar.MILLISECOND, Math.toIntExact(TimeUnit.MINUTES.toMillis(m)));
+		cal.add(Calendar.MILLISECOND, Math.toIntExact(TimeUnit.SECONDS.toMillis(s)));
+
 		modifyTerm(cal.getTime());
 	}
 	

--- a/ndl/src/main/java/orca/ndl/elements/OrcaReservationTerm.java
+++ b/ndl/src/main/java/orca/ndl/elements/OrcaReservationTerm.java
@@ -112,11 +112,13 @@ public class OrcaReservationTerm {
 		Calendar cal = Calendar.getInstance();
 		cal.setTime(start);
 
-		// valid reservation terms are all calculated in MilliSeconds
-		cal.add(Calendar.MILLISECOND, Math.toIntExact(TimeUnit.DAYS.toMillis(d)));
-		cal.add(Calendar.MILLISECOND, Math.toIntExact(TimeUnit.HOURS.toMillis(h)));
-		cal.add(Calendar.MILLISECOND, Math.toIntExact(TimeUnit.MINUTES.toMillis(m)));
-		cal.add(Calendar.MILLISECOND, Math.toIntExact(TimeUnit.SECONDS.toMillis(s)));
+		// Daylight savings can cause a mismatch between number of Days and number of Milliseconds.
+		// It would be nice to do everything in Milliseconds,
+		// HOWEVER it doesn't take many days (less than 30) to overflow MAXINT Milliseconds.
+		cal.add(Calendar.DAY_OF_YEAR, d);
+		cal.add(Calendar.HOUR, h);
+		cal.add(Calendar.MINUTE, m);
+		cal.add(Calendar.SECOND, s);
 
 		modifyTerm(cal.getTime());
 	}

--- a/ndl/src/test/java/orca/ndl/elements/OrcaReservationTermTest.java
+++ b/ndl/src/test/java/orca/ndl/elements/OrcaReservationTermTest.java
@@ -10,8 +10,9 @@ import static org.junit.Assert.*;
 
 public class OrcaReservationTermTest {
 
+    // copied from ReservationConverter
     private static final long TWO_WEEKS = TimeUnit.DAYS.toMillis(14);
-    public static final long DEFAULT_MAX_DURATION = TWO_WEEKS;
+    private static final long DEFAULT_MAX_DURATION = TWO_WEEKS;
 
     @Test
     public void getDurationInMinutes() throws Exception {

--- a/ndl/src/test/java/orca/ndl/elements/OrcaReservationTermTest.java
+++ b/ndl/src/test/java/orca/ndl/elements/OrcaReservationTermTest.java
@@ -1,0 +1,102 @@
+package orca.ndl.elements;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class OrcaReservationTermTest {
+
+    private static final long TWO_WEEKS = TimeUnit.DAYS.toMillis(14);
+    public static final long DEFAULT_MAX_DURATION = TWO_WEEKS;
+
+    @Test
+    public void getDurationInMinutes() throws Exception {
+        OrcaReservationTerm term = new OrcaReservationTerm();
+        term.setStart(new Date());
+        term.setDuration(Math.toIntExact(TimeUnit.MILLISECONDS.toDays(DEFAULT_MAX_DURATION)), 0, 0, 0);
+
+        final int durationInMinutes = term.getDurationInMinutes();
+
+        assertEquals("Duration in Minutes did not match expected", TimeUnit.MILLISECONDS.toMinutes(DEFAULT_MAX_DURATION), durationInMinutes);
+    }
+
+    @Test
+    public void getDurationInSeconds() throws Exception {
+        OrcaReservationTerm term = new OrcaReservationTerm();
+        term.setStart(new Date());
+        term.setDuration(Math.toIntExact(TimeUnit.MILLISECONDS.toDays(DEFAULT_MAX_DURATION)), 0, 0, 0);
+
+        final int durationInSeconds = term.getDurationInSeconds();
+
+        assertEquals("Duration in Seconds did not match expected", TimeUnit.MILLISECONDS.toSeconds(DEFAULT_MAX_DURATION), durationInSeconds);
+    }
+
+    @Test
+    public void setDurationInDays() throws Exception {
+        OrcaReservationTerm term = new OrcaReservationTerm();
+        term.setStart(new Date());
+        term.setDuration(Math.toIntExact(TimeUnit.MILLISECONDS.toDays(DEFAULT_MAX_DURATION)), 0, 0, 0);
+
+        final Date termEnd = term.end;
+
+        Calendar termStart = Calendar.getInstance();
+        termStart.setTime(term.start);
+
+        termStart.add(Calendar.MILLISECOND, Math.toIntExact(DEFAULT_MAX_DURATION));
+
+        assertEquals("Term end did not match expected value.", termStart.getTime(), termEnd);
+    }
+
+    @Test
+    public void setDurationInHours() throws Exception {
+        OrcaReservationTerm term = new OrcaReservationTerm();
+        term.setStart(new Date());
+        term.setDuration(0, Math.toIntExact(TimeUnit.MILLISECONDS.toHours(DEFAULT_MAX_DURATION)), 0, 0);
+
+        final Date termEnd = term.end;
+
+        Calendar termStart = Calendar.getInstance();
+        termStart.setTime(term.start);
+
+        termStart.add(Calendar.MILLISECOND, Math.toIntExact(DEFAULT_MAX_DURATION));
+
+        assertEquals("Term end did not match expected value.", termStart.getTime(), termEnd);
+    }
+
+    @Test
+    public void setDurationInMinutes() throws Exception {
+        OrcaReservationTerm term = new OrcaReservationTerm();
+        term.setStart(new Date());
+        term.setDuration(0, 0, Math.toIntExact(TimeUnit.MILLISECONDS.toMinutes(DEFAULT_MAX_DURATION)), 0);
+
+        final Date termEnd = term.end;
+
+        Calendar termStart = Calendar.getInstance();
+        termStart.setTime(term.start);
+
+        termStart.add(Calendar.MILLISECOND, Math.toIntExact(DEFAULT_MAX_DURATION));
+
+        assertEquals("Term end did not match expected value.", termStart.getTime(), termEnd);
+    }
+
+    @Test
+    public void setDurationInSeconds() throws Exception {
+        OrcaReservationTerm term = new OrcaReservationTerm();
+        term.setStart(new Date());
+        term.setDuration(0, 0, 0, Math.toIntExact(TimeUnit.MILLISECONDS.toSeconds(DEFAULT_MAX_DURATION)));
+
+        final Date termEnd = term.end;
+
+        Calendar termStart = Calendar.getInstance();
+        termStart.setTime(term.start);
+
+        termStart.add(Calendar.MILLISECOND, Math.toIntExact(DEFAULT_MAX_DURATION));
+
+        assertEquals("Term end did not match expected value.", termStart.getTime(), termEnd);
+    }
+
+}

--- a/ndl/src/test/java/orca/ndl/elements/OrcaReservationTermTest.java
+++ b/ndl/src/test/java/orca/ndl/elements/OrcaReservationTermTest.java
@@ -10,44 +10,42 @@ import static org.junit.Assert.*;
 
 public class OrcaReservationTermTest {
 
-    // copied from ReservationConverter
-    private static final long TWO_WEEKS = TimeUnit.DAYS.toMillis(14);
-    private static final long DEFAULT_MAX_DURATION = TWO_WEEKS;
+    public static final int NUM_DAYS = 1;
 
     @Test
     public void getDurationInMinutes() throws Exception {
         OrcaReservationTerm term = new OrcaReservationTerm();
         term.setStart(new Date());
-        term.setDuration(Math.toIntExact(TimeUnit.MILLISECONDS.toDays(DEFAULT_MAX_DURATION)), 0, 0, 0);
+        term.setDuration(NUM_DAYS, 0, 0, 0);
 
         final int durationInMinutes = term.getDurationInMinutes();
 
-        assertEquals("Duration in Minutes did not match expected", TimeUnit.MILLISECONDS.toMinutes(DEFAULT_MAX_DURATION), durationInMinutes);
+        assertEquals("Duration in Minutes did not match expected", TimeUnit.DAYS.toMinutes(NUM_DAYS), durationInMinutes);
     }
 
     @Test
     public void getDurationInSeconds() throws Exception {
         OrcaReservationTerm term = new OrcaReservationTerm();
         term.setStart(new Date());
-        term.setDuration(Math.toIntExact(TimeUnit.MILLISECONDS.toDays(DEFAULT_MAX_DURATION)), 0, 0, 0);
+        term.setDuration(NUM_DAYS, 0, 0, 0);
 
         final int durationInSeconds = term.getDurationInSeconds();
 
-        assertEquals("Duration in Seconds did not match expected", TimeUnit.MILLISECONDS.toSeconds(DEFAULT_MAX_DURATION), durationInSeconds);
+        assertEquals("Duration in Seconds did not match expected", TimeUnit.DAYS.toSeconds(NUM_DAYS), durationInSeconds);
     }
 
     @Test
     public void setDurationInDays() throws Exception {
         OrcaReservationTerm term = new OrcaReservationTerm();
         term.setStart(new Date());
-        term.setDuration(Math.toIntExact(TimeUnit.MILLISECONDS.toDays(DEFAULT_MAX_DURATION)), 0, 0, 0);
+        term.setDuration(NUM_DAYS, 0, 0, 0);
 
         final Date termEnd = term.end;
 
         Calendar termStart = Calendar.getInstance();
         termStart.setTime(term.start);
 
-        termStart.add(Calendar.MILLISECOND, Math.toIntExact(DEFAULT_MAX_DURATION));
+        termStart.add(Calendar.DAY_OF_YEAR, NUM_DAYS);
 
         assertEquals("Term end did not match expected value.", termStart.getTime(), termEnd);
     }
@@ -56,14 +54,14 @@ public class OrcaReservationTermTest {
     public void setDurationInHours() throws Exception {
         OrcaReservationTerm term = new OrcaReservationTerm();
         term.setStart(new Date());
-        term.setDuration(0, Math.toIntExact(TimeUnit.MILLISECONDS.toHours(DEFAULT_MAX_DURATION)), 0, 0);
+        term.setDuration(0, Math.toIntExact(TimeUnit.DAYS.toHours(NUM_DAYS)), 0, 0);
 
         final Date termEnd = term.end;
 
         Calendar termStart = Calendar.getInstance();
         termStart.setTime(term.start);
 
-        termStart.add(Calendar.MILLISECOND, Math.toIntExact(DEFAULT_MAX_DURATION));
+        termStart.add(Calendar.DAY_OF_YEAR, NUM_DAYS);
 
         assertEquals("Term end did not match expected value.", termStart.getTime(), termEnd);
     }
@@ -72,14 +70,14 @@ public class OrcaReservationTermTest {
     public void setDurationInMinutes() throws Exception {
         OrcaReservationTerm term = new OrcaReservationTerm();
         term.setStart(new Date());
-        term.setDuration(0, 0, Math.toIntExact(TimeUnit.MILLISECONDS.toMinutes(DEFAULT_MAX_DURATION)), 0);
+        term.setDuration(0, 0, Math.toIntExact(TimeUnit.DAYS.toMinutes(NUM_DAYS)), 0);
 
         final Date termEnd = term.end;
 
         Calendar termStart = Calendar.getInstance();
         termStart.setTime(term.start);
 
-        termStart.add(Calendar.MILLISECOND, Math.toIntExact(DEFAULT_MAX_DURATION));
+        termStart.add(Calendar.DAY_OF_YEAR, NUM_DAYS);
 
         assertEquals("Term end did not match expected value.", termStart.getTime(), termEnd);
     }
@@ -88,14 +86,14 @@ public class OrcaReservationTermTest {
     public void setDurationInSeconds() throws Exception {
         OrcaReservationTerm term = new OrcaReservationTerm();
         term.setStart(new Date());
-        term.setDuration(0, 0, 0, Math.toIntExact(TimeUnit.MILLISECONDS.toSeconds(DEFAULT_MAX_DURATION)));
+        term.setDuration(0, 0, 0, Math.toIntExact(TimeUnit.DAYS.toSeconds(NUM_DAYS)));
 
         final Date termEnd = term.end;
 
         Calendar termStart = Calendar.getInstance();
         termStart.setTime(term.start);
 
-        termStart.add(Calendar.MILLISECOND, Math.toIntExact(DEFAULT_MAX_DURATION));
+        termStart.add(Calendar.DAY_OF_YEAR, NUM_DAYS);
 
         assertEquals("Term end did not match expected value.", termStart.getTime(), termEnd);
     }


### PR DESCRIPTION
A simple non-breaking API change that fixes #154.

Plus a little extra to avoid test errors near changes in Daylight Savings Time, and reducing dependency on magic numbers.

Whether createSlice() should check a requested reservations duration vs. the maximum duration can be a separate issue.