### PR TITLE
41 unbound splitting

### DIFF
--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/ReservationConverter.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/ReservationConverter.java
@@ -6,8 +6,10 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Formatter;
@@ -67,9 +69,6 @@ import com.hp.hpl.jena.rdf.model.Statement;
 import com.hp.hpl.jena.rdf.model.StmtIterator;
 import com.hp.hpl.jena.sparql.core.ResultBinding;
 import com.hp.hpl.jena.util.iterator.ExtendedIterator;
-
-import edu.emory.mathcs.backport.java.util.Arrays;
-import edu.emory.mathcs.backport.java.util.Collections;
 
 public class ReservationConverter implements LayerConstant {
     static final String SUDO_NO = "no";
@@ -2324,7 +2323,7 @@ public class ReservationConverter implements LayerConstant {
                 userKeys = (List<String>) e.get(KEYS_FIELD);
             } catch (ClassCastException cce) {
                 try {
-                    userKeys = new ArrayList<String>(Arrays.asList((Object[]) e.get(KEYS_FIELD)));
+                    userKeys = new ArrayList<String>(Arrays.asList((String[]) e.get(KEYS_FIELD)));
                 } catch (ClassCastException cce1) {
                     try {
                         userKeys = Collections.singletonList((String) e.get(KEYS_FIELD));

--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/ReservationConverter.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/ReservationConverter.java
@@ -2334,11 +2334,13 @@ public class ReservationConverter implements LayerConstant {
                 } else if (keysObject instanceof String) {
                     userKeys = Collections.singletonList((String) keysObject);
                 } else {
-                    Globals.Log.error("Could not coerce " + KEYS_FIELD + " to List. Object was of class " + keysObject.getClass().getCanonicalName());
+                    Globals.Log.error("Could not coerce " + KEYS_FIELD + " to List. Object was of class "
+                            + keysObject.getClass().getCanonicalName());
                     continue;
                 }
             } catch (ClassCastException cce) {
-                Globals.Log.error("Could not coerce " + KEYS_FIELD + " to List. Object was of class " + keysObject.getClass().getCanonicalName(), cce);
+                Globals.Log.error("Could not coerce " + KEYS_FIELD + " to List. Object was of class "
+                        + keysObject.getClass().getCanonicalName(), cce);
                 continue;
             }
 

--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/ReservationConverter.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/ReservationConverter.java
@@ -2331,12 +2331,9 @@ public class ReservationConverter implements LayerConstant {
                 } else if (keysObject instanceof Object[]) {
                     final Object[] keysObjectArray = (Object[]) keysObject;
                     userKeys = Arrays.asList(Arrays.copyOf(keysObjectArray, keysObjectArray.length, String[].class));
-                } else if (keysObject instanceof String) {
-                    userKeys = Collections.singletonList((String) keysObject);
                 } else {
-                    Globals.Log.error("Could not coerce " + KEYS_FIELD + " to List. Object was of class "
-                            + keysObject.getClass().getCanonicalName());
-                    continue;
+                    // we probably only know at this point that it is an 'Object'.
+                    userKeys = Collections.singletonList((String) keysObject);
                 }
             } catch (ClassCastException cce) {
                 Globals.Log.error("Could not coerce " + KEYS_FIELD + " to List. Object was of class "

--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/XmlrpcHandlerHelper.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/XmlrpcHandlerHelper.java
@@ -11,7 +11,9 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -62,9 +64,6 @@ import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.DERUTF8String;
 
 import com.hp.hpl.jena.ontology.OntResource;
-
-import edu.emory.mathcs.backport.java.util.Arrays;
-import edu.emory.mathcs.backport.java.util.Collections;
 
 /**
  * This is a helper class for all XMLRPC handlers. WARNING: Any method you declare public (non-static) becomes a remote

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionTest.java
@@ -87,8 +87,9 @@ public class OrcaRegressionTest {
                 { "../../embed/src/test/resources/orca/embed/158_mp_two_domain_one_unbound_request.rdf", true, 4 + 4 },
                 { "../../embed/src/test/resources/orca/embed/158_mp_three_domain_one_unbound_request.rdf", false,
                         4 + 6 },
-                { "../../embed/src/test/resources/orca/embed/41_single_large_nodegroup_unbound_request.rdf", true, 133},
-                { "../../embed/src/test/resources/orca/embed/41_mp_unbound_request.rdf", true, 134}
+                { "../../embed/src/test/resources/orca/embed/41_single_large_nodegroup_unbound_request.rdf", true,
+                        133 },
+                { "../../embed/src/test/resources/orca/embed/41_mp_unbound_request.rdf", true, 134 }
                 // TS8 really only tests Post-boot Scripts. Not useful in Unit tests
                 /*
                  * { "../../embed/src/test/resources/orca/embed/TS8/TS8-1.rdf", true, 12}, {

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionTest.java
@@ -86,7 +86,9 @@ public class OrcaRegressionTest {
                 { "../../embed/src/test/resources/orca/embed/158_mp_one_domain_one_unbound_request.rdf", true, 4 + 0 },
                 { "../../embed/src/test/resources/orca/embed/158_mp_two_domain_one_unbound_request.rdf", true, 4 + 4 },
                 { "../../embed/src/test/resources/orca/embed/158_mp_three_domain_one_unbound_request.rdf", false,
-                        4 + 6 }
+                        4 + 6 },
+                { "../../embed/src/test/resources/orca/embed/41_single_large_nodegroup_unbound_request.rdf", true, 133},
+                { "../../embed/src/test/resources/orca/embed/41_mp_unbound_request.rdf", true, 134}
                 // TS8 really only tests Post-boot Scripts. Not useful in Unit tests
                 /*
                  * { "../../embed/src/test/resources/orca/embed/TS8/TS8-1.rdf", true, 12}, {

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -1144,7 +1144,7 @@ public class OrcaXmlrpcHandlerTest {
      *
      * @return a UserMap with junk values
      */
-    private static List<Map<String, ?>> getUsersMap() {
+    protected static List<Map<String, ?>> getUsersMap() {
         List<Map<String, ?>> users = new ArrayList<>();
         Map<String, Object> userEntry = new HashMap<>();
         List<String> keys = new ArrayList<String>();

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/ReservationConverterTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/ReservationConverterTest.java
@@ -118,8 +118,8 @@ public class ReservationConverterTest extends RequestWorkflowTest {
     }
 
     /**
-     * Test that SSH key property is generated from UsersMap.
-     * This function passes the keys in the Map as a List, as used by most of our Unit Tests.
+     * Test that SSH key property is generated from UsersMap. This function passes the keys in the Map as a List, as
+     * used by most of our Unit Tests.
      *
      * @throws ReservationConverter.ReservationConverterException
      */
@@ -130,14 +130,15 @@ public class ReservationConverterTest extends RequestWorkflowTest {
 
         assertNotNull("Generated SSH Properties were null", sshProperties);
 
-        final String keyProperty = sshProperties.getProperty(String.format(ConfigurationProperties.ConfigSSHKeyPattern, 1));
+        final String keyProperty = sshProperties
+                .getProperty(String.format(ConfigurationProperties.ConfigSSHKeyPattern, 1));
 
         assertNotNull("Returned SSH key was null", keyProperty);
     }
 
     /**
-     * Test that SSH key property is generated from UsersMap.
-     * This function passes the keys in the Map as an Object[], which is how they appear from XMLRPC.
+     * Test that SSH key property is generated from UsersMap. This function passes the keys in the Map as an Object[],
+     * which is how they appear from XMLRPC.
      *
      * @throws ReservationConverter.ReservationConverterException
      */
@@ -148,14 +149,15 @@ public class ReservationConverterTest extends RequestWorkflowTest {
 
         assertNotNull("Generated SSH Properties were null", sshProperties);
 
-        final String keyProperty = sshProperties.getProperty(String.format(ConfigurationProperties.ConfigSSHKeyPattern, 1));
+        final String keyProperty = sshProperties
+                .getProperty(String.format(ConfigurationProperties.ConfigSSHKeyPattern, 1));
 
         assertNotNull("Returned SSH key was null", keyProperty);
     }
 
     /**
-     * Test that SSH key property is generated from UsersMap.
-     * This function passes the keys in the Map as a String object.
+     * Test that SSH key property is generated from UsersMap. This function passes the keys in the Map as a String
+     * object.
      *
      * @throws ReservationConverter.ReservationConverterException
      */
@@ -166,13 +168,15 @@ public class ReservationConverterTest extends RequestWorkflowTest {
 
         assertNotNull("Generated SSH Properties were null", sshProperties);
 
-        final String keyProperty = sshProperties.getProperty(String.format(ConfigurationProperties.ConfigSSHKeyPattern, 1));
+        final String keyProperty = sshProperties
+                .getProperty(String.format(ConfigurationProperties.ConfigSSHKeyPattern, 1));
 
         assertNotNull("Returned SSH key was null", keyProperty);
     }
 
     /**
-     * Similar to function in OrcaXmlrpcHandlerTest, this is a slightly modified version explicity for testing ReservationConverter
+     * Similar to function in OrcaXmlrpcHandlerTest, this is a slightly modified version explicity for testing
+     * ReservationConverter
      *
      * Craft a userMap required by createSlice() and modifySlice().
      *
@@ -181,7 +185,7 @@ public class ReservationConverterTest extends RequestWorkflowTest {
     private static List<Map<String, ?>> getUsersMapWithObjects() {
         List<Map<String, ?>> users = new ArrayList<>();
         Map<String, Object> userEntry = new HashMap<>();
-        Object[] keys = {"ssh-rsa this is not a key"};
+        Object[] keys = { "ssh-rsa this is not a key" };
         userEntry.put("keys", keys);
         userEntry.put("login", "root");
         userEntry.put("sudo", false);
@@ -190,7 +194,8 @@ public class ReservationConverterTest extends RequestWorkflowTest {
     }
 
     /**
-     * Similar to function in OrcaXmlrpcHandlerTest, this is a slightly modified version explicity for testing ReservationConverter
+     * Similar to function in OrcaXmlrpcHandlerTest, this is a slightly modified version explicity for testing
+     * ReservationConverter
      *
      * Craft a userMap required by createSlice() and modifySlice().
      *

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/ReservationConverterTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/ReservationConverterTest.java
@@ -2,8 +2,13 @@ package orca.controllers.xmlrpc;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import orca.embed.RequestWorkflowTest;
@@ -15,6 +20,7 @@ import orca.ndl.NdlModel;
 import orca.ndl.elements.NetworkElement;
 
 import orca.ndl.elements.OrcaReservationTerm;
+import orca.shirako.common.meta.ConfigurationProperties;
 import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
@@ -111,4 +117,93 @@ public class ReservationConverterTest extends RequestWorkflowTest {
         System.out.println("Term end date updated to: " + orc.leaseEnd);
     }
 
+    /**
+     * Test that SSH key property is generated from UsersMap.
+     * This function passes the keys in the Map as a List, as used by most of our Unit Tests.
+     *
+     * @throws ReservationConverter.ReservationConverterException
+     */
+    public void testGenerateSSHPropertiesWithListKey() throws ReservationConverter.ReservationConverterException {
+        List<Map<String, ?>> users = OrcaXmlrpcHandlerTest.getUsersMap();
+
+        final Properties sshProperties = ReservationConverter.generateSSHProperties(users);
+
+        assertNotNull("Generated SSH Properties were null", sshProperties);
+
+        final String keyProperty = sshProperties.getProperty(String.format(ConfigurationProperties.ConfigSSHKeyPattern, 1));
+
+        assertNotNull("Returned SSH key was null", keyProperty);
+    }
+
+    /**
+     * Test that SSH key property is generated from UsersMap.
+     * This function passes the keys in the Map as an Object[], which is how they appear from XMLRPC.
+     *
+     * @throws ReservationConverter.ReservationConverterException
+     */
+    public void testGenerateSSHPropertiesWithObjectKey() throws ReservationConverter.ReservationConverterException {
+        List<Map<String, ?>> users = getUsersMapWithObjects();
+
+        final Properties sshProperties = ReservationConverter.generateSSHProperties(users);
+
+        assertNotNull("Generated SSH Properties were null", sshProperties);
+
+        final String keyProperty = sshProperties.getProperty(String.format(ConfigurationProperties.ConfigSSHKeyPattern, 1));
+
+        assertNotNull("Returned SSH key was null", keyProperty);
+    }
+
+    /**
+     * Test that SSH key property is generated from UsersMap.
+     * This function passes the keys in the Map as a String object.
+     *
+     * @throws ReservationConverter.ReservationConverterException
+     */
+    public void testGenerateSSHPropertiesWithStringKey() throws ReservationConverter.ReservationConverterException {
+        List<Map<String, ?>> users = getUsersMapWithString();
+
+        final Properties sshProperties = ReservationConverter.generateSSHProperties(users);
+
+        assertNotNull("Generated SSH Properties were null", sshProperties);
+
+        final String keyProperty = sshProperties.getProperty(String.format(ConfigurationProperties.ConfigSSHKeyPattern, 1));
+
+        assertNotNull("Returned SSH key was null", keyProperty);
+    }
+
+    /**
+     * Similar to function in OrcaXmlrpcHandlerTest, this is a slightly modified version explicity for testing ReservationConverter
+     *
+     * Craft a userMap required by createSlice() and modifySlice().
+     *
+     * @return a UserMap with junk values
+     */
+    private static List<Map<String, ?>> getUsersMapWithObjects() {
+        List<Map<String, ?>> users = new ArrayList<>();
+        Map<String, Object> userEntry = new HashMap<>();
+        Object[] keys = {"ssh-rsa this is not a key"};
+        userEntry.put("keys", keys);
+        userEntry.put("login", "root");
+        userEntry.put("sudo", false);
+        users.add(userEntry);
+        return users;
+    }
+
+    /**
+     * Similar to function in OrcaXmlrpcHandlerTest, this is a slightly modified version explicity for testing ReservationConverter
+     *
+     * Craft a userMap required by createSlice() and modifySlice().
+     *
+     * @return a UserMap with junk values
+     */
+    private static List<Map<String, ?>> getUsersMapWithString() {
+        List<Map<String, ?>> users = new ArrayList<>();
+        Map<String, Object> userEntry = new HashMap<>();
+        String keys = "ssh-rsa this is not a key";
+        userEntry.put("keys", keys);
+        userEntry.put("login", "root");
+        userEntry.put("sudo", false);
+        users.add(userEntry);
+        return users;
+    }
 }

--- a/embed/src/main/java/orca/embed/cloudembed/VTRequestMapping.java
+++ b/embed/src/main/java/orca/embed/cloudembed/VTRequestMapping.java
@@ -3,6 +3,7 @@ package orca.embed.cloudembed;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
@@ -19,8 +20,6 @@ import orca.ndl.elements.NetworkElement;
 import com.hp.hpl.jena.ontology.Individual;
 import com.hp.hpl.jena.ontology.OntModel;
 import com.hp.hpl.jena.rdf.model.Resource;
-
-import edu.emory.mathcs.backport.java.util.Collections;
 
 public class VTRequestMapping extends RequestMapping {
 

--- a/embed/src/main/java/orca/embed/cloudembed/controller/MultiPointHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/MultiPointHandler.java
@@ -5,8 +5,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import orca.embed.cloudembed.IConnectionManager;
 import orca.embed.policyhelpers.DomainResourcePools;
@@ -197,9 +197,9 @@ public class MultiPointHandler extends InterDomainHandler implements LayerConsta
         return request;
     }
 
-    public ComputeElement createNE(OntModel m, Resource rs, LinkedList<NetworkElement> cg, NetworkConnection c_e) {
+    public ComputeElement createNE(OntModel m, Resource rs, List<NetworkElement> cg, NetworkConnection c_e) {
         OntResource ne_rs = null;
-        ComputeElement ne = (ComputeElement) cg.getFirst();
+        ComputeElement ne = (ComputeElement) cg.get(0);
         ComputeElement new_ne = null;
         String new_ne_url = null, new_ne_name = null;
         if (cg == null) {

--- a/embed/src/main/java/orca/embed/cloudembed/controller/UnboundRequestHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/UnboundRequestHandler.java
@@ -260,8 +260,10 @@ public class UnboundRequestHandler extends MultiPointHandler {
         getVMInfo(master_ce, rr);
         getVMInfo(slave_ce, rr);
 
-        final ComputeElement masterNE = createNE(requestModel, max_domain_rs, Collections.singletonList(master_ce), connection);
-        final ComputeElement slaveNE = createNE(requestModel, second_domain_rs, Collections.singletonList(slave_ce), connection);
+        final ComputeElement masterNE = createNE(requestModel, max_domain_rs, Collections.singletonList(master_ce),
+                connection);
+        final ComputeElement slaveNE = createNE(requestModel, second_domain_rs, Collections.singletonList(slave_ce),
+                connection);
 
         connection.setNe1(masterNE);
         connection.setNe2(slaveNE);

--- a/embed/src/main/java/orca/embed/cloudembed/controller/UnboundRequestHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/UnboundRequestHandler.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map.Entry;
+import java.util.Collections;
 
 import orca.embed.cloudembed.IConnectionManager;
 import orca.embed.policyhelpers.DomainResourcePools;
@@ -239,24 +240,31 @@ public class UnboundRequestHandler extends MultiPointHandler {
             master_ont.addProperty(NdlCommons.inDomainProperty, max_domain_rs);
         Individual slave_ont = requestModel.createIndividual(slave_str, NdlCommons.computeElementClass);
         slave_ont.addProperty(NdlCommons.inDomainProperty, second_domain_rs);
-        DomainResourceType dType = new DomainResourceType(rType, x1);
 
+        DomainResourceType dType = new DomainResourceType(rType, x1);
         dType.setDomainURL(max_domain);
         dType.setRank(10);
         ComputeElement master_ce = new ComputeElement(requestModel, master_ont);
         master_ce.setResourceType(dType);
+        master_ce.setGroup("MasterGroup");
+
         dType = new DomainResourceType(rType, x2);
         dType.setDomainURL(second_domain);
         dType.setRank(10);
         ComputeElement slave_ce = new ComputeElement(requestModel, slave_ont);
         slave_ce.setResourceType(dType);
+        slave_ce.setGroup("SlaveGroup");
+
         // add interfaces....
 
         getVMInfo(master_ce, rr);
         getVMInfo(slave_ce, rr);
 
-        connection.setNe1(master_ce);
-        connection.setNe2(slave_ce);
+        final ComputeElement masterNE = createNE(requestModel, max_domain_rs, Collections.singletonList(master_ce), connection);
+        final ComputeElement slaveNE = createNE(requestModel, second_domain_rs, Collections.singletonList(slave_ce), connection);
+
+        connection.setNe1(masterNE);
+        connection.setNe2(slaveNE);
 
         // process node dependency,image information, etc.
         // request.setRequest(connection);

--- a/embed/src/test/resources/orca/embed/41_mp_unbound_request.rdf
+++ b/embed/src/test/resources/orca/embed/41_mp_unbound_request.rdf
@@ -1,0 +1,154 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:request="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#Node0">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-Node0"/>
+    <topology:hasGUID>abb26698-cd76-4cc2-b199-4c4479c2e5c7</topology:hasGUID>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#Ubuntu+14.04"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ComputeElement"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-Node0"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup2"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup3"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup1"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup0"/>
+    <layer:atLayer rdf:resource="http://geni-orca.renci.org/owl/ethernet.owl#EthernetNetworkElement"/>
+    <topology:hasGUID>19ead910-da15-41d8-93dd-31a65f48135b</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#BroadcastConnection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup0-ip-172-16-100-50">
+    <ip4:netmask>255.255.255.0</ip4:netmask>
+    <layer:label_ID>172.16.100.50</layer:label_ID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/ip4.owl#IPAddress"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#Term">
+    <time:hasDurationDescription rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#TermDuration"/>
+    <rdf:type rdf:resource="http://www.w3.org/2006/time#Interval"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup1-ip-172-16-100-17">
+    <ip4:netmask>255.255.255.0</ip4:netmask>
+    <layer:label_ID>172.16.100.17</layer:label_ID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/ip4.owl#IPAddress"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup3-ip-172-16-100-34">
+    <ip4:netmask>255.255.255.0</ip4:netmask>
+    <layer:label_ID>172.16.100.34</layer:label_ID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/ip4.owl#IPAddress"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup2">
+    <ip4:localIPAddress rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup2-ip-172-16-100-1"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup2-ip-172-16-100-1">
+    <ip4:netmask>255.255.255.0</ip4:netmask>
+    <layer:label_ID>172.16.100.1</layer:label_ID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/ip4.owl#IPAddress"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup1">
+    <ip4:localIPAddress rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup1-ip-172-16-100-17"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#NodeGroup3">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup3"/>
+    <topology:hasGUID>a6f721e9-4270-498a-8a92-b31ad29c4a89</topology:hasGUID>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#Ubuntu+14.04"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <layer:numCE rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</layer:numCE>
+    <request-schema:groupName>NodeGroup3</request-schema:groupName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ServerCloud"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#NodeGroup0"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#NodeGroup3"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#NodeGroup1"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#Node0"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#NodeGroup2"/>
+    <request-schema:hasTerm rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#Term"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/request.owl#Reservation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup0">
+    <ip4:localIPAddress rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup0-ip-172-16-100-50"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#NodeGroup0">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup0"/>
+    <topology:hasGUID>e993eaa5-4093-427b-a93d-c1f669acd694</topology:hasGUID>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#Ubuntu+14.04"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <layer:numCE rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</layer:numCE>
+    <request-schema:groupName>NodeGroup0</request-schema:groupName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ServerCloud"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#NodeGroup2">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup2"/>
+    <topology:hasGUID>497be351-e305-4dcd-a885-e0afc6fb4dae</topology:hasGUID>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#Ubuntu+14.04"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <layer:numCE rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</layer:numCE>
+    <request-schema:groupName>NodeGroup2</request-schema:groupName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ServerCloud"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#NodeGroup1">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup1"/>
+    <topology:hasGUID>1f44b684-c3e8-45d7-b4e8-c11c31a3b00f</topology:hasGUID>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#Ubuntu+14.04"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <layer:numCE rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</layer:numCE>
+    <request-schema:groupName>NodeGroup1</request-schema:groupName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ServerCloud"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup3">
+    <ip4:localIPAddress rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-NodeGroup3-ip-172-16-100-34"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#Ubuntu+14.04">
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ubuntu 14.04</topology:hasName>
+    <topology:hasURL>http://geni-images.renci.org/images/standard/ubuntu/ub1404-v1.0.4.xml</topology:hasURL>
+    <topology:hasGUID>9394ca154aa35eb55e604503ae7943ddaecc6ca5</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#DiskImage"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#TermDuration">
+    <time:days rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1</time:days>
+    <rdf:type rdf:resource="http://www.w3.org/2006/time#DurationDescription"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-Node0-ip-172-16-100-33">
+    <ip4:netmask>255.255.255.0</ip4:netmask>
+    <layer:label_ID>172.16.100.33</layer:label_ID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/ip4.owl#IPAddress"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-Node0">
+    <ip4:localIPAddress rdf:resource="http://geni-orca.renci.org/owl/daf3d61f-488c-4c82-8573-cb3a1d7ccfc8#VLAN0-Node0-ip-172-16-100-33"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/embed/src/test/resources/orca/embed/41_single_large_nodegroup_unbound_request.rdf
+++ b/embed/src/test/resources/orca/embed/41_single_large_nodegroup_unbound_request.rdf
@@ -1,0 +1,67 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:request="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#Centos+6.7+v1.1.0">
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Centos 6.7 v1.1.0</topology:hasName>
+    <topology:hasURL>http://geni-images.renci.org/images/standard/centos/centos6.7-v1.1.0/centos6.7-v1.1.0.xml</topology:hasURL>
+    <topology:hasGUID>0c22c525b8a4f0f480f17587557b57a7a111d198</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#DiskImage"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#VLAN0-NodeGroup0">
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#VLAN0"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#NodeGroup0"/>
+    <request-schema:hasTerm rdf:resource="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#Term"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/request.owl#Reservation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#VLAN0">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#VLAN0-NodeGroup0"/>
+    <layer:atLayer rdf:resource="http://geni-orca.renci.org/owl/ethernet.owl#EthernetNetworkElement"/>
+    <layer:bandwidth rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10000000</layer:bandwidth>
+    <topology:hasGUID>20505a55-32aa-4f4e-aa76-8af763de8410</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#BroadcastConnection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#Term">
+    <time:hasDurationDescription rdf:resource="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#TermDuration"/>
+    <rdf:type rdf:resource="http://www.w3.org/2006/time#Interval"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#TermDuration">
+    <time:days rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1</time:days>
+    <rdf:type rdf:resource="http://www.w3.org/2006/time#DurationDescription"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#NodeGroup0">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#VLAN0-NodeGroup0"/>
+    <topology:hasGUID>cb84796f-fb25-44fb-b035-bc795a821e38</topology:hasGUID>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/9d95f97a-a050-4311-bec3-f577a1d9c5d4#Centos+6.7+v1.1.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOSmall"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <layer:numCE rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">128</layer:numCE>
+    <request-schema:groupName>NodeGroup0</request-schema:groupName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ServerCloud"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/handlers/ec2/resources/handlers/ec2/handler.xml
+++ b/handlers/ec2/resources/handlers/ec2/handler.xml
@@ -431,25 +431,25 @@
                                                 <var name="iface.net.vlan" unset="true"></var> 
                                                 <var name="iface.mac" unset="true"></var> 
                                                 <echo>
-                                                    iface @{iface}
+                                                     iface @{iface} 
                                                 </echo> 
                                                 <propertyregex property="iface.net.name" input="@{iface}" regexp="(.*)\..*\..*" replace="\1" casesensitive="false" /> 
                                                 <propertyregex property="iface.net.vlan" input="@{iface}" regexp=".*\.(.*)\..*" replace="\1" casesensitive="false" /> 
                                                 <propertyregex property="iface.mac" input="@{iface}" regexp=".*\..*\.(.*)" replace="\1" casesensitive="false" /> 
                                                 <echo>
-                                                    quantum.tenant.id ${quantum.tenant.id}
+                                                     quantum.tenant.id ${quantum.tenant.id} 
                                                 </echo> 
                                                 <echo>
-                                                    shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance}
+                                                     shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance} 
                                                 </echo> 
                                                 <echo>
-                                                    iface.mac ${iface.mac}
+                                                     iface.mac ${iface.mac} 
                                                 </echo> 
                                                 <echo>
-                                                    iface.net.vlan ${iface.net.vlan}
+                                                     iface.net.vlan ${iface.net.vlan} 
                                                 </echo> 
                                                 <echo>
-                                                    iface.net.name ${iface.net.name}
+                                                     iface.net.name ${iface.net.name} 
                                                 </echo> 
                                                 <var name="code" unset="true"></var> 
                                                 <var name="add.iface.output" unset="true"></var> 
@@ -478,10 +478,10 @@
                                                     <env key="QUANTUM_NET_VLAN" value="${iface.net.vlan}" /> 
                                                 </exec> 
                                                 <echo>
-                                                    result code: ${code}
+                                                     result code: ${code} 
                                                 </echo> 
                                                 <echo>
-                                                    output: ${add.iface.output}
+                                                     output: ${add.iface.output} 
                                                 </echo> 
                                                 <if> 
                                                     <isset property="instance.quantum.ifaces" /> 
@@ -499,7 +499,7 @@
                                         </for> 
                                         <property name="shirako.save.unit.quantum.ifaces" value="${instance.quantum.ifaces}" /> 
                                         <echo>
-                                            shirako.save.unit.quantum.ifaces: ${shirako.save.unit.quantum.ifaces}
+                                             shirako.save.unit.quantum.ifaces: ${shirako.save.unit.quantum.ifaces} 
                                         </echo> 
                                     </then> 
                                 </if> 
@@ -688,28 +688,28 @@
                     <var name="iface.net.vlan" unset="true"></var> 
                     <var name="iface.mac" unset="true"></var> 
                     <echo>
-                        iface @{iface}
+                         iface @{iface} 
                     </echo> 
                     <propertyregex property="iface.net.name" input="@{iface}" regexp="(.*)\..*\..*" replace="\1" casesensitive="false" /> 
                     <propertyregex property="iface.net.vlan" input="@{iface}" regexp=".*\.(.*)\..*" replace="\1" casesensitive="false" /> 
                     <propertyregex property="iface.mac" input="@{iface}" regexp=".*\..*\.(.*)" replace="\1" casesensitive="false" /> 
                     <echo>
-                        quantum.tenant.id ${quantum.tenant.id}
+                         quantum.tenant.id ${quantum.tenant.id} 
                     </echo> 
                     <echo>
-                        shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance}
+                         shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance} 
                     </echo> 
                     <echo>
-                        iface.mac ${iface.mac}
+                         iface.mac ${iface.mac} 
                     </echo> 
                     <echo>
-                        iface.net.vlan ${iface.net.vlan}
+                         iface.net.vlan ${iface.net.vlan} 
                     </echo> 
                     <echo>
-                        iface.net.name ${iface.net.name}
+                         iface.net.name ${iface.net.name} 
                     </echo> 
                     <echo>
-                        unit.ec2.instance ${unit.ec2.instance}
+                         unit.ec2.instance ${unit.ec2.instance} 
                     </echo> 
                     <echo message="Running under emulation...exiting" /> 
                     <property name="shirako.target.code" value="0" /> 
@@ -794,10 +794,10 @@
                         <env key="QUANTUM_NET_VLAN" value="${modify.@{seqnum}.vlan.tag}" /> 
                     </exec> 
                     <echo>
-                        result code: ${code}
+                         result code: ${code} 
                     </echo> 
                     <echo>
-                        output: ${add.iface.output}
+                         output: ${add.iface.output} 
                     </echo> 
                     <!-- add properties to userdata file --> 
                     <echo message="About to update userdata file: " /> 
@@ -817,14 +817,14 @@
                     <property name="target.ip" value="${modify.@{seqnum}.target.ip}" /> 
                     <if> 
                         <and> 
-                            <not>
-                                <contains string="${storage_type}" substring="modify" />
+                            <not> 
+                                <contains string="${storage_type}" substring="modify" /> 
                             </not> 
-                            <not>
-                                <contains string="${port}" substring="modify" />
+                            <not> 
+                                <contains string="${port}" substring="modify" /> 
                             </not> 
-                            <not>
-                                <contains string="${target.ip}" substring="modify" />
+                            <not> 
+                                <contains string="${target.ip}" substring="modify" /> 
                             </not> 
                         </and> 
                         <then> 
@@ -999,28 +999,28 @@
                     <var name="iface.net.vlan" unset="true"></var> 
                     <var name="iface.mac" unset="true"></var> 
                     <echo>
-                        iface @{iface}
+                         iface @{iface} 
                     </echo> 
                     <propertyregex property="iface.net.name" input="@{iface}" regexp="(.*)\..*\..*" replace="\1" casesensitive="false" /> 
                     <propertyregex property="iface.net.vlan" input="@{iface}" regexp=".*\.(.*)\..*" replace="\1" casesensitive="false" /> 
                     <propertyregex property="iface.mac" input="@{iface}" regexp=".*\..*\.(.*)" replace="\1" casesensitive="false" /> 
                     <echo>
-                        quantum.tenant.id ${quantum.tenant.id}
+                         quantum.tenant.id ${quantum.tenant.id} 
                     </echo> 
                     <echo>
-                        shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance}
+                         shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance} 
                     </echo> 
                     <echo>
-                        iface.mac ${iface.mac}
+                         iface.mac ${iface.mac} 
                     </echo> 
                     <echo>
-                        iface.net.vlan ${iface.net.vlan}
+                         iface.net.vlan ${iface.net.vlan} 
                     </echo> 
                     <echo>
-                        iface.net.name ${iface.net.name}
+                         iface.net.name ${iface.net.name} 
                     </echo> 
                     <echo>
-                        unit.ec2.instance ${unit.ec2.instance}
+                         unit.ec2.instance ${unit.ec2.instance} 
                     </echo> 
                     <echo message="Running under emulation...exiting" /> 
                     <property name="shirako.target.code" value="0" /> 
@@ -1076,10 +1076,10 @@
                         <env key="QUANTUM_NET_VLAN" value="${modify.@{seqnum}.vlan.tag}" /> 
                     </exec> 
                     <echo>
-                        result code: ${code}
+                         result code: ${code} 
                     </echo> 
                     <echo>
-                        output: ${add.iface.output}
+                         output: ${add.iface.output} 
                     </echo> 
                     <!-- add property to userdata file TODO: add actual config values --> 
                     <ec2.removeproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}" section="interfaces" key="${modify.@{seqnum}.mac}" /> 

--- a/ndl/src/main/java/orca/ndl/elements/ComputeElement.java
+++ b/ndl/src/main/java/orca/ndl/elements/ComputeElement.java
@@ -3,6 +3,7 @@ package orca.ndl.elements;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -50,7 +51,7 @@ public class ComputeElement extends NetworkElement {
     protected boolean isSplittable;
 
     @NotPersistent
-    protected LinkedList<NetworkElement> ceGroup;
+    protected List<NetworkElement> ceGroup;
 
     @NotPersistent
     protected Set<NetworkElement> dependencies = new HashSet<NetworkElement>();
@@ -380,11 +381,11 @@ public class ComputeElement extends NetworkElement {
         CHAP_Password = cHAP_Password;
     }
 
-    public LinkedList<NetworkElement> getCeGroup() {
+    public List<NetworkElement> getCeGroup() {
         return ceGroup;
     }
 
-    public void setCeGroup(LinkedList<NetworkElement> cg) {
+    public void setCeGroup(List<NetworkElement> cg) {
         this.ceGroup = cg;
     }
 

--- a/network/src/main/java/orca/network/InterCloudHandler.java
+++ b/network/src/main/java/orca/network/InterCloudHandler.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Hashtable;
 import java.util.LinkedList;
 import java.util.Random;
@@ -36,8 +37,6 @@ import com.hp.hpl.jena.rdf.model.ModelFactory;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.reasoner.Reasoner;
 import com.hp.hpl.jena.util.FileManager;
-
-import edu.emory.mathcs.backport.java.util.Collections;
 
 public class InterCloudHandler extends InterDomainHandler {
 

--- a/network/src/main/java/orca/network/SliceRequest.java
+++ b/network/src/main/java/orca/network/SliceRequest.java
@@ -7,6 +7,7 @@ import java.net.UnknownHostException;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.Iterator;
@@ -36,8 +37,6 @@ import com.hp.hpl.jena.query.ResultSet;
 import com.hp.hpl.jena.rdf.model.*;
 import com.hp.hpl.jena.util.FileManager;
 import com.hp.hpl.jena.vocabulary.XSD;
-
-import edu.emory.mathcs.backport.java.util.Collections;
 
 import orca.ndl.*;
 import orca.ndl.elements.Device;

--- a/tools/build/pom.xml
+++ b/tools/build/pom.xml
@@ -1,15 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> 
     <modelVersion>
          4.0.0 
-    </modelVersion>
+    </modelVersion> 
     <groupId>
-        orca.tools
-    </groupId>
+         orca.tools 
+    </groupId> 
     <artifactId>
-         build
+         build 
     </artifactId> 
     <packaging>
-         jar
+         jar 
     </packaging> 
     <parent> 
         <groupId>

--- a/tools/cmdline/pom.xml
+++ b/tools/cmdline/pom.xml
@@ -41,21 +41,21 @@
             <version>
                  ${project.version} 
             </version> 
-        </dependency>
-        <dependency>
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca
-            </groupId>
+                 orca 
+            </groupId> 
             <artifactId>
-                core
-            </artifactId>
+                 core 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
+                 pom 
+            </type> 
+        </dependency> 
         <dependency> 
             <groupId>
                  orca.controllers 
@@ -69,60 +69,60 @@
             <type>
                  pom 
             </type> 
-        </dependency>
-        <dependency>
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca
-            </groupId>
+                 orca 
+            </groupId> 
             <artifactId>
-                nodeagent
-            </artifactId>
+                 nodeagent 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <classifier>
-                client
-            </classifier>
-        </dependency>
-        <dependency>
+                 client 
+            </classifier> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.plugins
-            </groupId>
+                 orca.plugins 
+            </groupId> 
             <artifactId>
-                ben
-            </artifactId>
+                 ben 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
-        </dependency>
-        <dependency>
+                 ${project.version} 
+            </version> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.dependencies
-            </groupId>
+                 orca.dependencies 
+            </groupId> 
             <artifactId>
-                ant-contrib
-            </artifactId>
+                 ant-contrib 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.dependencies
-            </groupId>
+                 orca.dependencies 
+            </groupId> 
             <artifactId>
-                handler-dependencies
-            </artifactId>
+                 handler-dependencies 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
+                 pom 
+            </type> 
+        </dependency> 
     </dependencies> 
     <build> 
         <plugins> 

--- a/tools/dependencies/handler-dependencies/pom.xml
+++ b/tools/dependencies/handler-dependencies/pom.xml
@@ -6,17 +6,17 @@
          orca.dependencies 
     </groupId> 
     <artifactId>
-         handler-dependencies
+         handler-dependencies 
     </artifactId> 
     <packaging>
          pom 
     </packaging> 
     <name>
-         Orca Dependencies Handlers
+         Orca Dependencies Handlers 
     </name> 
     <description>
-         A grouping of all of the 'handlers' in a single place, for dependency management.
-    </description>
+         A grouping of all of the 'handlers' in a single place, for dependency management. 
+    </description> 
     <parent> 
         <groupId>
              orca 
@@ -28,160 +28,160 @@
              5.2.2-SNAPSHOT 
         </version> 
     </parent> 
-    <dependencies>
-        <dependency>
+    <dependencies> 
+        <dependency> 
             <groupId>
-                orca.core
-            </groupId>
+                 orca.core 
+            </groupId> 
             <artifactId>
-                handlers
-            </artifactId>
+                 handlers 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.handlers
-            </groupId>
+                 orca.handlers 
+            </groupId> 
             <artifactId>
-                ec2
-            </artifactId>
+                 ec2 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.handlers
-            </groupId>
+                 orca.handlers 
+            </groupId> 
             <artifactId>
-                xcat
-            </artifactId>
+                 xcat 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.handlers
-            </groupId>
+                 orca.handlers 
+            </groupId> 
             <artifactId>
-                nodeagent2
-            </artifactId>
+                 nodeagent2 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.handlers
-            </groupId>
+                 orca.handlers 
+            </groupId> 
             <artifactId>
-                ibm_ds
-            </artifactId>
+                 ibm_ds 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.handlers
-            </groupId>
+                 orca.handlers 
+            </groupId> 
             <artifactId>
-                slurm
-            </artifactId>
+                 slurm 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.handlers
-            </groupId>
+                 orca.handlers 
+            </groupId> 
             <artifactId>
-                storage_service
-            </artifactId>
+                 storage_service 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.handlers.network
-            </groupId>
+                 orca.handlers.network 
+            </groupId> 
             <artifactId>
-                nsi
-            </artifactId>
+                 nsi 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.handlers.network
-            </groupId>
+                 orca.handlers.network 
+            </groupId> 
             <artifactId>
-                oscars
-            </artifactId>
+                 oscars 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.handlers.network
-            </groupId>
+                 orca.handlers.network 
+            </groupId> 
             <artifactId>
-                oess
-            </artifactId>
+                 oess 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-        <dependency>
+                 pom 
+            </type> 
+        </dependency> 
+        <dependency> 
             <groupId>
-                orca.handlers.network
-            </groupId>
+                 orca.handlers.network 
+            </groupId> 
             <artifactId>
-                providers
-            </artifactId>
+                 providers 
+            </artifactId> 
             <version>
-                ${project.version}
-            </version>
+                 ${project.version} 
+            </version> 
             <type>
-                pom
-            </type>
-        </dependency>
-    </dependencies>
+                 pom 
+            </type> 
+        </dependency> 
+    </dependencies> 
 </project>

--- a/tools/dependencies/pom.xml
+++ b/tools/dependencies/pom.xml
@@ -43,13 +43,13 @@
         </module> 
         <module>
              axis2 
-        </module>
+        </module> 
         <module>
-            jaxb
-        </module>
+             jaxb 
+        </module> 
         <module>
-            handler-dependencies
-        </module>
+             handler-dependencies 
+        </module> 
     </modules> 
     <build> 
         <plugins> 


### PR DESCRIPTION
Fixes #41, by ensuring that when the "splitting" occurs, that the NodeGroups created have the requisite group information.

I was able to reuse the createNE function from MultiPointHandler.java for this, although I did need to slightly change the over-restrictive method signature from LinkedList to List.  

In doing so, I noticed that we were still using edu.emory.mathcs.backport libraries in several places, even though we are using Java that is new enough to directly use the Java libraries.  

I removed all instances of the `backport` library usage, which actually broke SSH key handling when Flukes talks to Orca, so that needed to be fixed.  Additional tests were added to ReservationConverter to protect against this in the future.

Tests are currently running Jenkins: [41_unbound_splitting #2](https://ci.exogeni.net:8443/job/ORCA5/branch/41_unbound_splitting/2/)