### PR TITLE
161 interdomain modify

### DIFF
--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
@@ -89,7 +89,19 @@ public class OrcaRegressionModifyTest {
                 //add storage modify
                 {"../../embed/src/test/resources/orca/embed/TS1/TS1-2.rdf",
                         "src/test/resources/146_modify_add_storage_request.rdf",
-                        2}
+                        2},
+                // Interdomain modify
+                {"../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_request.rdf",
+                        "../../embed/src/test/resources/orca/embed/161_interdomain_simplified_A1_B1_B2_modify_request.rdf",
+                        13},
+                // Interdomain modify
+                {"../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_request.rdf",
+                        "../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_B2_C1_modify_request.rdf",
+                        17},
+                // Interdomain modify
+                {"../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_request.rdf",
+                        "../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_to_B2_modify_request.rdf",
+                        9}
         });
     }
 

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -3,6 +3,7 @@ package orca.controllers.xmlrpc;
 import com.hp.hpl.jena.ontology.Individual;
 import orca.controllers.OrcaController;
 import orca.embed.policyhelpers.DomainResourcePools;
+import orca.embed.policyhelpers.SystemNativeError;
 import orca.embed.workflow.RequestWorkflow;
 import orca.manage.IOrcaServiceManager;
 import orca.manage.OrcaConstants;
@@ -1234,7 +1235,12 @@ public class OrcaXmlrpcHandlerTest {
         RequestWorkflow workflow = ndlSlice.getWorkflow();
         workflow.setGlobalControllerAssignedLabel(orcaXmlrpcHandler.instance.getControllerAssignedLabel());
         workflow.setShared_IP_set(orcaXmlrpcHandler.instance.getShared_IP_set());
-        workflow.run(drp, orcaXmlrpcHandler.abstractModels, resReq, userDN, controller_url, ndlSlice.getSliceID());
+        final SystemNativeError runError = workflow.run(drp, orcaXmlrpcHandler.abstractModels, resReq, userDN, controller_url, ndlSlice.getSliceID());
+
+        // this shouldn't happen, unless we've made an error in creating our tests
+        if (runError != null) {
+            assertFalse("Could not create slice necessary for Modify: " + runError.getMessage(), runError.isError());
+        }
 
         ArrayList<TicketReservationMng> reservations = orc.getReservations(sm, workflow.getBoundElements(), orcaXmlrpcHandler.typesMap, workflow.getTerm(), workflow.getslice());
 

--- a/embed/src/main/java/orca/embed/cloudembed/controller/ModifyHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/ModifyHandler.java
@@ -2,15 +2,8 @@ package orca.embed.cloudembed.controller;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.UUID;
 
 import net.jwhoisserver.utils.InetNetwork;
 import net.jwhoisserver.utils.InetNetworkException;
@@ -185,7 +178,8 @@ public class ModifyHandler extends UnboundRequestHandler {
 		for(ReservationMng ar: a_r){
 			config_ar = OrcaConverter.fill(ar.getConfigurationProperties());
 			local_ar = OrcaConverter.fill(ar.getLocalProperties());
-			String url_ar=config_ar.getProperty(UnitProperties.UnitDomain);
+			String url_ar=config_ar.getProperty(UnitProperties.UnitHostNameUrl);
+
 			if(url_ar==null){
 				logger.error("ar reservation no url property:"+ar.getReservationID());
 				continue;
@@ -193,11 +187,13 @@ public class ModifyHandler extends UnboundRequestHandler {
 			for(ReservationMng mr: m_r){
 				config_mr = OrcaConverter.fill(mr.getConfigurationProperties());
 				local_mr = OrcaConverter.fill(mr.getLocalProperties());
-				String url_mr=config_mr.getProperty(UnitProperties.UnitDomain);
+				String url_mr=config_mr.getProperty(UnitProperties.UnitHostNameUrl);
+
 				if(url_mr==null){
 					logger.error("mr reservation no url property:"+mr.getReservationID());
 					continue;
 				}
+
 				if(url_ar.equals(url_mr)){
 					logger.debug("Modifying via adding storage url_al="+url_ar+";"+";url_ml="+url_mr);
 					logger.debug("config:"+config_ar.toString());

--- a/embed/src/test/resources/orca/embed/161_interdomain_A1_B1_B2_C1_modify_request.rdf
+++ b/embed/src/test/resources/orca/embed/161_interdomain_A1_B1_B2_C1_modify_request.rdf
@@ -1,0 +1,137 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:modify="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#421b3e9f-4b75-4979-8d8e-5993f76474a9/modify">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/99506218-ae70-4171-bac0-875d70e6e56c"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/a4c23106-e219-4297-9c94-8e78d2d5e933"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/e815cf8d-8f79-4e0f-b65f-e9d3ac7fa49f"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/4af906b5-4cb7-4c36-b5ab-10be1578a9be"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/693ce500-366d-4f53-b720-1eec9ddc5157"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/c6d2111a-e94e-441d-8b10-37878c4a3a3f"/>
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">421b3e9f-4b75-4979-8d8e-5993f76474a9/modify</topology:hasName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyReservation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link181-C-UH">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/4af906b5-4cb7-4c36-b5ab-10be1578a9be">
+    <modify-schema:modifyElement rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#A-RCI"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#A-RCI"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link181-B-BBN">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#B-BBN">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link181-B-BBN"/>
+    <modify-schema:isModify rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</modify-schema:isModify>
+    <topology:hasGUID>0075bb5e-4232-4716-ae86-5cf40f9f0c1e</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link180">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link180-A-RCI"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link180-B2-BBN"/>
+    <layer:atLayer rdf:resource="http://geni-orca.renci.org/owl/ethernet.owl#EthernetNetworkElement"/>
+    <layer:bandwidth rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10000000</layer:bandwidth>
+    <topology:hasGUID>fad131c2-b74c-4c7c-9fa9-3c0290cbb1d9</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkConnection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/99506218-ae70-4171-bac0-875d70e6e56c">
+    <modify-schema:addElement rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link181"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link181"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/c6d2111a-e94e-441d-8b10-37878c4a3a3f">
+    <modify-schema:addElement rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#C-UH"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#C-UH"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/e815cf8d-8f79-4e0f-b65f-e9d3ac7fa49f">
+    <modify-schema:addElement rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link180"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link180"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link181">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link181-B-BBN"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link181-C-UH"/>
+    <layer:atLayer rdf:resource="http://geni-orca.renci.org/owl/ethernet.owl#EthernetNetworkElement"/>
+    <layer:bandwidth rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10000000</layer:bandwidth>
+    <topology:hasGUID>843861c9-018f-402d-9bae-7951d524353a</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkConnection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#A-RCI">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link180-A-RCI"/>
+    <modify-schema:isModify rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</modify-schema:isModify>
+    <topology:hasGUID>cfc52bc3-ad38-4f26-802e-e6f9d387c7c6</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link180-A-RCI">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/a4c23106-e219-4297-9c94-8e78d2d5e933">
+    <modify-schema:modifyElement rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#B-BBN"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#B-BBN"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/bbnvmsite.rdf#bbnvmsite/Domain">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkDomain"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link180-B2-BBN">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Centos+6.7+v1.1.0">
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Centos 6.7 v1.1.0</topology:hasName>
+    <topology:hasURL>http://geni-images.renci.org/images/standard/centos/centos6.7-v1.1.0/centos6.7-v1.1.0.xml</topology:hasURL>
+    <topology:hasGUID>0c22c525b8a4f0f480f17587557b57a7a111d198</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#DiskImage"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#modifyElement/693ce500-366d-4f53-b720-1eec9ddc5157">
+    <modify-schema:addElement rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#B2-BBN"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#B2-BBN"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/uhvmsite.rdf#uhvmsite/Domain">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkDomain"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#C-UH">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link181-C-UH"/>
+    <topology:hasGUID>d1787b5c-4bdc-491d-90e3-76043af420cb</topology:hasGUID>
+    <request-schema:inDomain rdf:resource="http://geni-orca.renci.org/owl/uhvmsite.rdf#uhvmsite/Domain"/>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Centos+6.7+v1.1.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#B2-BBN">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Link180-B2-BBN"/>
+    <topology:hasGUID>d4de384c-db12-408e-be00-f24d8ca1384a</topology:hasGUID>
+    <request-schema:inDomain rdf:resource="http://geni-orca.renci.org/owl/bbnvmsite.rdf#bbnvmsite/Domain"/>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/421b3e9f-4b75-4979-8d8e-5993f76474a9#Centos+6.7+v1.1.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/embed/src/test/resources/orca/embed/161_interdomain_A1_B1_request.rdf
+++ b/embed/src/test/resources/orca/embed/161_interdomain_A1_B1_request.rdf
@@ -1,0 +1,99 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:request="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Term">
+    <time:hasDurationDescription rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#TermDuration"/>
+    <time:hasBeginning rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#TermBeginning"/>
+    <rdf:type rdf:resource="http://www.w3.org/2006/time#Interval"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3-A-RCI"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3-B-BBN"/>
+    <layer:atLayer rdf:resource="http://geni-orca.renci.org/owl/ethernet.owl#EthernetNetworkElement"/>
+    <layer:bandwidth rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10000000</layer:bandwidth>
+    <topology:hasGUID>c6018a7b-60ed-437c-8b08-7763fd505734</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkConnection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3-B-BBN-ip-172-16-0-2">
+    <ip4:netmask>255.255.255.252</ip4:netmask>
+    <layer:label_ID>172.16.0.2</layer:label_ID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/ip4.owl#IPAddress"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#A-RCI"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#B-BBN"/>
+    <request-schema:hasTerm rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Term"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/request.owl#Reservation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#TermDuration">
+    <time:days rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1</time:days>
+    <rdf:type rdf:resource="http://www.w3.org/2006/time#DurationDescription"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#B-BBN">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3-B-BBN"/>
+    <topology:hasGUID>0075bb5e-4232-4716-ae86-5cf40f9f0c1e</topology:hasGUID>
+    <request-schema:inDomain rdf:resource="http://geni-orca.renci.org/owl/bbnvmsite.rdf#bbnvmsite/Domain"/>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Centos+6.7+v1.0.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3-A-RCI">
+    <ip4:localIPAddress rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3-A-RCI-ip-172-16-0-1"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#A-RCI">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3-A-RCI"/>
+    <topology:hasGUID>cfc52bc3-ad38-4f26-802e-e6f9d387c7c6</topology:hasGUID>
+    <request-schema:inDomain rdf:resource="http://geni-orca.renci.org/owl/rcivmsite.rdf#rcivmsite/Domain"/>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Centos+6.7+v1.0.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3-B-BBN">
+    <ip4:localIPAddress rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3-B-BBN-ip-172-16-0-2"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Link3-A-RCI-ip-172-16-0-1">
+    <ip4:netmask>255.255.255.252</ip4:netmask>
+    <layer:label_ID>172.16.0.1</layer:label_ID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/ip4.owl#IPAddress"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#Centos+6.7+v1.0.0">
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Centos 6.7 v1.0.0</topology:hasName>
+    <topology:hasURL>http://geni-images.renci.org/images/standard/centos/centos6.7-v1.0.0/centos6.7-v1.0.0.xml</topology:hasURL>
+    <topology:hasGUID>dceedc1e70bd4d8d95bb4e92197f64217d17eea0</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#DiskImage"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/bbnvmsite.rdf#bbnvmsite/Domain">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkDomain"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/rcivmsite.rdf#rcivmsite/Domain">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkDomain"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/embed/src/test/resources/orca/embed/161_interdomain_A1_B1_to_B2_modify_request.rdf
+++ b/embed/src/test/resources/orca/embed/161_interdomain_A1_B1_to_B2_modify_request.rdf
@@ -1,0 +1,87 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:modify="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#modifyElement/1165d4d4-7493-4400-9336-944c47b4350d">
+    <modify-schema:addElement rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Link12"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Link12"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Link12-B-BBN">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#modifyElement/f4dc742d-f3e0-42f5-a626-1ad3a981f31c">
+    <modify-schema:modifyElement rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#B-BBN"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#B-BBN"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Centos+6.7+v1.1.0">
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Centos 6.7 v1.1.0</topology:hasName>
+    <topology:hasURL>http://geni-images.renci.org/images/standard/centos/centos6.7-v1.1.0/centos6.7-v1.1.0.xml</topology:hasURL>
+    <topology:hasGUID>0c22c525b8a4f0f480f17587557b57a7a111d198</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#DiskImage"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Link12">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Link12-B-BBN"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Link12-B2-BBN"/>
+    <layer:atLayer rdf:resource="http://geni-orca.renci.org/owl/ethernet.owl#EthernetNetworkElement"/>
+    <layer:bandwidth rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10000000</layer:bandwidth>
+    <topology:hasGUID>c5076075-fc4d-4d37-8560-4db144df4c23</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkConnection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/bbnvmsite.rdf#bbnvmsite/Domain">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkDomain"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#B-BBN">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Link12-B-BBN"/>
+    <modify-schema:isModify rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</modify-schema:isModify>
+    <topology:hasGUID>0075bb5e-4232-4716-ae86-5cf40f9f0c1e</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Link12-B2-BBN">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#e7a5af5c-30ea-47fb-8edc-19c874a9d676/modify">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#modifyElement/1165d4d4-7493-4400-9336-944c47b4350d"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#modifyElement/f4dc742d-f3e0-42f5-a626-1ad3a981f31c"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#modifyElement/6acbf1e8-f485-4338-86ca-4b70eb3c1b02"/>
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">e7a5af5c-30ea-47fb-8edc-19c874a9d676/modify</topology:hasName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyReservation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#B2-BBN">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Link12-B2-BBN"/>
+    <topology:hasGUID>6aef7506-85fb-47af-81d0-9246ebf98947</topology:hasGUID>
+    <request-schema:inDomain rdf:resource="http://geni-orca.renci.org/owl/bbnvmsite.rdf#bbnvmsite/Domain"/>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#Centos+6.7+v1.1.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#modifyElement/6acbf1e8-f485-4338-86ca-4b70eb3c1b02">
+    <modify-schema:addElement rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#B2-BBN"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/e7a5af5c-30ea-47fb-8edc-19c874a9d676#B2-BBN"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/embed/src/test/resources/orca/embed/161_interdomain_simplified_A1_B1_B2_modify_request.rdf
+++ b/embed/src/test/resources/orca/embed/161_interdomain_simplified_A1_B1_B2_modify_request.rdf
@@ -1,0 +1,87 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:modify="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#modifyElement/eb349287-deba-488d-8670-c3f5d7be6c30">
+    <modify-schema:addElement rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Link79"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Link79"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Centos+6.7+v1.1.0">
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Centos 6.7 v1.1.0</topology:hasName>
+    <topology:hasURL>http://geni-images.renci.org/images/standard/centos/centos6.7-v1.1.0/centos6.7-v1.1.0.xml</topology:hasURL>
+    <topology:hasGUID>0c22c525b8a4f0f480f17587557b57a7a111d198</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#DiskImage"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#A-RCI">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Link79-A-RCI"/>
+    <modify-schema:isModify rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</modify-schema:isModify>
+    <topology:hasGUID>cfc52bc3-ad38-4f26-802e-e6f9d387c7c6</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#B2-BBN">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Link79-B2-BBN"/>
+    <topology:hasGUID>b614402d-da8d-4317-850b-75d081c43ced</topology:hasGUID>
+    <request-schema:inDomain rdf:resource="http://geni-orca.renci.org/owl/bbnvmsite.rdf#bbnvmsite/Domain"/>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Centos+6.7+v1.1.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#modifyElement/e1bfd562-67e4-441a-9e4b-00b4fde7458f">
+    <modify-schema:modifyElement rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#A-RCI"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/d5873c92-0fa6-412b-9ef4-bbaff90000fb#A-RCI"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#87be33dd-4922-4ca2-98b0-220f67d3df3b/modify">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#modifyElement/eb349287-deba-488d-8670-c3f5d7be6c30"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#modifyElement/e1bfd562-67e4-441a-9e4b-00b4fde7458f"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#modifyElement/e2e69d49-24f8-491c-a006-976fb0ce8c4d"/>
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">87be33dd-4922-4ca2-98b0-220f67d3df3b/modify</topology:hasName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyReservation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Link79-A-RCI">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#modifyElement/e2e69d49-24f8-491c-a006-976fb0ce8c4d">
+    <modify-schema:addElement rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#B2-BBN"/>
+    <modify-schema:modifySubject rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#B2-BBN"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/modify.owl#ModifyElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Link79-B2-BBN">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/bbnvmsite.rdf#bbnvmsite/Domain">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkDomain"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Link79">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Link79-A-RCI"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/87be33dd-4922-4ca2-98b0-220f67d3df3b#Link79-B2-BBN"/>
+    <layer:atLayer rdf:resource="http://geni-orca.renci.org/owl/ethernet.owl#EthernetNetworkElement"/>
+    <layer:bandwidth rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10000000</layer:bandwidth>
+    <topology:hasGUID>37989757-90ac-40fa-83f8-bb0acccdcbb5</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#NetworkConnection"/>
+  </rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
Fixes #161, originally reported in RENCI-NRIG/exogeni#175

It was discovered that the `UnitDomain` field being used in the `modifyStorage` storage function was not able to correctly differentiate between the B2 node that was being added and the B1 node that was already present but being modified.

The minor visualization issue noticed in this ticket is addressed in RENCI-NRIG/flukes#17