### PR TITLE
162 modify interdomain broadcast

### DIFF
--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -628,6 +628,36 @@ public class OrcaXmlrpcHandlerTest {
     }
 
     /**
+     * #162
+     * Start a new slice with three nodes, in different domains, with no links between them. Create this slice.
+     * Modify the slice by adding a broadcast link between two nodes (A and B). Submit this modify.
+     * Modify the slice by adding a broadcast link between two nodes (B and C). Submit this modify.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void test162ModifyAddInterDomainBroadcastLinks() throws Exception {
+        // Create Request
+        String createRequestFile = "src/test/resources/162_interdomain_link_add_request.rdf";
+
+        // modify request
+        LinkedHashMap<String, Integer> modifyRequests = new LinkedHashMap<>();
+        modifyRequests.put("src/test/resources/162_interdomain_link_add_broadcast_A-B_modify_request.rdf", 3+5);
+        modifyRequests.put("src/test/resources/162_interdomain_link_add_broadcast_B-A_modify_request.rdf", 3+5+3);
+
+        XmlrpcControllerSlice slice = doTestMultipleModifySlice(
+                "test162ModifyAddInterDomainBroadcastLinks",
+                createRequestFile,
+                modifyRequests);
+
+        List<TicketReservationMng> computedReservations = slice.getComputedReservations();
+
+        //
+        assertReservationsHaveNetworkInterface(computedReservations);
+        assertSliceHasNoDuplicateInterfaces(slice);
+    }
+
+    /**
      * Adding and removing Nodes one at a time, means that we should always be able to predict
      * the interface numbering.
      *

--- a/controllers/xmlrpc/src/test/resources/162_interdomain_link_add_broadcast_A-B_modify_request.rdf
+++ b/controllers/xmlrpc/src/test/resources/162_interdomain_link_add_broadcast_A-B_modify_request.rdf
@@ -1,0 +1,75 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:modify="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#modifyElement/d8e79f34-899e-41da-bfdb-6e0b1b67c90d">
+    <modify-schema:modifyElement rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#B-BBN"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#B-BBN"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#VLAN1-A-RCI">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#VLAN1">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#VLAN1-B-BBN"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#VLAN1-A-RCI"/>
+    <layer:atLayer rdf:resource="http://geni-orca.renci.org/owl/ethernet.owl#EthernetNetworkElement"/>
+    <layer:bandwidth rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10000000</layer:bandwidth>
+    <topology:hasGUID>51c4cfcb-ae61-47bc-8b8a-a32f922bb0f0</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#BroadcastConnection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#B-BBN">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#VLAN1-B-BBN"/>
+    <modify-schema:isModify rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</modify-schema:isModify>
+    <topology:hasGUID>a14cbc95-ff08-4930-8e48-2c9952e27373</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#modifyElement/e40b9825-4492-47db-a260-a9d91620c81c">
+    <modify-schema:addElement rdf:resource="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#VLAN1"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#VLAN1"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#38086793-02f0-46fe-a41d-9f7089a39909/modify">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#modifyElement/e40b9825-4492-47db-a260-a9d91620c81c"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#modifyElement/d8e79f34-899e-41da-bfdb-6e0b1b67c90d"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#modifyElement/5aca9ce2-b2dc-4cb5-9e10-48f773231a86"/>
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">38086793-02f0-46fe-a41d-9f7089a39909/modify</topology:hasName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyReservation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#modifyElement/5aca9ce2-b2dc-4cb5-9e10-48f773231a86">
+    <modify-schema:modifyElement rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#A-RCI"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#A-RCI"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#VLAN1-B-BBN">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#A-RCI">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/38086793-02f0-46fe-a41d-9f7089a39909#VLAN1-A-RCI"/>
+    <modify-schema:isModify rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</modify-schema:isModify>
+    <topology:hasGUID>8c34ef3d-3fbe-47ab-87ff-a3d52601d637</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/controllers/xmlrpc/src/test/resources/162_interdomain_link_add_broadcast_B-A_modify_request.rdf
+++ b/controllers/xmlrpc/src/test/resources/162_interdomain_link_add_broadcast_B-A_modify_request.rdf
@@ -1,0 +1,75 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:modify="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#VLAN0-C-UH">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#d9591b35-0bc3-4ed2-a902-3573ecef7489/modify">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#modifyElement/8c4cb948-fcb7-4f16-ac3c-e277243bf1d0"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#modifyElement/430ea455-ceee-4ec7-9c33-4a2c4bee2556"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#modifyElement/f14bb2a7-b474-4b9b-b74c-5d72f21ff868"/>
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">d9591b35-0bc3-4ed2-a902-3573ecef7489/modify</topology:hasName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyReservation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#VLAN0">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#VLAN0-C-UH"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#VLAN0-B-BBN"/>
+    <layer:atLayer rdf:resource="http://geni-orca.renci.org/owl/ethernet.owl#EthernetNetworkElement"/>
+    <layer:bandwidth rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10000000</layer:bandwidth>
+    <topology:hasGUID>f57b83f8-0b73-4727-9eda-cfcca1833131</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#BroadcastConnection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#VLAN0-B-BBN">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#C-UH">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#VLAN0-C-UH"/>
+    <modify-schema:isModify rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</modify-schema:isModify>
+    <topology:hasGUID>a0661383-6f09-4cc5-b9f2-8a42886b3585</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#modifyElement/430ea455-ceee-4ec7-9c33-4a2c4bee2556">
+    <modify-schema:modifyElement rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#C-UH"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#C-UH"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#B-BBN">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#VLAN0-B-BBN"/>
+    <modify-schema:isModify rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</modify-schema:isModify>
+    <topology:hasGUID>a14cbc95-ff08-4930-8e48-2c9952e27373</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#modifyElement/f14bb2a7-b474-4b9b-b74c-5d72f21ff868">
+    <modify-schema:modifyElement rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#B-BBN"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#B-BBN"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#modifyElement/8c4cb948-fcb7-4f16-ac3c-e277243bf1d0">
+    <modify-schema:addElement rdf:resource="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#VLAN0"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/d9591b35-0bc3-4ed2-a902-3573ecef7489#VLAN0"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/controllers/xmlrpc/src/test/resources/162_interdomain_link_add_request.rdf
+++ b/controllers/xmlrpc/src/test/resources/162_interdomain_link_add_request.rdf
@@ -1,0 +1,81 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:request="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#Term">
+    <time:hasDurationDescription rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#TermDuration"/>
+    <rdf:type rdf:resource="http://www.w3.org/2006/time#Interval"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#TermDuration">
+    <time:days rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1</time:days>
+    <rdf:type rdf:resource="http://www.w3.org/2006/time#DurationDescription"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#B-BBN"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#C-UH"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#A-RCI"/>
+    <request-schema:hasTerm rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#Term"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/request.owl#Reservation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#Centos+6.7+v1.1.0">
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Centos 6.7 v1.1.0</topology:hasName>
+    <topology:hasURL>http://geni-images.renci.org/images/standard/centos/centos6.7-v1.1.0/centos6.7-v1.1.0.xml</topology:hasURL>
+    <topology:hasGUID>0c22c525b8a4f0f480f17587557b57a7a111d198</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#DiskImage"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/bbnvmsite.rdf#bbnvmsite/Domain">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkDomain"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#C-UH">
+    <topology:hasGUID>a0661383-6f09-4cc5-b9f2-8a42886b3585</topology:hasGUID>
+    <request-schema:inDomain rdf:resource="http://geni-orca.renci.org/owl/uhvmsite.rdf#uhvmsite/Domain"/>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#Centos+6.7+v1.1.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#B-BBN">
+    <topology:hasGUID>a14cbc95-ff08-4930-8e48-2c9952e27373</topology:hasGUID>
+    <request-schema:inDomain rdf:resource="http://geni-orca.renci.org/owl/bbnvmsite.rdf#bbnvmsite/Domain"/>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#Centos+6.7+v1.1.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/uhvmsite.rdf#uhvmsite/Domain">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkDomain"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/rcivmsite.rdf#rcivmsite/Domain">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkDomain"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#A-RCI">
+    <topology:hasGUID>8c34ef3d-3fbe-47ab-87ff-a3d52601d637</topology:hasGUID>
+    <request-schema:inDomain rdf:resource="http://geni-orca.renci.org/owl/rcivmsite.rdf#rcivmsite/Domain"/>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/15cc86cd-aa15-4d0b-bc3b-80f5737a18a7#Centos+6.7+v1.1.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/embed/src/main/java/orca/embed/cloudembed/controller/InterCloudHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/InterCloudHandler.java
@@ -139,7 +139,11 @@ public class InterCloudHandler extends ModifyHandler {
 			s_rr.remove(RequestReservation.MultiPoint_Domain);
             request.getElements().removeAll(mp_elements);
             for(NetworkElement ne:this.mpRequest.getElements()){
-            	//ne.setInDomain(RequestReservation.Interdomain_Domain);
+				// #162 make sure the element has not been Closed before trying to add it
+				if (ne.getModel().isClosed()){
+					continue;
+				}
+
             	String domainName=ne.getInDomain();
             	String pureType=ne.getResourceType().getResourceType();
             	if(domainName.endsWith(pureType)){

--- a/embed/src/main/java/orca/embed/cloudembed/controller/ModifyHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/ModifyHandler.java
@@ -802,7 +802,9 @@ public class ModifyHandler extends UnboundRequestHandler {
 		        	Iterator<NetworkElement> elementIt = elements.iterator();
 		        	while(elementIt.hasNext()){
 		        		element = elementIt.next();
-		        		if(element.getName().equals(connectionName) || element.getURI().equals(connectionName)){
+
+		        		// #162 make sure the element has not been Closed before trying to add it to the manifest
+		        		if(!element.getModel().isClosed() && (element.getName().equals(connectionName) || element.getURI().equals(connectionName))){
 		        			logger.info("Modify CreateManifest InterDomain:element url ="+element.getURI()+";isModify="+element.isModify());
 		        			createManifest(element, manifestModel, manifest, domainList);
 		        		}


### PR DESCRIPTION
Fixes #162, which resulted in an NPE when modifying a slice to add Inter-Domain broadcast links.  

Broadcast VLANs get substituted with multiple links along the path of the interdomain link, and the original VLAN element is 'closed'.  The modify was not ignoring these closed elements, resulting in the NPE.

The change in ModifyHandler is earlier in the call stack.  The follow-on check in InterCloudHandler is thus not strictly necessary, but defensive.