### PR TITLE
Fixing logging and unnecessary parameter check in prepare-key script …

### DIFF
--- a/handlers/ec2/resources/handlers/ec2/handler.xml
+++ b/handlers/ec2/resources/handlers/ec2/handler.xml
@@ -365,9 +365,6 @@
 													<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
 													<env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
 													<env key="EC2_SSH_TIMEOUT" value="${ec2.ssh.timeout}" />
-													<env key="AMI_NAME" value="${ec2.ami.name}" />
-													<env key="AKI_NAME" value="${ec2.aki.name}" />
-													<env key="ARI_NAME" value="${ec2.ari.name}" />
 													<arg value="${shirako.save.unit.manage.ip}" />
 													<arg value="${loginProperty}" />
 													<arg value="${keysProperty}" />
@@ -591,38 +588,35 @@
 					<var name="message" unset="true" />
 
 					<!-- re-create the NEUCA INI file -->
-					<echo message="Creating account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" />
-										<echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" />
-										<echo message="LoginProperty : ${loginProperty}" />
-										<echo message="KeysProperty : ${keysProperty}" />
-										<echo message="SudoProperty : ${sudoProperty}" />
-										<exec executable="${ec2.scripts}/${cloud.type}-get-userdata" resultproperty="icode" outputproperty="userdata.old" >
-											  <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
-											  <env key="EC2_HOME" value="${ec2.home}" />
-											  <env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
-											  <env key="EC2_LOG_FILE" value="${ec2.log.file}" />
-											  <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
-											  <env key="EC2_DIR" value="${ec2.dir}" />
-											  <env key="EUCA_KEY_DIR" value="${ec2.keys}" />
-											  <env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
-											  <arg value="${unit.ec2.instance}" />
-										</exec>
-										<echo message="Exit code for get-userdata is ${icode}" />
-					<echo message="Old userdata : ${userdata.old}" />
+					<echo message="Creating account on ${unit.manage.ip}" />
+					<echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" />
+					<exec executable="${ec2.scripts}/${cloud.type}-get-userdata" resultproperty="icode" outputproperty="userdata.old" >
+						<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+						<env key="EC2_HOME" value="${ec2.home}" />
+						<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+						<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+						<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+						<env key="EC2_DIR" value="${ec2.dir}" />
+						<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+						<env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
+						<arg value="${unit.ec2.instance}" />
+					</exec>
+					<echo message="Exit code for get-userdata is ${icode}" />
+					<!-- <echo message="Old userdata : ${userdata.old}" /> -->
 					
 					<!-- setup userdata:  set userdataold the userdata string in order to parse and copy to ${neuca.ini.file} -->
 					<tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" />
-										<echo message="neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" />
-										<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${userdata.old}" />
-										<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
-										<echo message="neuca.ini: ${neuca.ini}" />
+					<echo message="neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" />
+					<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${userdata.old}" />
+					<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+					<!-- <echo message="neuca.ini: ${neuca.ini}" /> -->
 
 					<!-- add keys -->
 					<echo message="Modify.ssh, numlogins : ${modify.@{seqnum}.config.ssh.numlogins} " />
 					<for list="${modify.@{seqnum}.config.ssh.numlogins}" param="iter" delimiter="," parallel="false">
 
 						<sequential>
-								<var name="icode" unset="true" />
+							<var name="icode" unset="true" />
 							<var name="loginProperty" unset="true" />
 							<var name="keysProperty" unset="true" />
 							<var name="sudoProperty" unset="true" />
@@ -638,9 +632,9 @@
 							<echo message="SudoProperty : ${sudoProperty}" />
 
 							<!-- add key to userdata:  setuserdataold to ${neuca.ini.file} to read from file -->
-														<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}"  section="users" key="${loginProperty}" value="${keysProperty}" />
-														<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
-														<echo message="neuca.ini: ${neuca.ini}" />
+							<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}"  section="users" key="${loginProperty}" value="${keysProperty}" />
+							<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+							<echo message="neuca.ini: ${neuca.ini}" />
 
 							<!-- add key to VM -->
 							<exec executable="${ec2.scripts}/${cloud.type}-prepare-key" resultproperty="icode">
@@ -653,9 +647,6 @@
 								<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
 								<env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
 								<env key="EC2_SSH_TIMEOUT" value="${ec2.ssh.timeout}" />
-								<env key="AMI_NAME" value="${ec2.ami.name}" />
-								<env key="AKI_NAME" value="${ec2.aki.name}" />
-								<env key="ARI_NAME" value="${ec2.ari.name}" />
 								<arg value="${unit.manage.ip}" />
 								<arg value="${loginProperty}" />
 								<arg value="${keysProperty}" />
@@ -675,23 +666,23 @@
 
 					<!-- update the userdata file  -->
 					<echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" />
-										<echo message="update userdata instance: ${shirako.save.unit.ec2.instance}" />
-										<var name="code" unset="true" />
-										<var name="update.userdata.output" unset="true" />
-										<exec executable="${ec2.scripts}/${cloud.type}-update-userdata" resultproperty="code" outputproperty="update.userdata.output">
-											 <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
-											 <env key="EC2_HOME" value="${ec2.home}" />
-											 <env key="EC2_DIR" value="${ec2.dir}" />
-											 <env key="EUCA_KEY_DIR" value="${ec2.keys}" />
-											 <env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
-											 <env key="EC2_LOG_FILE" value="${ec2.log.file}" />
-											 <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
-											 <env key="NEUCA_INI" value="${neuca.ini.file}" />
-											 <env key="INSTANCE_ID" value="${shirako.save.unit.ec2.instance}" />
-										</exec>
-										<echo message="after update userdata: exit code ${code}, ${update.userdata.output}" />
+					<echo message="update userdata instance: ${shirako.save.unit.ec2.instance}" />
+					<var name="code" unset="true" />
+					<var name="update.userdata.output" unset="true" />
+					<exec executable="${ec2.scripts}/${cloud.type}-update-userdata" resultproperty="code" outputproperty="update.userdata.output">
+						<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+						<env key="EC2_HOME" value="${ec2.home}" />
+						<env key="EC2_DIR" value="${ec2.dir}" />
+						<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+						<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+						<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+						<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+						<env key="NEUCA_INI" value="${neuca.ini.file}" />
+						<env key="INSTANCE_ID" value="${shirako.save.unit.ec2.instance}" />
+					</exec>
+					<echo message="after update userdata: exit code ${code}, ${update.userdata.output}" />
 					
-										<delete file="${neuca.ini.file}" />
+					<delete file="${neuca.ini.file}" />
 
 				</else>
 			</if>

--- a/handlers/ec2/resources/scripts/nova-essex-prepare-key
+++ b/handlers/ec2/resources/scripts/nova-essex-prepare-key
@@ -56,41 +56,38 @@ try:
     #DO THE WORK                                                                                                                                                                                       
     LOG.debug("nova-essex-prepare-key: " + str(sys.argv))
 
-    if str(os.environ['AMI_NAME']) and str(os.environ['AKI_NAME']) and str(os.environ['ARI_NAME']):
-        if len(sys.argv) == 4:
+    if len(sys.argv) == 4:
     
-            instance_ip = sys.argv[1].strip("'")
-            user_ssh_key = sys.argv[2].strip("'")
+        instance_ip = sys.argv[1].strip("'")
+        user_ssh_key = sys.argv[2].strip("'")
     
-            VM.prepare_key(instance_ip,user_ssh_key, os.environ['EUCA_KEY_DIR']+"/"+os.environ['EC2_SSH_KEY'])
+        VM.prepare_key(instance_ip,user_ssh_key, os.environ['EUCA_KEY_DIR']+"/"+os.environ['EC2_SSH_KEY'])
     
-            LOG.info("nova-essex-prepare-key: Success " + str(instance_ip) + ": " + str(user_ssh_key))
-        elif len(sys.argv) == 5:
-            instance_ip = sys.argv[1].strip("'")
-            user_name =  sys.argv[2].strip("'")
+        LOG.info("nova-essex-prepare-key: Success " + str(instance_ip) + ": " + str(user_ssh_key))
+    elif len(sys.argv) == 5:
+        instance_ip = sys.argv[1].strip("'")
+        user_name =  sys.argv[2].strip("'")
             
-            user_ssh_keys = sys.argv[3].strip("'").split('\n')
-            shouldSudo = sys.argv[4].strip("'")
-            LOG.debug("nova-essex-prepare-key: argv = " + str(sys.argv))
+        user_ssh_keys = sys.argv[3].strip("'").split('\n')
+        shouldSudo = sys.argv[4].strip("'")
+        LOG.debug("nova-essex-prepare-key: argv = " + str(sys.argv))
     
-            LOG.debug("instance_ip = " + str(instance_ip))
-            LOG.debug("user_name = " + str(user_name))
-            LOG.debug("user_ssh_keys (" + str(len(user_ssh_keys))  + ") = " + str(user_ssh_keys))
-            LOG.debug("shouldSudo = " + str(shouldSudo))
+        LOG.debug("instance_ip = " + str(instance_ip))
+        LOG.debug("user_name = " + str(user_name))
+        LOG.debug("user_ssh_keys (" + str(len(user_ssh_keys))  + ") = " + str(user_ssh_keys))
+        LOG.debug("shouldSudo = " + str(shouldSudo))
     
-            while user_ssh_keys.count('') > 0:
-                user_ssh_keys.remove('')
+        while user_ssh_keys.count('') > 0:
+            user_ssh_keys.remove('')
                 
     
-            for i in user_ssh_keys:
-                LOG.debug("user_ssh_keys -- " + str(i))
+        for i in user_ssh_keys:
+            LOG.debug("user_ssh_keys -- " + str(i))
     
-            VM.prepare_keys(instance_ip,user_name,user_ssh_keys, shouldSudo, os.environ['EUCA_KEY_DIR']+"/"+os.environ['EC2_SSH_KEY'])
-        else:
-            LOG.error("nova-essex-prepare-key: invalid argv length (" + str(len(sys.argv)) + "), argv = " + str(sys.argv))
-            sys.exit(1)
-
-
+        VM.prepare_keys(instance_ip,user_name,user_ssh_keys, shouldSudo, os.environ['EUCA_KEY_DIR']+"/"+os.environ['EC2_SSH_KEY'])
+    else:
+        LOG.error("nova-essex-prepare-key: invalid argv length (" + str(len(sys.argv)) + "), argv = " + str(sys.argv))
+        sys.exit(1)
 
 except Exception as e:
     LOG.error("nova-essex-prepare-key: " + str(type(e)) + " : " + str(e) + "\n" + str(traceback.format_exc()))


### PR DESCRIPTION
…- AMI/AKI/ARI parameters aren't needed and aren't supplied when modify is called (as opposed to creating a new instance)