### PR TITLE
Modify url to disable mysql server identity verification

### DIFF
--- a/core/util/src/main/java/orca/util/db/MySqlBase.java
+++ b/core/util/src/main/java/orca/util/db/MySqlBase.java
@@ -43,6 +43,7 @@ public class MySqlBase implements DatabaseBase
     public static final String PropertyMySqlPassword = "db.mysql.password";
     public static final String PropertyMySqlDb = "db.mysql.db";
     public static final String PropertyMySqlPool = "db.mysql.pool";
+    public static final String PropertyMySqlConnectionOptions = "db.mysql.connection-options";
 
     /**
      * Helper function to construct a query. Constructs a query of the form
@@ -154,6 +155,14 @@ public class MySqlBase implements DatabaseBase
      */
     @Persistent(key = PropertyMySqlPassword)
     protected String mySqlPasswd;
+    /**
+     * MySql Connections Options. Default empty.
+     * e.g. "&verifyServerCertificate=false&useSSL=true"
+     * https://github.com/RENCI-NRIG/exogeni/issues/173
+     * https://github.com/RENCI-NRIG/orca5/pull/156
+     */
+    @Persistent(key = PropertyMySqlConnectionOptions)
+    protected String mySqlConnectionOptions;
     /**
      * Location of the file to use to create the connection pool
      */
@@ -301,26 +310,26 @@ public class MySqlBase implements DatabaseBase
 	            if (mapFile != null) {
 	                mapper = new MySqlPropertiesMapper(mapFile);
 	            }
-	
+
 	            loadDrivers();
-	
+
 	            /*
 	             * If either username or password is null,
 	             * DriverManagerConnectionFactory will use nulls for both. This is a
 	             * "feature". We work around this by setting the username as part of
 	             * the URL
 	             */
-                    String url = "jdbc:mysql://" + mySqlServer + ":" + mySqlServerPort + "/" + db + "?user=" + mySqlUser + "&verifyServerCertificate=false&useSSL=true";
-	            logger.debug("mysql database: " + url);
-	
+                String url = "jdbc:mysql://" + mySqlServer + ":" + mySqlServerPort + "/" + db + "?user=" + mySqlUser + mySqlConnectionOptions;
+                logger.debug("mysql database: " + url);
+
 	            // register the connection pool
 	            DriverManagerConnectionFactory factory = new DriverManagerConnectionFactory(url, mySqlUser, mySqlPasswd);
 	            MySqlPool.registerPool(factory, joclFileLocation, pool);
-	
+
 	            if (mapper != null) {
 	                mapper.initialize();
 	            }
-	
+
 	            checkDb();
 	            initialized = true;
         	} catch (OrcaException e) {

--- a/core/util/src/main/java/orca/util/db/MySqlBase.java
+++ b/core/util/src/main/java/orca/util/db/MySqlBase.java
@@ -162,7 +162,7 @@ public class MySqlBase implements DatabaseBase
      * https://github.com/RENCI-NRIG/orca5/pull/156
      */
     @Persistent(key = PropertyMySqlConnectionOptions)
-    protected String mySqlConnectionOptions;
+    protected String mySqlConnectionOptions = "";
     /**
      * Location of the file to use to create the connection pool
      */

--- a/core/util/src/main/java/orca/util/db/MySqlBase.java
+++ b/core/util/src/main/java/orca/util/db/MySqlBase.java
@@ -310,7 +310,7 @@ public class MySqlBase implements DatabaseBase
 	             * "feature". We work around this by setting the username as part of
 	             * the URL
 	             */
-	            String url = "jdbc:mysql://" + mySqlServer + ":" + mySqlServerPort + "/" + db + "?user=" + mySqlUser;
+                    String url = "jdbc:mysql://" + mySqlServer + ":" + mySqlServerPort + "/" + db + "?user=" + mySqlUser + "&verifyServerCertificate=false&useSSL=true";
 	            logger.debug("mysql database: " + url);
 	
 	            // register the connection pool


### PR DESCRIPTION
In orca logs, messages appear as below:

>WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.

This change is made to handle these warnings and is tested on inno rack. 