### PR TITLE
176 formatter xml doctype revert

### DIFF
--- a/boot/ant/build.xml
+++ b/boot/ant/build.xml
@@ -1,31 +1,44 @@
-<!DOCTYPE project>
- ]&gt; 
-<project name="orca.util" default="help" basedir="." xmlns:artifact="urn:maven-artifact-ant">
-     &amp;deps; 
-    <target name="help"> 
-        <echo>
-             copy.local - copies template configuration files locally orca.boot.beans - generates orca.boot.beans 
-        </echo> 
-    </target> 
-    <target name="copy.local" description="copies configuration templates into the local configuration directory"> 
-        <mkdir dir="${local.dir}" /> 
-        <copy todir="${local.dir}"> 
-            <fileset dir="${config.dir}"> 
-                <include name="**/*" /> 
-            </fileset> 
-        </copy> 
-    </target> 
-    <target name="orca.boot.beans" description="generates orca.boot.beans"> 
-        <!-- prepare the output directory --> 
-        <delete dir="${tmp.dir}" /> 
-        <mkdir dir="${tmp.dir}" /> 
-        <xjc schema="resources/orca.boot.beans.schema.xsd" target="${tmp.dir}" package="orca.boot.beans" /> 
-        <!-- copy the generated beans to their destination --> 
-        <copy todir="src/main/java/orca/boot/beans" overwrite="true"> 
-            <fileset dir="${tmp.dir}/orca/boot/beans"> 
-                <include name="**/*" /> 
-            </fileset> 
-        </copy> 
-        <delete dir="${tmp.dir}" /> 
-    </target> 
+<!DOCTYPE project [
+<!ENTITY deps SYSTEM "deps.xml">
+]>
+<project name="orca.util"
+	default="help"
+	basedir="."
+	xmlns:artifact="urn:maven-artifact-ant">
+
+	&deps;
+
+	<target name="help">
+		<echo>
+			copy.local - copies template configuration files locally
+			orca.boot.beans - generates orca.boot.beans
+		</echo>
+	</target>
+
+	<target name="copy.local"
+		description="copies configuration templates into the local configuration directory">
+		<mkdir dir="${local.dir}" />
+		<copy todir="${local.dir}">
+			<fileset dir="${config.dir}">
+				<include name="**/*" />
+			</fileset>
+		</copy>
+	</target>
+
+	<target name="orca.boot.beans" description="generates orca.boot.beans">
+		<!-- prepare the output directory -->
+		<delete dir="${tmp.dir}" />
+		<mkdir dir="${tmp.dir}" />
+		<xjc schema="resources/orca.boot.beans.schema.xsd"
+			target="${tmp.dir}"
+			package="orca.boot.beans" />
+		<!-- copy the generated beans to their destination -->
+		<copy todir="src/main/java/orca/boot/beans" overwrite="true">
+			<fileset dir="${tmp.dir}/orca/boot/beans">
+				<include name="**/*" />
+			</fileset>
+		</copy>
+		<delete dir="${tmp.dir}" />
+	</target>
+
 </project>

--- a/controllers/openflow/build.xml
+++ b/controllers/openflow/build.xml
@@ -1,31 +1,39 @@
-<!DOCTYPE project>
- ]&gt; 
-<project name="orca.controllers.openflow" default="help" basedir="." xmlns:artifact="urn:maven-artifact-ant">
-     &amp;deps; 
-    <target name="help"> 
-        <echo>
-             Build file options: oftest: invokes the OpenFlow test 
-        </echo> 
-    </target> 
-    <target name="oftest"> 
-        <if> 
-            <isset property="config" /> 
-            <then> 
-                <delete dir="${cmdline.home}/logs" /> 
-                <delete dir="${cmdline.home}/log" /> 
-                <echo message="running ben unit test (real mode)..." /> 
-                <echo message="configuration file: ${config}" /> 
-                <java classname="orca.controllers.openflow.OpenFlowTest" Fork="Yes" failonerror="true" dir="../../run"> 
-                    <classpath refid="run.classpath" /> 
-                    <arg value="${config}" /> 
-                    <arg value="do.not.recover=true" /> 
-                    <arg value="manual=false" /> 
-                    <arg value="clean.machines=true" /> 
-                </java> 
-            </then> 
-            <else> 
-                <echo message="usage: -Dhandler=&lt;path to handler> -Dtarget=&lt;target name>" /> 
-            </else> 
-        </if> 
-    </target> 
+<!DOCTYPE project [
+	<!ENTITY deps SYSTEM "ant/deps.xml">
+]>
+<project name="orca.controllers.openflow"
+		default="help"
+		basedir="."
+		xmlns:artifact="urn:maven-artifact-ant">
+
+	&deps;
+
+	<target name="help">
+		<echo>
+			Build file options:
+			oftest: invokes the OpenFlow test            
+		</echo>
+	</target>
+
+	<target name="oftest">
+		<if>
+			<isset property="config" />
+			<then>
+				<delete dir="${cmdline.home}/logs" />
+				<delete dir="${cmdline.home}/log" />
+				<echo message="running ben unit test (real mode)..." />
+				<echo message="configuration file: ${config}" />
+				<java classname="orca.controllers.openflow.OpenFlowTest" Fork="Yes" failonerror="true" dir="../../run">
+					<classpath refid="run.classpath" />
+					<arg value="${config}" />
+					<arg value="do.not.recover=true" />
+					<arg value="manual=false" />
+					<arg value="clean.machines=true" />
+				</java>
+			</then>
+			<else>
+				<echo message="usage: -Dhandler=&lt;path to handler&gt; -Dtarget=&lt;target name&gt;" />
+			</else>
+		</if>
+	</target>
 </project>

--- a/controllers/openflow/resources/handlers/network/openflow/handler.xml
+++ b/controllers/openflow/resources/handlers/network/openflow/handler.xml
@@ -1,16 +1,34 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY openflowtasks SYSTEM "openflow.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY openflowtasks SYSTEM "openflow.tasks.xml">
+]>
+
 <project name="openflow" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;openflowtasks; 
-    <!--<property file="test.properties" />--> 
-    <target name="join" depends="resolve.configuration,openflow.load.tasks"> 
-        <!-- get the credentials from a file, if needed --> 
-        <echo message="[OpenFlow Handler] Join... Slice ID: ${unit.of.slice}" /> 
-        <create.slice user="${flowvisor.user}" password="${flowvisor.passwd}" deviceAddress="${flowvisor.host}" port="${flowvisor.port}" slice.name="${flowvisor.slice.name}" slice.passwd="${flowvisor.slice.passwd}" slice.ctrlUrl="${flowvisor.slice.controller}" slice.email="${flowvisor.slice.email}" /> 
-        <!--<add.flowspace
+
+	&paths;
+	&core;    
+	&drivertasks;
+	&openflowtasks;
+
+	<!--<property file="test.properties" />-->
+
+	<target name="join" depends="resolve.configuration,openflow.load.tasks">
+                <!-- get the credentials from a file, if needed -->
+                <echo message="[OpenFlow Handler] Join... Slice ID: ${unit.of.slice}" />
+
+                <create.slice
+                  user="${flowvisor.user}"
+                  password="${flowvisor.passwd}"
+                  deviceAddress="${flowvisor.host}"
+                  port="${flowvisor.port}"
+                  slice.name="${flowvisor.slice.name}"
+                  slice.passwd="${flowvisor.slice.passwd}"
+                  slice.ctrlUrl="${flowvisor.slice.controller}"
+                  slice.email="${flowvisor.slice.email}"
+                />
+                <!--<add.flowspace
                   user="${flowvisor.user}"
                   password="${flowvisor.passwd}"
                   deviceAddress="${flowvisor.host}"
@@ -18,10 +36,19 @@
                   slice.name="${flowvisor.slice.name}"
                   flowspace.src.ip="${flowvisor.slice.flowspace.src.ip}"
                   flowspace.dst.ip="${flowvisor.slice.flowspace.dst.ip}"
-                />--> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,openflow.load.tasks"> 
-        <echo message="[OpenFlow Handler] Leave...Slice ID: ${unit.of.slice}" /> 
-        <delete.slice user="${flowvisor.user}" password="${flowvisor.passwd}" deviceAddress="${flowvisor.host}" port="${flowvisor.port}" slice.name="${flowvisor.slice.name}" /> 
-    </target> 
+                />-->
+        </target>
+
+
+	<target name="leave" depends="resolve.configuration,openflow.load.tasks">
+		<echo message="[OpenFlow Handler] Leave...Slice ID: ${unit.of.slice}" />
+
+		<delete.slice
+                  user="${flowvisor.user}"
+                  password="${flowvisor.passwd}"
+                  deviceAddress="${flowvisor.host}"
+                  port="${flowvisor.port}"
+                  slice.name="${flowvisor.slice.name}"
+                />
+	</target>
 </project>

--- a/controllers/openflow/resources/web/style.css
+++ b/controllers/openflow/resources/web/style.css
@@ -1,23 +1,47 @@
-.mainTable { }
-.mainTableCell {
-    padding-right: 5px;
-    padding-left: 20px
+
+.mainTable{
+//        border: 1px solid #001A57;
+//        padding-left: 5px;
+        padding-top: 20px;
+}        
+
+.mainTableCell{
+        padding-right: 5px;
+        padding-left: 20px;
 }
-.masterTable { }
-.workerTable { }
-.batchMenu {
-    border-left: 1px solid #cc3300;
-    padding-left: 20px
+
+.masterTable{
+//        padding-left: 10px;
+        padding-bottom: 10px;
+//        border: 1px solid #CC3300;
+          padding-right: 20px;  
 }
-.batchSummary {
-    border-right: 1px solid #cc3300;
-    padding-right: 20px
+
+.workerTable{
+//        padding-left: 10px;
+        padding-bottom: 10px;
+//        border: 1px solid #CC3300;
+          padding-right: 20px;  
 }
-.batchSummaryCell {
-    color: #001a57;
-    padding-bottom: 10px
+
+
+.batchMenu{
+      border-left: 1px solid #CC3300;
+      padding-left: 20px;
 }
-.menuTable {
-    color: #cc3300;
-    padding-bottom: 10px
+
+.batchSummary{
+      border-right: 1px solid #CC3300;
+      padding-right: 20px;
 }
+
+.batchSummaryCell{
+      color: #001A57;
+      padding-bottom: 10px; 
+}
+
+.menuTable{
+      color: #CC3300;
+      padding-bottom: 10px; 
+}
+  

--- a/handlers/ec2/ant/build.xml
+++ b/handlers/ec2/ant/build.xml
@@ -1,52 +1,76 @@
-<!DOCTYPE project>
- ]&gt; 
-<project name="orca.shirako" default="help" basedir="." xmlns:artifact="antlib:org.apache.maven.artifact.ant">
-     &amp;deps; 
-    <target name="help"> 
-        <echo>
-             proxies.soap.axis2.beans - generates orca.shirako.proxies.soapaxis2.beans (Axis 2.x) proxies.soap.axis2.services - generates orca.shirako.proxies.soapaxis2.services (Axis 2.x) manage.extensions.beans manage.extensions.api.beans 
-        </echo> 
-    </target> 
-    <!-- Begin AXIS 2.x support --> 
-    <!--
+<!DOCTYPE project [
+	<!ENTITY deps SYSTEM "deps.xml">
+]>
+<project name="orca.shirako"
+		default="help"
+		basedir="."
+	xmlns:artifact="antlib:org.apache.maven.artifact.ant">
+
+	&deps;
+
+	<target name="help">
+		<echo>
+			proxies.soap.axis2.beans - generates orca.shirako.proxies.soapaxis2.beans (Axis 2.x)
+			proxies.soap.axis2.services - generates orca.shirako.proxies.soapaxis2.services (Axis 2.x)
+			manage.extensions.beans
+		    manage.extensions.api.beans
+		</echo>
+	</target>
+
+
+	<!-- Begin AXIS 2.x support -->
+
+	<!--
 	  Helper target to invoke wsdl2java with the right parameters.
 	  Parameters: 
 	  ${wsdl.file} - path to the wsdl to be compiled
-  --> 
-    <target name="proxies.soap.axis2.helper" description="helper target to invoke wsdl2java with the right parameters"> 
-        <java classname="org.apache.axis2.wsdl.WSDL2Java" fork="true" classpath="${runtime_classpath}"> 
-            <arg value="-d" /> 
-            <arg value="adb" /> 
-            <arg value="-uri" /> 
-            <arg file="${wsdl.file}" /> 
-            <arg value="-ss" /> 
-            <arg value="-g" /> 
-            <!--
+  -->
+	<target name="proxies.soap.axis2.helper"
+		description="helper target to invoke wsdl2java with the right parameters">
+		<java classname="org.apache.axis2.wsdl.WSDL2Java" fork="true" classpath="${runtime_classpath}">
+			<arg value="-d" />
+			<arg value="adb" />
+			<arg value="-uri" />
+			<arg file="${wsdl.file}" />
+			<arg value="-ss" />
+			<arg value="-g" />
+<!--
 			<arg value="-sd" />
---> 
-            <arg value="-o" /> 
-            <arg file="${tmp.dir}" /> 
-            <arg value="-p" /> 
-            <arg value="${pkg.name}" /> 
-            <arg value="-ns2p" /> 
-            <arg value="http://imageproxy.orca=orca.handlers.ec2.tasks.imgproxy" /> 
-        </java> 
-    </target> 
-    <!--
+-->
+			<arg value="-o" />
+			<arg file="${tmp.dir}" />
+			<arg value="-p" />
+			<arg value="${pkg.name}" />
+			<arg value="-ns2p" />
+			<arg value="http://imageproxy.orca=orca.handlers.ec2.tasks.imgproxy" />		    
+		</java>
+	</target>
+
+	<!--
 	  Regenerates the soap.services package:
-        --> 
-    <target name="imageproxy.axis2.service" description="recreate SOAP handlers/stubs for image proxy"> 
-        <delete dir="${tmp.dir}" /> 
-        <mkdir dir="${tmp.dir}" /> 
-        <!-- compile the wsdl and copy the deployment descriptors --> 
-        <!-- actor --> 
-        <antcall target="proxies.soap.axis2.helper"> 
-            <param name="wsdl.file" value="src/main/axis2/imageproxy.wsdl" /> 
-            <param name="pkg.name" value="orca.handlers.ec2.tasks.imgproxy" /> 
-        </antcall> 
-        <!-- Put all code files at the right place --> 
-        <copy todir="src/main/java/orca/handlers/ec2/tasks/imgproxy" overwrite="true"> 
-            <fileset dir="${tmp.dir}/src/orca/handlers/ec2/tasks/imgproxy" includes="**/*.java" /> 
-        </copy> 
-    </target> 
+        -->
+	<target name="imageproxy.axis2.service" description="recreate SOAP handlers/stubs for image proxy">
+		<delete dir="${tmp.dir}" />
+		<mkdir dir="${tmp.dir}" />
+
+		<!-- compile the wsdl and copy the deployment descriptors -->
+
+		<!-- actor -->
+		<antcall target="proxies.soap.axis2.helper">
+			<param name="wsdl.file"
+					value="src/main/axis2/imageproxy.wsdl" />
+			<param name="pkg.name"
+					value="orca.handlers.ec2.tasks.imgproxy" />
+		</antcall>
+
+		<!-- Put all code files at the right place -->
+		<copy todir="src/main/java/orca/handlers/ec2/tasks/imgproxy" overwrite="true">
+			<fileset dir="${tmp.dir}/src/orca/handlers/ec2/tasks/imgproxy"
+					includes="**/*.java" 
+				/>
+		</copy>
+
+	</target>
+
+
 </project>

--- a/handlers/ec2/resources/handlers/ec2/handler.xml
+++ b/handlers/ec2/resources/handlers/ec2/handler.xml
@@ -1,1243 +1,1309 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+]>
 <project name="ec2" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; 
-    <!--<property file="test.properties" />--> 
-    <target name="join" depends="resolve.configuration"> 
-        <taskdef resource="orca/handlers/ec2/ec2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy HH:mm:ss z" /> 
-        </tstamp> 
-        <echo message="EC2 HANDLER: JOIN on ${start.TIME}" /> 
-        <!-- see ec2.site.sample.properties and wiki for description
+
+  &paths;
+  &core;
+  &drivertasks;	
+  
+  <!--<property file="test.properties" />-->
+
+	<target name="join" depends="resolve.configuration">
+		<taskdef resource="orca/handlers/ec2/ec2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy HH:mm:ss z" />
+		</tstamp>
+		<echo message="EC2 HANDLER: JOIN on ${start.TIME}" />
+		<!-- see ec2.site.sample.properties and wiki for description
 	 of static properties that can be specified in ec2.site.properties
-	--> 
-        <if> 
-            <isset property="ec2.site.properties" /> 
-            <then> 
-                <property file="${ec2.site.properties}" /> 
-            </then> 
-        </if> 
-        <var name="code" unset="true"></var> 
-        <var name="message" unset="true"></var> 
-        <echo message="Cloud Type: ${cloud.type} " /> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <!-- create the NEUCA INI file --> 
-                <tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" /> 
-                <echo message="EMULATION: neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" /> 
-                <ec2.generate.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" outputproperty="iface.list" /> 
-                <echo message="EMULATION: iface.list = ${iface.list}" /> 
-                <loadfile property="neuca.ini" srcFile="${neuca.ini.file}" /> 
-                <echo message="EMULATION: neuca.ini: ${neuca.ini}" /> 
-                <echo message="EMULATION: creating Euca instance ${unit.hostname.url} using emi ${ec2.ami.name} ...(may take some time)" /> 
-                <var name="create.instance.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <echo message="${ec2.scripts}/${cloud.type}-start " /> 
-                <echo message="UNIT_HOSTNAME_URL=${unit.hostname.url}" /> 
-                <echo message="EC2_HOME=${ec2.home}" /> 
-                <echo message="EUCA_KEY_DIR=${ec2.keys}" /> 
-                <echo message="EC2_LOG_DIR=${ec2.log.dir}" /> 
-                <echo message="EC2_LOG_FILE=${ec2.log.file}" /> 
-                <echo message="EC2_LOG_LEVEL=${ec2.log.level}" /> 
-                <echo message="EUCA_GROUP=${euca.group}" /> 
-                <echo message="NEUCA_INI=${neuca.ini.file}" /> 
-                <echo message="AMI_NAME=${ec2.ami.name}" /> 
-                <echo message="AKI_NAME=${ec2.aki.name}" /> 
-                <echo message="ARI_NAME=${ec2.ari.name}" /> 
-                <echo message="EC2_INSTANCE_TYPE=${ec2.instance.type}" /> 
-                <echo message="EC2_SSH_KEY=${ec2.ssh.key}" /> 
-                <echo message="EC2_USE_PUBLIC_ADDRESSING=${ec2.use.public.addressing}" /> 
-                <echo message="EC2_PING_RETRIES=${ec2.ping.retries}" /> 
-                <echo message="EC2_SSH_RETRIES=${ec2.ssh.retries}" /> 
-                <echo message="EC2_SSH_TIMEOUT=${ec2.ssh.timeout}" /> 
-                <echo message="EC2_STARTUP_RETRIES=${ec2.startup.retries}" /> 
-                <echo message="EC2_CONNECTION_TIMEOUT=${ec2.connection.timeout}" /> 
-                <echo message="EC2_REQUEST_TIMEOUT=${ec2.request.timeout}" /> 
-                <echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" /> 
-                <echo message="before create instance" /> 
-                <exec executable="${ec2.scripts}/${cloud.type}-start" resultproperty="code" outputproperty="create.instance.output"> 
-                    <env key="EMULATION" value="${emulation}" /> 
-                    <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                    <env key="EC2_HOME" value="${ec2.home}" /> 
-                    <env key="EC2_DIR" value="${ec2.dir}" /> 
-                    <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                    <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                    <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                    <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                    <env key="EUCA_GROUP" value="${euca.group}" /> 
-                    <env key="NEUCA_INI" value="${neuca.ini.file}" /> 
-                    <env key="AMI_NAME" value="${ec2.ami.name}" /> 
-                    <env key="AKI_NAME" value="${ec2.aki.name}" /> 
-                    <env key="ARI_NAME" value="${ec2.ari.name}" /> 
-                    <env key="EC2_INSTANCE_TYPE" value="${ec2.instance.type}" /> 
-                    <env key="EC2_SSH_KEY" value="${ec2.ssh.key}" /> 
-                    <env key="EC2_USE_PUBLIC_ADDRESSING" value="${ec2.use.public.addressing}" /> 
-                    <env key="EC2_PING_RETRIES" value="${ec2.ping.retries}" /> 
-                    <env key="EC2_SSH_RETRIES" value="${ec2.ssh.retries}" /> 
-                    <env key="EC2_SSH_TIMEOUT" value="${ec2.ssh.timeout}" /> 
-                    <env key="EC2_STARTUP_RETRIES" value="${ec2.startup.retries}" /> 
-                    <env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" /> 
-                    <env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" /> 
-                </exec> 
-                <echo message="Handler running under emulation: exit code ${code}, ${create.instance.output}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <!-- set the euca group --> 
-                <if> 
-                    <not> 
-                        <isset property="euca.group" /> 
-                    </not> 
-                    <then> 
-                        <property name="euca.group" value="default" /> 
-                    </then> 
-                </if> 
-                <if> 
-                    <equals arg1="${ec2.debug}" arg2="true" /> 
-                    <then> 
-                        <echo message="********************************* ec2 join (ALL PROPERTIES) *********************************" /> 
-                        <echoproperties /> 
-                        <echo message="**********************************************************************************" /> 
-                    </then> 
-                </if> 
-                <!-- image proxy (optional) --> 
-                <if> 
-                    <!-- statically specified in ec2.site.properties --> 
-                    <equals arg1="${ec2.img.proxy.use}" arg2="true" /> 
-                    <then> 
-                        <!-- be sure config.image.url and config.image.guid are passed by controller --> 
-                        <!-- else use default emi in ec2.ami.name --> 
-                        <if> 
-                            <and> 
-                                <isset property="config.image.url" /> 
-                                <isset property="config.image.guid" /> 
-                            </and> 
-                            <then> 
-                                <var name="code" unset="true"></var> 
-                                <var name="message" unset="true"></var> 
-                                <echo message="invoking image proxy ${ec2.img.proxy.url} to download and install image ${config.image.url}... (may take some time)" /> 
-                                <!-- config.image.url and config.image.guid are externally specified --> 
-                                <ec2.image.proxy.register url="${config.image.url}" signature="${config.image.guid}" axisTimeout="${ec2.img.proxy.timeout}" imgproxyServiceUrl="${ec2.img.proxy.url}" statusPropertyName="img.proxy.status" emiPropertyName="img.proxy.emi" ekiPropertyName="img.proxy.eki" eriPropertyName="img.proxy.eri" /> 
-                                <echo message="Status from image proxy is ${img.proxy.status}" /> 
-                                <if> 
-                                    <not> 
-                                        <equals arg1="${img.proxy.status}" arg2="SUCCESS" /> 
-                                    </not> 
-                                    <then> 
-                                        <property name="code" value="-1" /> 
-                                        <property name="message" value="${img.proxy.status}" /> 
-                                    </then> 
-                                    <else> 
-                                        <echo message="New EMI from image proxy is ${img.proxy.emi}" /> 
-                                        <var name="ec2.ami.name" unset="true"></var> 
-                                        <property name="ec2.ami.name" value="${img.proxy.emi}" /> 
-                                        <property name="code" value="0" /> 
-                                        <if> 
-                                            <isset property="img.proxy.eki" /> 
-                                            <then> 
-                                                <echo message="New EKI from image proxy is ${img.proxy.eki}" /> 
-                                                <var name="ec2.aki.name" unset="true"></var> 
-                                                <property name="ec2.aki.name" value="${img.proxy.eki}" /> 
-                                            </then> 
-                                        </if> 
-                                        <if> 
-                                            <isset property="img.proxy.eri" /> 
-                                            <then> 
-                                                <echo message="New ERI from image proxy is ${img.proxy.eri}" /> 
-                                                <var name="ec2.ari.name" unset="true"></var> 
-                                                <property name="ec2.ari.name" value="${img.proxy.eri}" /> 
-                                            </then> 
-                                        </if> 
-                                    </else> 
-                                </if> 
-                            </then> 
-                            <else> 
-                                <property name="message" value="Controller did not pass image proxy properties ${config.image.url} or ${config.image.guid}, using default emi ${ec2.ami.name}" /> 
-                                <echo message="${message}" /> 
-                                <var name="code" unset="true"></var> 
-                                <property name="code" value="1" /> 
-                            </else> 
-                        </if> 
-                    </then> 
-                    <else> 
-                        <echo message="Skipping image proxy, using emi ${ec2.ami.name} " /> 
-                    </else> 
-                </if> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="Error encountered by image proxy, exiting ..." /> 
-                    </then> 
-                    <else> 
-                        <!-- see if the controller specified instance type or use site default --> 
-                        <if> 
-                            <isset property="unit.ec2.instance.type" /> 
-                            <then> 
-                                <echo message="User supplied instance type is ${unit.ec2.instance.type}" /> 
-                                <var name="ec2.instance.type" unset="true"></var> 
-                                <property name="ec2.instance.type" value="${unit.ec2.instance.type}" /> 
-                            </then> 
-                            <else> 
-                                <echo message="User did not specify instance type, using default ${ec2.instance.type}" /> 
-                            </else> 
-                        </if> 
-                        <echo message="creating Euca instance ${unit.hostname.url} using emi ${ec2.ami.name} ...(may take some time)" /> 
-                        <var name="create.instance.output" unset="true"></var> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <echo message="${ec2.scripts}/${cloud.type}-start " /> 
-                        <echo message="UNIT_HOSTNAME_URL=${unit.hostname.url}" /> 
-                        <echo message="EC2_HOME=${ec2.home}" /> 
-                        <echo message="EUCA_KEY_DIR=${ec2.keys}" /> 
-                        <echo message="EC2_LOG_DIR=${ec2.log.dir}" /> 
-                        <echo message="EC2_LOG_FILE=${ec2.log.file}" /> 
-                        <echo message="EC2_LOG_LEVEL=${ec2.log.level}" /> 
-                        <echo message="EUCA_GROUP=${euca.group}" /> 
-                        <echo message="NEUCA_INI=${neuca.ini.file}" /> 
-                        <echo message="AMI_NAME=${ec2.ami.name}" /> 
-                        <echo message="AKI_NAME=${ec2.aki.name}" /> 
-                        <echo message="ARI_NAME=${ec2.ari.name}" /> 
-                        <echo message="EC2_INSTANCE_TYPE=${ec2.instance.type}" /> 
-                        <echo message="EC2_SSH_KEY=${ec2.ssh.key}" /> 
-                        <echo message="EC2_USE_PUBLIC_ADDRESSING=${ec2.use.public.addressing}" /> 
-                        <echo message="EC2_PING_RETRIES=${ec2.ping.retries}" /> 
-                        <echo message="EC2_SSH_RETRIES=${ec2.ssh.retries}" /> 
-                        <echo message="EC2_SSH_TIMEOUT=${ec2.ssh.timeout}" /> 
-                        <echo message="EC2_STARTUP_RETRIES=${ec2.startup.retries}" /> 
-                        <echo message="EC2_CONNECTION_TIMEOUT=${ec2.connection.timeout}" /> 
-                        <echo message="EC2_REQUEST_TIMEOUT=${ec2.request.timeout}" /> 
-                        <echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" /> 
-                        <echo message="before create instance" /> 
-                        <exec executable="${ec2.scripts}/${cloud.type}-start" resultproperty="code" outputproperty="create.instance.output"> 
-                            <env key="EMULATION" value="${emulation}" /> 
-                            <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                            <env key="EC2_HOME" value="${ec2.home}" /> 
-                            <env key="EC2_DIR" value="${ec2.dir}" /> 
-                            <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                            <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                            <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                            <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                            <env key="EUCA_GROUP" value="${euca.group}" /> 
-                            <env key="NEUCA_INI" value="${neuca.ini.file}" /> 
-                            <env key="AMI_NAME" value="${ec2.ami.name}" /> 
-                            <env key="AKI_NAME" value="${ec2.aki.name}" /> 
-                            <env key="ARI_NAME" value="${ec2.ari.name}" /> 
-                            <env key="EC2_INSTANCE_TYPE" value="${ec2.instance.type}" /> 
-                            <env key="EC2_SSH_KEY" value="${ec2.ssh.key}" /> 
-                            <env key="EC2_USE_PUBLIC_ADDRESSING" value="${ec2.use.public.addressing}" /> 
-                            <env key="EC2_PING_RETRIES" value="${ec2.ping.retries}" /> 
-                            <env key="EC2_SSH_RETRIES" value="${ec2.ssh.retries}" /> 
-                            <env key="EC2_SSH_TIMEOUT" value="${ec2.ssh.timeout}" /> 
-                            <env key="EC2_STARTUP_RETRIES" value="${ec2.startup.retries}" /> 
-                            <env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" /> 
-                            <env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" /> 
-                        </exec> 
-                        <echo message="after create instance: exit code ${code}, ${create.instance.output}" /> 
-                        <if> 
-                            <not> 
-                                <equals arg1="${code}" arg2="0" /> 
-                            </not> 
-                            <then> 
-                                <echo message="unable to create instance: exit code ${code}, ${create.instance.output}" /> 
-                                <property name="shirako.save.unit.ec2.consolelog" value="${create.instance.output}" /> 
-                                <property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" /> 
-                                <echo message="console-log: ${shirako.save.unit.ec2.consolelog} " /> 
-                            </then> 
-                            <else> 
-                                <var name="shirako.save.unit.ec2.instance" unset="true"></var> 
-                                <property name="shirako.save.unit.ec2.instance" value="${create.instance.output}" /> 
-                                <!-- hairpin the hostname property so the user sees it too --> 
-                                <var name="shirako.save.unit.hostname.url" unset="true"></var> 
-                                <property name="shirako.save.unit.hostname.url" value="${unit.hostname.url}" /> 
-                                <echo message="create-instance exit code: ${code} instance=${shirako.save.unit.ec2.instance}" /> 
-                                <!-- obtain worker node information (if available) --> 
-                                <var name="shirako.save.unit.ec2.host" unset="true"></var> 
-                                <var name="code" unset="true"></var> 
-                                <var name="message" unset="true"></var> 
-                                <exec executable="${ec2.scripts}/${cloud.type}-get-host" resultproperty="code" outputproperty="shirako.save.unit.ec2.host"> 
-                                    <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                                    <env key="EC2_HOME" value="${ec2.home}" /> 
-                                    <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                                    <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                                    <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                                    <env key="EC2_DIR" value="${ec2.dir}" /> 
-                                    <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                                    <env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" /> 
-                                    <env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" /> 
-                                    <arg value="${shirako.save.unit.ec2.instance}" /> 
-                                </exec> 
-                                <echo message="get-host exit code: ${code} host=${shirako.save.unit.ec2.host}" /> 
-                                <!-- obtain console-log (if available) --> 
-                                <var name="shirako.save.unit.ec2.consolelog" unset="true"></var> 
-                                <var name="code" unset="true"></var> 
-                                <var name="message" unset="true"></var> 
-                                <exec executable="${ec2.scripts}/${cloud.type}-get-console-log" resultproperty="code" outputproperty="shirako.save.unit.ec2.consolelog"> 
-                                    <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                                    <env key="EC2_HOME" value="${ec2.home}" /> 
-                                    <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                                    <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                                    <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                                    <env key="EC2_DIR" value="${ec2.dir}" /> 
-                                    <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                                    <env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" /> 
-                                    <env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" /> 
-                                    <arg value="${shirako.save.unit.ec2.instance}" /> 
-                                </exec> 
-                                <!-- <echo message="get-console-log exit code: ${code} consolelog=${shirako.save.unit.ec2.consolelog}" /> --> 
-                                <!-- obtain management IP address --> 
-                                <echo message="obtaining ip address for instance ${shirako.save.unit.ec2.instance}" /> 
-                                <var name="code" unset="true"></var> 
-                                <var name="message" unset="true"></var> 
-                                <exec executable="${ec2.scripts}/${cloud.type}-get-ip" resultproperty="code" outputproperty="shirako.save.unit.manage.ip"> 
-                                    <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                                    <env key="EC2_HOME" value="${ec2.home}" /> 
-                                    <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                                    <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                                    <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                                    <env key="EC2_DIR" value="${ec2.dir}" /> 
-                                    <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                                    <env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" /> 
-                                    <env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" /> 
-                                    <arg value="${shirako.save.unit.ec2.instance}" /> 
-                                </exec> 
-                                <echo message="get-ip exit code: ${code} ip=${shirako.save.unit.manage.ip}" /> 
-                                <!-- set the user's private key, if needed --> 
-                                <if> 
-                                    <and> 
-                                        <isset property="shirako.save.unit.manage.ip" /> 
-                                        <equals arg1="${code}" arg2="0" /> 
-                                    </and> 
-                                    <then> 
-                                        <!-- entering here ${code} should be 0 and will stay this way unless there is an error below --> 
-                                        <echo message="installing ${config.ssh.numlogins} user keys and accounts in the instance" /> 
-                                        <var name="message" unset="true"></var> 
-                                        <for list="${config.ssh.numlogins}" param="iter" delimiter="," parallel="false"> 
-                                            <sequential> 
-                                                <var name="icode" unset="true"></var> 
-                                                <var name="loginProperty" unset="true"></var> 
-                                                <var name="keysProperty" unset="true"></var> 
-                                                <var name="sudoProperty" unset="true"></var> 
-                                                <property name="loginProperty" value="${config.ssh.user@{iter}.login}" /> 
-                                                <property name="keysProperty" value="${config.ssh.user@{iter}.keys}" /> 
-                                                <property name="sudoProperty" value="${config.ssh.user@{iter}.sudo}" /> 
-                                                <echo message="Creating account on ${shirako.save.unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" /> 
-                                                <exec executable="${ec2.scripts}/${cloud.type}-prepare-key" resultproperty="icode"> 
-                                                    <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                                                    <env key="EC2_HOME" value="${ec2.home}" /> 
-                                                    <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                                                    <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                                                    <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                                                    <env key="EC2_DIR" value="${ec2.dir}" /> 
-                                                    <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                                                    <env key="EC2_SSH_KEY" value="${ec2.ssh.key}" /> 
-                                                    <env key="EC2_SSH_TIMEOUT" value="${ec2.ssh.timeout}" /> 
-                                                    <arg value="${shirako.save.unit.manage.ip}" /> 
-                                                    <arg value="${loginProperty}" /> 
-                                                    <arg value="${keysProperty}" /> 
-                                                    <arg value="${sudoProperty}" /> 
-                                                </exec> 
-                                                <echo message="Exit code for login ${loginProperty} is ${icode}" /> 
-                                                <if> 
-                                                    <not> 
-                                                        <equals arg1="${icode}" arg2="0" /> 
-                                                    </not> 
-                                                    <then> 
-                                                        <fail message="Unable to create account ${loginProperty}, failing" /> 
-                                                    </then> 
-                                                </if> 
-                                            </sequential> 
-                                        </for> 
-                                        <!-- default port is SSH --> 
-                                        <property name="shirako.save.unit.manage.port" value="22" /> 
-                                        <!-- optionally open shorewall dnat proxy to this host --> 
-                                        <if> 
-                                            <!-- statically specified in ec2.site.properties --> 
-                                            <and> 
-                                                <equals arg1="${ec2.use.proxy}" arg2="true" /> 
-                                                <equals arg1="${code}" arg2="0" /> 
-                                            </and> 
-                                            <then> 
-                                                <!-- all properties passed to proxy script should be statically specified in ec2.site.properties.
+	-->
+		<if>
+			<isset property="ec2.site.properties" />
+			<then>
+				<property file="${ec2.site.properties}" />
+			</then>
+		</if>
+
+		<var name="code" unset="true" />
+		<var name="message" unset="true" />
+
+		<echo message="Cloud Type: ${cloud.type} " />
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<!-- create the NEUCA INI file -->
+				<tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" />
+				<echo message="EMULATION: neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" />
+				<ec2.generate.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" outputproperty="iface.list" />
+				<echo message="EMULATION: iface.list = ${iface.list}" />
+				<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+				<echo message="EMULATION: neuca.ini: ${neuca.ini}" />
+	
+	
+				<echo message="EMULATION: creating Euca instance ${unit.hostname.url} using emi ${ec2.ami.name} ...(may take some time)" />
+				<var name="create.instance.output" unset="true" />
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+				<echo message="${ec2.scripts}/${cloud.type}-start " />
+				<echo message="UNIT_HOSTNAME_URL=${unit.hostname.url}" />
+				<echo message="EC2_HOME=${ec2.home}" />
+				<echo message="EUCA_KEY_DIR=${ec2.keys}" />
+				<echo message="EC2_LOG_DIR=${ec2.log.dir}" />
+				<echo message="EC2_LOG_FILE=${ec2.log.file}" />
+				<echo message="EC2_LOG_LEVEL=${ec2.log.level}" />
+				<echo message="EUCA_GROUP=${euca.group}" />
+				<echo message="NEUCA_INI=${neuca.ini.file}" />
+				<echo message="AMI_NAME=${ec2.ami.name}" />
+				<echo message="AKI_NAME=${ec2.aki.name}" />
+				<echo message="ARI_NAME=${ec2.ari.name}" />
+				<echo message="EC2_INSTANCE_TYPE=${ec2.instance.type}" />
+				<echo message="EC2_SSH_KEY=${ec2.ssh.key}" />
+				<echo message="EC2_USE_PUBLIC_ADDRESSING=${ec2.use.public.addressing}" />
+				<echo message="EC2_PING_RETRIES=${ec2.ping.retries}" />
+				<echo message="EC2_SSH_RETRIES=${ec2.ssh.retries}" />
+				<echo message="EC2_SSH_TIMEOUT=${ec2.ssh.timeout}" />
+				<echo message="EC2_STARTUP_RETRIES=${ec2.startup.retries}" />
+				<echo message="EC2_CONNECTION_TIMEOUT=${ec2.connection.timeout}" />
+				<echo message="EC2_REQUEST_TIMEOUT=${ec2.request.timeout}" />
+				<echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" />
+				<echo message="before create instance" />
+				<exec executable="${ec2.scripts}/${cloud.type}-start" resultproperty="code" outputproperty="create.instance.output">
+					<env key="EMULATION" value="${emulation}" />
+					<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+					<env key="EC2_HOME" value="${ec2.home}" />
+					<env key="EC2_DIR" value="${ec2.dir}" />
+					<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+					<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+					<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+					<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+					<env key="EUCA_GROUP" value="${euca.group}" />
+					<env key="NEUCA_INI" value="${neuca.ini.file}" />
+					<env key="AMI_NAME" value="${ec2.ami.name}" />
+					<env key="AKI_NAME" value="${ec2.aki.name}" />
+					<env key="ARI_NAME" value="${ec2.ari.name}" />
+					<env key="EC2_INSTANCE_TYPE" value="${ec2.instance.type}" />
+					<env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
+					<env key="EC2_USE_PUBLIC_ADDRESSING" value="${ec2.use.public.addressing}" />
+					<env key="EC2_PING_RETRIES" value="${ec2.ping.retries}" />
+					<env key="EC2_SSH_RETRIES" value="${ec2.ssh.retries}" />
+					<env key="EC2_SSH_TIMEOUT" value="${ec2.ssh.timeout}" />
+					<env key="EC2_STARTUP_RETRIES" value="${ec2.startup.retries}" />
+					<env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" />
+					<env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" />
+				</exec>
+				<echo message="Handler running under emulation: exit code ${code}, ${create.instance.output}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+				<!-- set the euca group -->
+				<if>
+					<not>
+						<isset property="euca.group" />
+					</not>
+					<then>
+						<property name="euca.group" value="default" />
+					</then>
+				</if>
+
+				<if>
+					<equals arg1="${ec2.debug}" arg2="true" />
+					<then>
+						<echo message="********************************* ec2 join (ALL PROPERTIES) *********************************" />
+						<echoproperties/>
+						<echo message="**********************************************************************************" />
+					</then>
+				</if>
+
+
+				<!-- image proxy (optional) -->
+				<if>
+					<!-- statically specified in ec2.site.properties -->
+					<equals arg1="${ec2.img.proxy.use}" arg2="true" />
+					<then>
+						<!-- be sure config.image.url and config.image.guid are passed by controller -->
+						<!-- else use default emi in ec2.ami.name -->
+						<if>
+							<and>
+								<isset property="config.image.url" />
+								<isset property="config.image.guid" />
+							</and>
+							<then>
+								<var name="code" unset="true" />
+								<var name="message" unset="true" />
+								<echo message="invoking image proxy ${ec2.img.proxy.url} to download and install image ${config.image.url}... (may take some time)" />
+								<!-- config.image.url and config.image.guid are externally specified -->
+								<ec2.image.proxy.register url="${config.image.url}" signature="${config.image.guid}" axisTimeout="${ec2.img.proxy.timeout}" imgproxyServiceUrl="${ec2.img.proxy.url}" statusPropertyName="img.proxy.status" emiPropertyName="img.proxy.emi" ekiPropertyName="img.proxy.eki" eriPropertyName="img.proxy.eri" />
+								<echo message="Status from image proxy is ${img.proxy.status}" />
+								<if>
+									<not>
+										<equals arg1="${img.proxy.status}" arg2="SUCCESS" />
+									</not>
+									<then>
+										<property name="code" value="-1" />
+										<property name="message" value="${img.proxy.status}" />
+									</then>
+									<else>
+										<echo message="New EMI from image proxy is ${img.proxy.emi}" />
+										<var name="ec2.ami.name" unset="true" />
+										<property name="ec2.ami.name" value="${img.proxy.emi}" />
+										<property name="code" value="0" />
+										<if>
+											<isset property="img.proxy.eki" />
+											<then>
+												<echo message="New EKI from image proxy is ${img.proxy.eki}" />
+												<var name="ec2.aki.name" unset="true" />
+												<property name="ec2.aki.name" value="${img.proxy.eki}" />
+											</then>
+										</if>
+										<if>
+											<isset property="img.proxy.eri" />
+											<then>
+												<echo message="New ERI from image proxy is ${img.proxy.eri}" />
+												<var name="ec2.ari.name" unset="true" />
+												<property name="ec2.ari.name" value="${img.proxy.eri}" />
+											</then>
+										</if>
+									</else>
+								</if>
+							</then>
+							<else>
+								<property name="message" value="Controller did not pass image proxy properties ${config.image.url} or ${config.image.guid}, using default emi ${ec2.ami.name}" />
+								<echo message="${message}" />
+								<var name="code" unset="true" />
+								<property name="code" value="1" />
+							</else>
+						</if>
+					</then>
+					<else>
+						<echo message="Skipping image proxy, using emi ${ec2.ami.name} " />
+					</else>
+				</if>
+
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo message="Error encountered by image proxy, exiting ..." />
+	
+					</then>
+					<else>
+						<!-- see if the controller specified instance type or use site default -->
+						<if>
+							<isset property="unit.ec2.instance.type" />
+							<then>
+								<echo message="User supplied instance type is ${unit.ec2.instance.type}" />
+								<var name="ec2.instance.type" unset="true" />
+								<property name="ec2.instance.type" value="${unit.ec2.instance.type}" />
+							</then>
+							<else>
+								<echo message="User did not specify instance type, using default ${ec2.instance.type}" />
+							</else>
+						</if>
+					   <echo message="creating Euca instance ${unit.hostname.url} using emi ${ec2.ami.name} ...(may take some time)" />
+						<var name="create.instance.output" unset="true" />
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<echo message="${ec2.scripts}/${cloud.type}-start " />
+						<echo message="UNIT_HOSTNAME_URL=${unit.hostname.url}" />
+						<echo message="EC2_HOME=${ec2.home}" />
+						<echo message="EUCA_KEY_DIR=${ec2.keys}" />
+						<echo message="EC2_LOG_DIR=${ec2.log.dir}" />
+						<echo message="EC2_LOG_FILE=${ec2.log.file}" />
+						<echo message="EC2_LOG_LEVEL=${ec2.log.level}" />
+						<echo message="EUCA_GROUP=${euca.group}" />
+						<echo message="NEUCA_INI=${neuca.ini.file}" />
+						<echo message="AMI_NAME=${ec2.ami.name}" />
+						<echo message="AKI_NAME=${ec2.aki.name}" />
+						<echo message="ARI_NAME=${ec2.ari.name}" />
+						<echo message="EC2_INSTANCE_TYPE=${ec2.instance.type}" />
+						<echo message="EC2_SSH_KEY=${ec2.ssh.key}" />
+						<echo message="EC2_USE_PUBLIC_ADDRESSING=${ec2.use.public.addressing}" />
+						<echo message="EC2_PING_RETRIES=${ec2.ping.retries}" />
+						<echo message="EC2_SSH_RETRIES=${ec2.ssh.retries}" />
+						<echo message="EC2_SSH_TIMEOUT=${ec2.ssh.timeout}" />
+						<echo message="EC2_STARTUP_RETRIES=${ec2.startup.retries}" />
+						<echo message="EC2_CONNECTION_TIMEOUT=${ec2.connection.timeout}" />
+						<echo message="EC2_REQUEST_TIMEOUT=${ec2.request.timeout}" />
+						<echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" />
+						<echo message="before create instance" />
+						<exec executable="${ec2.scripts}/${cloud.type}-start" resultproperty="code" outputproperty="create.instance.output">
+							<env key="EMULATION" value="${emulation}" />
+							<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+							<env key="EC2_HOME" value="${ec2.home}" />
+							<env key="EC2_DIR" value="${ec2.dir}" />
+							<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+							<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+							<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+							<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+							<env key="EUCA_GROUP" value="${euca.group}" />
+							<env key="NEUCA_INI" value="${neuca.ini.file}" />
+							<env key="AMI_NAME" value="${ec2.ami.name}" />
+							<env key="AKI_NAME" value="${ec2.aki.name}" />
+							<env key="ARI_NAME" value="${ec2.ari.name}" />
+							<env key="EC2_INSTANCE_TYPE" value="${ec2.instance.type}" />
+							<env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
+							<env key="EC2_USE_PUBLIC_ADDRESSING" value="${ec2.use.public.addressing}" />
+							<env key="EC2_PING_RETRIES" value="${ec2.ping.retries}" />
+							<env key="EC2_SSH_RETRIES" value="${ec2.ssh.retries}" />
+							<env key="EC2_SSH_TIMEOUT" value="${ec2.ssh.timeout}" />
+							<env key="EC2_STARTUP_RETRIES" value="${ec2.startup.retries}" />
+							<env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" />
+							<env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" />
+						</exec>
+						<echo message="after create instance: exit code ${code}, ${create.instance.output}" />
+
+						<if>
+							<not>
+								<equals arg1="${code}" arg2="0" />
+							</not>
+							<then>
+								<echo message="unable to create instance: exit code ${code}, ${create.instance.output}" />
+								<property name="shirako.save.unit.ec2.consolelog" value="${create.instance.output}" />
+								<property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" />
+								<echo message="console-log: ${shirako.save.unit.ec2.consolelog} "/>
+							</then>
+							<else>
+								<var name="shirako.save.unit.ec2.instance" unset="true" />
+								<property name="shirako.save.unit.ec2.instance" value="${create.instance.output}" />
+
+								<!-- hairpin the hostname property so the user sees it too -->
+								<var name="shirako.save.unit.hostname.url" unset="true" />
+								<property name="shirako.save.unit.hostname.url" value="${unit.hostname.url}" />
+								<echo message="create-instance exit code: ${code} instance=${shirako.save.unit.ec2.instance}" />
+
+								<!-- obtain worker node information (if available) -->
+								<var name="shirako.save.unit.ec2.host" unset="true" />
+								<var name="code" unset="true" />
+								<var name="message" unset="true" />
+								<exec executable="${ec2.scripts}/${cloud.type}-get-host" resultproperty="code" outputproperty="shirako.save.unit.ec2.host">
+									<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+									<env key="EC2_HOME" value="${ec2.home}" />
+									<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+									<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+									<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+									<env key="EC2_DIR" value="${ec2.dir}" />
+									<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+									<env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" />
+									<env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" />
+									<arg value="${shirako.save.unit.ec2.instance}" />
+								</exec>
+								<echo message="get-host exit code: ${code} host=${shirako.save.unit.ec2.host}" />
+
+								<!-- obtain console-log (if available) -->
+								<var name="shirako.save.unit.ec2.consolelog" unset="true" />
+								<var name="code" unset="true" />
+								<var name="message" unset="true" />	
+								<exec executable="${ec2.scripts}/${cloud.type}-get-console-log" resultproperty="code" outputproperty="shirako.save.unit.ec2.consolelog">
+									<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+									<env key="EC2_HOME" value="${ec2.home}" />
+									<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+									<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+									<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+									<env key="EC2_DIR" value="${ec2.dir}" />
+									<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+									<env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" />
+									<env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" />
+									<arg value="${shirako.save.unit.ec2.instance}" />
+								</exec>
+								<!-- <echo message="get-console-log exit code: ${code} consolelog=${shirako.save.unit.ec2.consolelog}" /> -->
+
+	
+								<!-- obtain management IP address -->
+								<echo message="obtaining ip address for instance ${shirako.save.unit.ec2.instance}" />
+								<var name="code" unset="true" />
+								<var name="message" unset="true" />
+								<exec executable="${ec2.scripts}/${cloud.type}-get-ip" resultproperty="code" outputproperty="shirako.save.unit.manage.ip">
+									<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+									<env key="EC2_HOME" value="${ec2.home}" />
+									<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+									<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+									<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+									<env key="EC2_DIR" value="${ec2.dir}" />
+									<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+									<env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" />
+									<env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" />
+									<arg value="${shirako.save.unit.ec2.instance}" />
+								</exec>
+								<echo message="get-ip exit code: ${code} ip=${shirako.save.unit.manage.ip}" />
+
+								<!-- set the user's private key, if needed -->
+								<if>
+									<and>
+										<isset property="shirako.save.unit.manage.ip" />
+										<equals arg1="${code}" arg2="0" />
+									</and>
+									<then>
+										<!-- entering here ${code} should be 0 and will stay this way unless there is an error below -->
+										<echo message="installing ${config.ssh.numlogins} user keys and accounts in the instance" />
+										<var name="message" unset="true" />
+										<for list="${config.ssh.numlogins}" param="iter" delimiter="," parallel="false">
+											<sequential>
+												<var name="icode" unset="true" />
+
+												<var name="loginProperty" unset="true" />
+												<var name="keysProperty" unset="true" />
+												<var name="sudoProperty" unset="true" />
+
+												<property name="loginProperty" value="${config.ssh.user@{iter}.login}" />
+												<property name="keysProperty" value="${config.ssh.user@{iter}.keys}" />
+												<property name="sudoProperty" value="${config.ssh.user@{iter}.sudo}" />
+
+												<echo message="Creating account on ${shirako.save.unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" />
+												<exec executable="${ec2.scripts}/${cloud.type}-prepare-key" resultproperty="icode">
+													<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+													<env key="EC2_HOME" value="${ec2.home}" />
+													<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+													<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+													<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+													<env key="EC2_DIR" value="${ec2.dir}" />
+													<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+													<env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
+													<env key="EC2_SSH_TIMEOUT" value="${ec2.ssh.timeout}" />
+													<env key="AMI_NAME" value="${ec2.ami.name}" />
+													<env key="AKI_NAME" value="${ec2.aki.name}" />
+													<env key="ARI_NAME" value="${ec2.ari.name}" />
+													<arg value="${shirako.save.unit.manage.ip}" />
+													<arg value="${loginProperty}" />
+													<arg value="${keysProperty}" />
+													<arg value="${sudoProperty}" />
+												</exec>
+												<echo message="Exit code for login ${loginProperty} is ${icode}" />
+												<if>
+													<not>
+														<equals arg1="${icode}" arg2="0" />
+													</not>
+													<then>
+														<fail message="Unable to create account ${loginProperty}, failing" />
+													</then>
+												</if>
+											</sequential>
+										</for>
+
+										<!-- default port is SSH -->
+										<property name="shirako.save.unit.manage.port" value="22" />
+										<!-- optionally open shorewall dnat proxy to this host -->
+										<if>
+											<!-- statically specified in ec2.site.properties -->
+											<and>
+												<equals arg1="${ec2.use.proxy}" arg2="true" />
+												<equals arg1="${code}" arg2="0" />
+											</and>
+											<then>
+												<!-- all properties passed to proxy script should be statically specified in ec2.site.properties.
 				 									See wiki notes on proxies for meaning of these properties.
-												--> 
-                                                <echo message="configuring ${proxy.type} SSH proxy for ${shirako.save.unit.manage.ip} via host ${proxy.proxy.ip}" /> 
-                                                <var name="code" unset="true"></var> 
-                                                <var name="message" unset="true"></var> 
-                                                <exec executable="${ec2.scripts}/start-proxy" resultproperty="code" outputproperty="proxy.script.output"> 
-                                                    <env key="PROXY_TYPE" value="${proxy.type}" /> 
-                                                    <env key="PROXY_PROXY_IP" value="${proxy.proxy.ip}" /> 
-                                                    <env key="PROXY_INSTANCE_IP" value="${shirako.save.unit.manage.ip}" /> 
-                                                    <env key="PROXY_USER" value="${proxy.user}" /> 
-                                                    <env key="PROXY_SSH_KEY" value="${proxy.ssh.key}" /> 
-                                                    <env key="PROXY_SCRIPT_PATH" value="${proxy.script.path}" /> 
-                                                </exec> 
-                                                <if> 
-                                                    <equals arg1="${code}" arg2="0" /> 
-                                                    <then> 
-                                                        <var name="shirako.save.unit.manage.ip" unset="true"></var> 
-                                                        <var name="shirako.save.unit.manage.port" unset="true"></var> 
-                                                        <propertyregex property="shirako.save.unit.manage.ip" input="${proxy.script.output}" regexp="([^:]+):([0123456789]+)" select="\1" casesensitive="false" /> 
-                                                        <propertyregex property="shirako.save.unit.manage.port" input="${proxy.script.output}" regexp="([^:]+):([0123456789]+)" select="\2" casesensitive="false" /> 
-                                                        <echo message="proxy configuration created on ${shirako.save.unit.manage.ip}:${shirako.save.unit.manage.port}" /> 
-                                                    </then> 
-                                                    <else> 
-                                                        <echo message="start-proxy failed with exit code: ${code} ${proxy.script.output}" /> 
-                                                        <property name="message" value="start-proxy failed with exit code: ${code} ${proxy.script.output}" /> 
-                                                        <echo message="terminating instance: ${shirako.save.unit.ec2.instance}" /> 
-                                                        <!-- be sure not to save exit code (renamed nocode), since we don't care here if stop exits successfully --> 
-                                                        <exec executable="${ec2.scripts}/${cloud.type}-stop" resultproperty="nocode" outputproperty="terminate.instance.output"> 
-                                                            <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                                                            <env key="EC2_HOME" value="${ec2.home}" /> 
-                                                            <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                                                            <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                                                            <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                                                            <env key="EC2_DIR" value="${ec2.dir}" /> 
-                                                            <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                                                            <env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" /> 
-                                                            <env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" /> 
-                                                            <arg value="${shirako.save.unit.ec2.instance}" /> 
-                                                        </exec> 
-                                                    </else> 
-                                                </if> 
-                                            </then> 
-                                        </if> 
-                                    </then> 
-                                </if> 
-                                <!-- create the NEUCA INI file --> 
-                                <tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" /> 
-                                <echo message="neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" /> 
-                                <ec2.generate.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" outputproperty="iface.list" /> 
-                                <echo message="iface.list = ${iface.list}" /> 
-                                <loadfile property="neuca.ini" srcFile="${neuca.ini.file}" /> 
-                                <echo message="neuca.ini: ${neuca.ini}" /> 
-                                <!-- if neuca-quantum, add interfaces --> 
-                                <if> 
-                                    <equals arg1="${cloud.type}" arg2="nova-essex" /> 
-                                    <then> 
-                                        <echo message="iface list: ${iface.list}" /> 
-                                        <var name="instance.quantum.ifaces" unset="true"></var> 
-                                        <for list="${iface.list}" param="iface" delimiter=" " parallel="false"> 
-                                            <sequential> 
-                                                <var name="iface.net.name" unset="true"></var> 
-                                                <var name="iface.net.vlan" unset="true"></var> 
-                                                <var name="iface.mac" unset="true"></var> 
-                                                <echo>
-                                                     iface @{iface} 
-                                                </echo> 
-                                                <propertyregex property="iface.net.name" input="@{iface}" regexp="(.*)\..*\..*" replace="\1" casesensitive="false" /> 
-                                                <propertyregex property="iface.net.vlan" input="@{iface}" regexp=".*\.(.*)\..*" replace="\1" casesensitive="false" /> 
-                                                <propertyregex property="iface.mac" input="@{iface}" regexp=".*\..*\.(.*)" replace="\1" casesensitive="false" /> 
-                                                <echo>
-                                                     quantum.tenant.id ${quantum.tenant.id} 
-                                                </echo> 
-                                                <echo>
-                                                     shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance} 
-                                                </echo> 
-                                                <echo>
-                                                     iface.mac ${iface.mac} 
-                                                </echo> 
-                                                <echo>
-                                                     iface.net.vlan ${iface.net.vlan} 
-                                                </echo> 
-                                                <echo>
-                                                     iface.net.name ${iface.net.name} 
-                                                </echo> 
-                                                <var name="code" unset="true"></var> 
-                                                <var name="add.iface.output" unset="true"></var> 
-                                                <echo message="EC2_HOME ${ec2.home}" /> 
-                                                <echo message="EC2_DIR ${ec2.dir}" /> 
-                                                <echo message="EUCA_KEY_DIR=${ec2.keys}" /> 
-                                                <echo message="EC2_LOG_DIR ${ec2.log.dir}" /> 
-                                                <echo message="EC2_LOG_FILE ${ec2.log.file}" /> 
-                                                <echo message="EC2_LOG_LEVEL ${ec2.log.level}" /> 
-                                                <echo message="QUANTUM_TENANT_ID ${quantum.tenant.id}" /> 
-                                                <echo message="QUANTUM_NET_INSTANCE_NAME ${shirako.save.unit.ec2.instance}" /> 
-                                                <echo message="QUANTUM_NET_IFACE_MAC ${iface.mac}" /> 
-                                                <echo message="QUANTUM_NET_NETWORK ${iface.net.name}" /> 
-                                                <echo message="QUANTUM_NET_VLAN ${iface.net.vlan}" /> 
-                                                <exec executable="${ec2.scripts}/neuca-quantum-add-iface" resultproperty="code" outputproperty="add.iface.output"> 
-                                                    <env key="EC2_HOME" value="${ec2.home}" /> 
-                                                    <env key="EC2_DIR" value="${ec2.dir}" /> 
-                                                    <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                                                    <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                                                    <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                                                    <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                                                    <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                                                    <env key="QUANTUM_NET_INSTANCE_NAME" value="${shirako.save.unit.ec2.instance}" /> 
-                                                    <env key="QUANTUM_NET_IFACE_MAC" value="${iface.mac}" /> 
-                                                    <env key="QUANTUM_NET_NETWORK" value="${iface.net.name}" /> 
-                                                    <env key="QUANTUM_NET_VLAN" value="${iface.net.vlan}" /> 
-                                                </exec> 
-                                                <echo>
-                                                     result code: ${code} 
-                                                </echo> 
-                                                <echo>
-                                                     output: ${add.iface.output} 
-                                                </echo> 
-                                                <if> 
-                                                    <isset property="instance.quantum.ifaces" /> 
-                                                    <then> 
-                                                        <var name="instance.quantum.ifaces.tmp" unset="true"></var> 
-                                                        <property name="instance.quantum.ifaces.tmp" value="${instance.quantum.ifaces}" /> 
-                                                        <var name="instance.quantum.ifaces" unset="true"></var> 
-                                                        <property name="instance.quantum.ifaces" value="${instance.quantum.ifaces.tmp},${add.iface.output}" /> 
-                                                    </then> 
-                                                    <else> 
-                                                        <property name="instance.quantum.ifaces" value="${add.iface.output}" /> 
-                                                    </else> 
-                                                </if> 
-                                            </sequential> 
-                                        </for> 
-                                        <property name="shirako.save.unit.quantum.ifaces" value="${instance.quantum.ifaces}" /> 
-                                        <echo>
-                                             shirako.save.unit.quantum.ifaces: ${shirako.save.unit.quantum.ifaces} 
-                                        </echo> 
-                                    </then> 
-                                </if> 
-                                <!-- update the userdata file  --> 
-                                <echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" /> 
-                                <echo message="update userdata instance: ${shirako.save.unit.ec2.instance}" /> 
-                                <var name="code" unset="true"></var> 
-                                <var name="update.userdata.output" unset="true"></var> 
-                                <exec executable="${ec2.scripts}/${cloud.type}-update-userdata" resultproperty="code" outputproperty="update.userdata.output"> 
-                                    <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                                    <env key="EC2_HOME" value="${ec2.home}" /> 
-                                    <env key="EC2_DIR" value="${ec2.dir}" /> 
-                                    <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                                    <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                                    <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                                    <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                                    <env key="NEUCA_INI" value="${neuca.ini.file}" /> 
-                                    <env key="INSTANCE_ID" value="${shirako.save.unit.ec2.instance}" /> 
-                                </exec> 
-                                <echo message="after update userdata: exit code ${code}, ${update.userdata.output}" /> 
-                                <delete file="${neuca.ini.file}" /> 
-                            </else> 
-                        </if> 
-                    </else> 
-                </if> 
-            </else> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <if> 
-            <isset property="message" /> 
-            <then> 
-                <property name="shirako.target.code.message" value="${message}" /> 
-            </then> 
-            <else> 
-                <property name="shirako.target.code.message" value="none" /> 
-            </else> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- Various Modify Operations --> 
-    <!-- Useful macros --> 
-    <macrodef name="modify.ssh" description="install new SSH keys via modify"> 
-        <attribute name="seqnum" description="sequence number" /> 
-        <sequential> 
-            <if> 
-                <equals arg1="${emulation}" arg2="true" /> 
-                <then> 
-                    <for list="${modify.@{seqnum}.config.ssh.numlogins}" param="iter" delimiter="," parallel="false"> 
-                        <sequential> 
-                            <var name="loginProperty" unset="true"></var> 
-                            <var name="keysProperty" unset="true"></var> 
-                            <var name="sudoProperty" unset="true"></var> 
-                            <property name="loginProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.login}" /> 
-                            <property name="keysProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.keys}" /> 
-                            <property name="sudoProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.sudo}" /> 
-                            <echo message="About to create account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" /> 
-                        </sequential> 
-                    </for> 
-                    <echo message="Running under emulation...exiting" /> 
-                    <property name="shirako.target.code" value="0" /> 
-                </then> 
-                <else> 
-                    <echo message="installing ${modify.@{seqnum}.config.ssh.numlogins} user keys and accounts in the instance" /> 
-                    <var name="message" unset="true"></var> 
-                    <!-- re-create the NEUCA INI file --> 
-                    <echo message="Creating account on ${unit.manage.ip}" /> 
-                    <echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" /> 
-                    <exec executable="${ec2.scripts}/${cloud.type}-get-userdata" resultproperty="icode" outputproperty="userdata.old"> 
-                        <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                        <env key="EC2_HOME" value="${ec2.home}" /> 
-                        <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                        <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                        <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                        <env key="EC2_DIR" value="${ec2.dir}" /> 
-                        <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                        <env key="EC2_SSH_KEY" value="${ec2.ssh.key}" /> 
-                        <arg value="${unit.ec2.instance}" /> 
-                    </exec> 
-                    <echo message="Exit code for get-userdata is ${icode}" /> 
-                    <!-- <echo message="Old userdata : ${userdata.old}" /> --> 
-                    <!-- setup userdata:  set userdataold the userdata string in order to parse and copy to ${neuca.ini.file} --> 
-                    <tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" /> 
-                    <echo message="neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" /> 
-                    <ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${userdata.old}" /> 
-                    <loadfile property="neuca.ini" srcFile="${neuca.ini.file}" /> 
-                    <!-- <echo message="neuca.ini: ${neuca.ini}" /> --> 
-                    <!-- add keys --> 
-                    <echo message="Modify.ssh, numlogins : ${modify.@{seqnum}.config.ssh.numlogins} " /> 
-                    <for list="${modify.@{seqnum}.config.ssh.numlogins}" param="iter" delimiter="," parallel="false"> 
-                        <sequential> 
-                            <var name="icode" unset="true"></var> 
-                            <var name="loginProperty" unset="true"></var> 
-                            <var name="keysProperty" unset="true"></var> 
-                            <var name="sudoProperty" unset="true"></var> 
-                            <property name="loginProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.login}" /> 
-                            <property name="keysProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.keys}" /> 
-                            <property name="sudoProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.sudo}" /> 
-                            <echo message="Creating account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" /> 
-                            <echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" /> 
-                            <echo message="LoginProperty : ${loginProperty}" /> 
-                            <echo message="KeysProperty : ${keysProperty}" /> 
-                            <echo message="SudoProperty : ${sudoProperty}" /> 
-                            <!-- add key to userdata:  setuserdataold to ${neuca.ini.file} to read from file --> 
-                            <ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}" section="users" key="${loginProperty}" value="${keysProperty}" /> 
-                            <loadfile property="neuca.ini" srcFile="${neuca.ini.file}" /> 
-                            <echo message="neuca.ini: ${neuca.ini}" /> 
-                            <!-- add key to VM --> 
-                            <exec executable="${ec2.scripts}/${cloud.type}-prepare-key" resultproperty="icode"> 
-                                <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                                <env key="EC2_HOME" value="${ec2.home}" /> 
-                                <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                                <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                                <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                                <env key="EC2_DIR" value="${ec2.dir}" /> 
-                                <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                                <env key="EC2_SSH_KEY" value="${ec2.ssh.key}" /> 
-                                <env key="EC2_SSH_TIMEOUT" value="${ec2.ssh.timeout}" /> 
-                                <arg value="${unit.manage.ip}" /> 
-                                <arg value="${loginProperty}" /> 
-                                <arg value="${keysProperty}" /> 
-                                <arg value="${sudoProperty}" /> 
-                            </exec> 
-                            <echo message="Exit code for login ${loginProperty} is ${icode}" /> 
-                            <if> 
-                                <not> 
-                                    <equals arg1="${icode}" arg2="0" /> 
-                                </not> 
-                                <then> 
-                                    <fail message="Unable to create account ${loginProperty}, failing" /> 
-                                </then> 
-                            </if> 
-                        </sequential> 
-                    </for> 
-                    <!-- update the userdata file  --> 
-                    <echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" /> 
-                    <echo message="update userdata instance: ${shirako.save.unit.ec2.instance}" /> 
-                    <var name="code" unset="true"></var> 
-                    <var name="update.userdata.output" unset="true"></var> 
-                    <exec executable="${ec2.scripts}/${cloud.type}-update-userdata" resultproperty="code" outputproperty="update.userdata.output"> 
-                        <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                        <env key="EC2_HOME" value="${ec2.home}" /> 
-                        <env key="EC2_DIR" value="${ec2.dir}" /> 
-                        <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                        <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                        <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                        <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                        <env key="NEUCA_INI" value="${neuca.ini.file}" /> 
-                        <env key="INSTANCE_ID" value="${shirako.save.unit.ec2.instance}" /> 
-                    </exec> 
-                    <echo message="after update userdata: exit code ${code}, ${update.userdata.output}" /> 
-                    <delete file="${neuca.ini.file}" /> 
-                </else> 
-            </if> 
-        </sequential> 
-    </macrodef> 
-    <!-- add logins --> 
-    <target name="modify.ssh" depends="resolve.configuration"> 
-        <taskdef resource="orca/handlers/ec2/ec2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <echo message="ec2.site.properties path is ${ec2.site.properties}" /> 
-        <if> 
-            <isset property="ec2.site.properties" /> 
-            <then> 
-                <echo message="Setting ec2.site.properites from ${ec2.site.properties}" /> 
-                <property file="${ec2.site.properties}" /> 
-            </then> 
-        </if> 
-        <var name="code" unset="true"></var> 
-        <var name="message" unset="true"></var> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="EC2 HANDLER: MODIFY.SSH on ${start.TIME}" /> 
-        <echo message="modify.ssh: ec2 instance=${unit.ec2.instance}, modify sequence number ${shirako.save.unit.modify.sequencenum}" /> 
-        <modify.ssh seqnum="${shirako.save.unit.modify.sequencenum}" /> 
-        <property name="shirako.target.code" value="0" /> 
-        <echo message="modify.ssh exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- add iface macro --> 
-    <macrodef name="modify.addiface" description="add a new network iface via modify"> 
-        <attribute name="seqnum" description="sequence number" /> 
-        <sequential> 
-            <if> 
-                <equals arg1="${emulation}" arg2="true" /> 
-                <then> 
-                    <var name="iface.net.name" unset="true"></var> 
-                    <var name="iface.net.vlan" unset="true"></var> 
-                    <var name="iface.mac" unset="true"></var> 
-                    <echo>
-                         iface @{iface} 
-                    </echo> 
-                    <propertyregex property="iface.net.name" input="@{iface}" regexp="(.*)\..*\..*" replace="\1" casesensitive="false" /> 
-                    <propertyregex property="iface.net.vlan" input="@{iface}" regexp=".*\.(.*)\..*" replace="\1" casesensitive="false" /> 
-                    <propertyregex property="iface.mac" input="@{iface}" regexp=".*\..*\.(.*)" replace="\1" casesensitive="false" /> 
-                    <echo>
-                         quantum.tenant.id ${quantum.tenant.id} 
-                    </echo> 
-                    <echo>
-                         shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance} 
-                    </echo> 
-                    <echo>
-                         iface.mac ${iface.mac} 
-                    </echo> 
-                    <echo>
-                         iface.net.vlan ${iface.net.vlan} 
-                    </echo> 
-                    <echo>
-                         iface.net.name ${iface.net.name} 
-                    </echo> 
-                    <echo>
-                         unit.ec2.instance ${unit.ec2.instance} 
-                    </echo> 
-                    <echo message="Running under emulation...exiting" /> 
-                    <property name="shirako.target.code" value="0" /> 
-                </then> 
-                <else> 
-                    <!-- Actually do it... no emulation --> 
-                    <echo message="adding interfaces to instance" /> 
-                    <var name="message" unset="true"></var> 
-                    <echo message="vlan.tag = ${modify.@{seqnum}.vlan.tag}" /> 
-                    <echo message="ip = ${modify.@{seqnum}.ip}" /> 
-                    <echo message="mode = ${modify.@{seqnum}.mode}" /> 
-                    <echo message="hosteth = ${modify.@{seqnum}.hosteth}" /> 
-                    <echo message="mac = ${modify.@{seqnum}.mac}" /> 
-                    <echo message="state = ${modify.@{seqnum}.state}" /> 
-                    <echo message="ipversion = ${modify.@{seqnum}.ipversion}" /> 
-                    <property name="ip" value="${modify.@{seqnum}.ip}" /> 
-                    <property name="state" value="${modify.@{seqnum}.state}" /> 
-                    <property name="ipversion" value="${modify.@{seqnum}.ipversion}" /> 
-                    <echo message="ip after setting to modify.x.ip = ${ip}" /> 
-                    <!-- set defaults for unset properties --> 
-                    <!-- <if> <not><isset property="${modify.@{seqnum}.ip}"/></not> --> 
-                    <if> 
-                        <contains string="${ip}" substring="modify" /> 
-                        <then> 
-                            <echo message="modify.${seqnum}.ip is not net.  Using default value: empty string." /> 
-                            <var name="ip" unset="true"></var> 
-                            <property name="ip" value="" /> 
-                        </then> 
-                    </if> 
-                    <if> 
-                        <contains string="${state}" substring="modify" /> 
-                        <then> 
-                            <echo message="modify.${seqnum}.state is not net.  Using default value: up." /> 
-                            <var name="state" unset="true"></var> 
-                            <property name="state" value="up" /> 
-                        </then> 
-                    </if> 
-                    <if> 
-                        <contains string="${ipversion}" substring="modify" /> 
-                        <then> 
-                            <echo message="modify.${seqnum}.ipversion is not net.  Using default value: ipv4." /> 
-                            <var name="ipversion" unset="true"></var> 
-                            <property name="ipversion" value="ipv4" /> 
-                        </then> 
-                    </if> 
-                    <!-- Get old userdata --> 
-                    <echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" /> 
-                    <echo message="LoginProperty : ${loginProperty}" /> 
-                    <echo message="KeysProperty : ${keysProperty}" /> 
-                    <echo message="SudoProperty : ${sudoProperty}" /> 
-                    <exec executable="${ec2.scripts}/${cloud.type}-get-userdata" resultproperty="icode" outputproperty="userdata.old"> 
-                        <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                        <env key="EC2_HOME" value="${ec2.home}" /> 
-                        <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                        <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                        <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                        <env key="EC2_DIR" value="${ec2.dir}" /> 
-                        <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                        <env key="EC2_SSH_KEY" value="${ec2.ssh.key}" /> 
-                        <arg value="${unit.ec2.instance}" /> 
-                    </exec> 
-                    <echo message="Exit code for get-userdata is ${icode}" /> 
-                    <echo message="Old userdata : ${userdata.old}" /> 
-                    <!-- setup userdata:  set userdataold the userdata string in order to parse and copy to ${neuca.ini.file} --> 
-                    <tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" /> 
-                    <echo message="neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" /> 
-                    <ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${userdata.old}" /> 
-                    <loadfile property="neuca.ini" srcFile="${neuca.ini.file}" /> 
-                    <echo message="neuca.ini: ${neuca.ini}" /> 
-                    <!-- process each iface to add --> 
-                    <exec executable="${ec2.scripts}/neuca-quantum-add-iface" resultproperty="code" outputproperty="add.iface.output"> 
-                        <env key="EC2_HOME" value="${ec2.home}" /> 
-                        <env key="EC2_DIR" value="${ec2.dir}" /> 
-                        <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                        <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                        <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                        <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                        <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                        <env key="QUANTUM_NET_INSTANCE_NAME" value="${unit.ec2.instance}" /> 
-                        <env key="QUANTUM_NET_IFACE_MAC" value="${modify.@{seqnum}.mac}" /> 
-                        <env key="QUANTUM_NET_NETWORK" value="${modify.@{seqnum}.hosteth}" /> 
-                        <env key="QUANTUM_NET_VLAN" value="${modify.@{seqnum}.vlan.tag}" /> 
-                    </exec> 
-                    <echo>
-                         result code: ${code} 
-                    </echo> 
-                    <echo>
-                         output: ${add.iface.output} 
-                    </echo> 
-                    <!-- add properties to userdata file --> 
-                    <echo message="About to update userdata file: " /> 
-                    <echo message="mac        :  ${modify.@{seqnum}.mac}" /> 
-                    <echo message="state      :  ${state}" /> 
-                    <echo message="ipversion  :  ${ipversion}" /> 
-                    <echo message="ip         :  ${ip}" /> 
-                    <!-- adding network property to userdata --> 
-                    <ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}" section="interfaces" key="${modify.@{seqnum}.mac}" value="${state}:${ipversion}:${ip}" /> 
-                    <loadfile property="neuca.ini" srcFile="${neuca.ini.file}" /> 
-                    <!-- Possibly add storage info to userdata --> 
-                    <echo message="storage_type = ${modify.@{seqnum}.type}" /> 
-                    <echo message="port = ${modify.@{seqnum}.target.port}" /> 
-                    <echo message="target.ip = ${modify.@{seqnum}.target.ip}" /> 
-                    <property name="storage_type" value="${modify.@{seqnum}.type}" /> 
-                    <property name="port" value="${modify.@{seqnum}.target.port}" /> 
-                    <property name="target.ip" value="${modify.@{seqnum}.target.ip}" /> 
-                    <if> 
-                        <and> 
-                            <not> 
-                                <contains string="${storage_type}" substring="modify" /> 
-                            </not> 
-                            <not> 
-                                <contains string="${port}" substring="modify" /> 
-                            </not> 
-                            <not> 
-                                <contains string="${target.ip}" substring="modify" /> 
-                            </not> 
-                        </and> 
-                        <then> 
-                            <!-- We need to add storage info to userdata --> 
-                            <echo message="Adding storage info to userdata" /> 
-                            <echo message="chap_password = ${modify.@{seqnum}.target.chap_password}" /> 
-                            <echo message="chap_user = ${modify.@{seqnum}.target.chap_user}" /> 
-                            <echo message="iscsi.initiator.iqn = ${modify.@{seqnum}.iscsi.initiator.iqn}" /> 
-                            <echo message="lun.guid = ${modify.@{seqnum}.target.lun.guid}" /> 
-                            <echo message="mount_point = ${modify.@{seqnum}.target.mount_point}" /> 
-                            <echo message="options = ${modify.@{seqnum}.target.options}" /> 
-                            <echo message="port = ${modify.@{seqnum}.target.port}" /> 
-                            <echo message="should_attach = ${modify.@{seqnum}.target.should_attach}" /> 
-                            <echo message="should_format = ${modify.@{seqnum}.target.should_format}" /> 
-                            <echo message="target.ip = ${modify.@{seqnum}.target.ip}" /> 
-                            <echo message="target.lun.num = ${modify.@{seqnum}.target.lun.num}" /> 
-                            <echo message="storage_type = ${modify.@{seqnum}.type}" /> 
-                            <property name="chap_password" value="${modify.@{seqnum}.target.chap_password}" /> 
-                            <property name="chap_user" value="${modify.@{seqnum}.target.chap_user}" /> 
-                            <property name="iscsi.initiator.iqn" value="${modify.@{seqnum}.iscsi.initiator.iqn}" /> 
-                            <property name="lun.guid" value="${modify.@{seqnum}.target.lun.guid}" /> 
-                            <property name="mount_point" value="${modify.@{seqnum}.target.mount_point}" /> 
-                            <property name="options" value="${modify.@{seqnum}.target.options}" /> 
-                            <!-- <property name="port"  value="${modify.@{seqnum}.target.port}" /> --> 
-                            <property name="should_attach" value="${modify.@{seqnum}.target.should_attach}" /> 
-                            <property name="should_format" value="${modify.@{seqnum}.target.should_format}" /> 
-                            <!-- <property name="target.ip"  value="${modify.@{seqnum}.target.ip}" /> --> 
-                            <property name="target.lun.num" value="${modify.@{seqnum}.target.lun.num}" /> 
-                            <!-- <property name="type"  value="${modify.@{seqnum}.type}" /> --> 
-                            <property name="fs.type" value="${modify.@{seqnum}.fs.type}" /> 
-                            <!-- set defaults for unset properties --> 
-                            <if> 
-                                <contains string="${target.lun.num}" substring="modify" /> 
-                                <then> 
-                                    <echo message="modify.${seqnum}.target.lun.num  is not net.  Using default value: 0." /> 
-                                    <var name="target.lun.num " unset="true"></var> 
-                                    <property name="target.lun.num " value="0" /> 
-                                </then> 
-                            </if> 
-                            <if> 
-                                <contains string="${should_attach}" substring="modify" /> 
-                                <then> 
-                                    <echo message="modify.${seqnum}.target.should_attach is not net.  Using default value: no." /> 
-                                    <var name="should_attach" unset="true"></var> 
-                                    <property name="should_attach" value="no" /> 
-                                </then> 
-                            </if> 
-                            <if> 
-                                <contains string="${chap_user}" substring="modify" /> 
-                                <then> 
-                                    <echo message="modify.${seqnum}.target.chap_user is not net.  Using default value: empty string." /> 
-                                    <var name="chap_user" unset="true"></var> 
-                                    <property name="chap_user" value="" /> 
-                                </then> 
-                            </if> 
-                            <if> 
-                                <contains string="${chap_password}" substring="modify" /> 
-                                <then> 
-                                    <echo message="modify.${seqnum}.target.chap_password is not net.  Using default value: empty string." /> 
-                                    <var name="chap_password" unset="true"></var> 
-                                    <property name="chap_password" value="" /> 
-                                </then> 
-                            </if> 
-                            <if> 
-                                <contains string="${fs.type}" substring="modify" /> 
-                                <then> 
-                                    <echo message="modify.${seqnum}.fs.type} is not net.  Using default value: empty string." /> 
-                                    <var name="fs.type}" unset="true"></var> 
-                                    <property name="fs.type}" value="" /> 
-                                </then> 
-                            </if> 
-                            <if> 
-                                <contains string="${options}" substring="modify" /> 
-                                <then> 
-                                    <echo message="modify.${seqnum}.target.options is not net.  Using default value: empty string." /> 
-                                    <var name="options" unset="true"></var> 
-                                    <property name="options" value="" /> 
-                                </then> 
-                            </if> 
-                            <if> 
-                                <contains string="${should_format}" substring="modify" /> 
-                                <then> 
-                                    <echo message="modify.${seqnum}.target.should_format is not net.  Using default value: no." /> 
-                                    <var name="should_format" unset="true"></var> 
-                                    <property name="should_format" value="=no" /> 
-                                </then> 
-                            </if> 
-                            <if> 
-                                <contains string="${mount_point}" substring="modify" /> 
-                                <then> 
-                                    <echo message="modify.${seqnum}.target.mount_point is not net.  Using default value: empty string." /> 
-                                    <var name="mount_point" unset="true"></var> 
-                                    <property name="mount_point" value="" /> 
-                                </then> 
-                            </if> 
-                            <if> 
-                                <contains string="${iscsi.initiator.iqn}" substring="modify" /> 
-                                <then> 
-                                    <echo message="modify.${seqnum}.iscsi.initiator.iqn is not net.  Using default value: empty string." /> 
-                                    <var name="iscsi.initiator.iqn" unset="true"></var> 
-                                    <property name="iscsi.initiator.iqn" value="" /> 
-                                </then> 
-                            </if> 
-                            <!-- adding storage property to userdata --> 
-                            <ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}" section="storage" key="dev.mod.@{seqnum}" value="${storage_type}:${target.ip}:${port}:${target.lun.num}:${chap_user}:${chap_password}:${should_attach}:${fs.type}:${options}:${should_format}:${mount_point}" /> 
-                            <loadfile property="neuca.ini" srcFile="${neuca.ini.file}" /> 
-                            <!-- adding iscsi.initiator.iqn property to userdata --> 
-                            <ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}" section="global" key="iscsi_initiator_iqn" value="${iscsi.initiator.iqn}" /> 
-                            <loadfile property="neuca.ini" srcFile="${neuca.ini.file}" /> 
-                        </then> 
-                    </if> 
-                    <!-- Finally update the userdata file  --> 
-                    <echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" /> 
-                    <echo message="update userdata instance: ${shirako.save.unit.ec2.instance}" /> 
-                    <var name="code" unset="true"></var> 
-                    <var name="update.userdata.output" unset="true"></var> 
-                    <exec executable="${ec2.scripts}/${cloud.type}-update-userdata" resultproperty="code" outputproperty="update.userdata.output"> 
-                        <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                        <env key="EC2_HOME" value="${ec2.home}" /> 
-                        <env key="EC2_DIR" value="${ec2.dir}" /> 
-                        <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                        <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                        <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                        <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                        <env key="NEUCA_INI" value="${neuca.ini.file}" /> 
-                        <env key="INSTANCE_ID" value="${shirako.save.unit.ec2.instance}" /> 
-                    </exec> 
-                    <echo message="after update userdata: exit code ${code}, ${update.userdata.output}" /> 
-                    <delete file="${neuca.ini.file}" /> 
-                </else> 
-            </if> 
-        </sequential> 
-    </macrodef> 
-    <!-- add network interface --> 
-    <target name="modify.addiface" depends="resolve.configuration"> 
-        <taskdef resource="orca/handlers/ec2/ec2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <echo message="ec2.site.properties path is ${ec2.site.properties}" /> 
-        <if> 
-            <isset property="ec2.site.properties" /> 
-            <then> 
-                <echo message="Setting ec2.site.properites from ${ec2.site.properties}" /> 
-                <property file="${ec2.site.properties}" /> 
-            </then> 
-        </if> 
-        <var name="code" unset="true"></var> 
-        <var name="message" unset="true"></var> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="EC2 HANDLER: MODIFY.ADDIFACE on ${start.TIME}" /> 
-        <echo message="modify.addiface: ec2 instance=${unit.ec2.instance}, modify sequence number ${shirako.save.unit.modify.sequencenum}" /> 
-        <if> 
-            <equals arg1="${ec2.debug}" arg2="true" /> 
-            <then> 
-                <echo message="********************************* modify.addiface (ALL PROPERTIES) *********************************" /> 
-                <echoproperties /> 
-                <echo message="**********************************************************************************" /> 
-            </then> 
-        </if> 
-        <modify.addiface seqnum="${shirako.save.unit.modify.sequencenum}" /> 
-        <property name="shirako.target.code" value="0" /> 
-        <echo message="modify.addiface exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- remove iface macro --> 
-    <macrodef name="modify.removeiface" description="remvoe a network iface via modify"> 
-        <attribute name="seqnum" description="sequence number" /> 
-        <sequential> 
-            <if> 
-                <equals arg1="${emulation}" arg2="true" /> 
-                <then> 
-                    <var name="iface.net.name" unset="true"></var> 
-                    <var name="iface.net.vlan" unset="true"></var> 
-                    <var name="iface.mac" unset="true"></var> 
-                    <echo>
-                         iface @{iface} 
-                    </echo> 
-                    <propertyregex property="iface.net.name" input="@{iface}" regexp="(.*)\..*\..*" replace="\1" casesensitive="false" /> 
-                    <propertyregex property="iface.net.vlan" input="@{iface}" regexp=".*\.(.*)\..*" replace="\1" casesensitive="false" /> 
-                    <propertyregex property="iface.mac" input="@{iface}" regexp=".*\..*\.(.*)" replace="\1" casesensitive="false" /> 
-                    <echo>
-                         quantum.tenant.id ${quantum.tenant.id} 
-                    </echo> 
-                    <echo>
-                         shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance} 
-                    </echo> 
-                    <echo>
-                         iface.mac ${iface.mac} 
-                    </echo> 
-                    <echo>
-                         iface.net.vlan ${iface.net.vlan} 
-                    </echo> 
-                    <echo>
-                         iface.net.name ${iface.net.name} 
-                    </echo> 
-                    <echo>
-                         unit.ec2.instance ${unit.ec2.instance} 
-                    </echo> 
-                    <echo message="Running under emulation...exiting" /> 
-                    <property name="shirako.target.code" value="0" /> 
-                </then> 
-                <else> 
-                    <!-- Actually do it... no emulation --> 
-                    <echo message="adding interfaces to instance" /> 
-                    <var name="message" unset="true"></var> 
-                    <echo message="vlan.tag = ${modify.@{seqnum}.vlan.tag}" /> 
-                    <echo message="ip = ${modify.@{seqnum}.ip}" /> 
-                    <echo message="mode = ${modify.@{seqnum}.mode}" /> 
-                    <echo message="hosteth = ${modify.@{seqnum}.hosteth}" /> 
-                    <echo message="mac = ${modify.@{seqnum}.mac}" /> 
-                    <echo message="state = ${modify.@{seqnum}.state}" /> 
-                    <echo message="ipversion = ${modify.@{seqnum}.ipversion}" /> 
-                    <!-- Get old userdata --> 
-                    <echo message="Creating account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" /> 
-                    <echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" /> 
-                    <echo message="LoginProperty : ${loginProperty}" /> 
-                    <echo message="KeysProperty : ${keysProperty}" /> 
-                    <echo message="SudoProperty : ${sudoProperty}" /> 
-                    <exec executable="${ec2.scripts}/${cloud.type}-get-userdata" resultproperty="icode" outputproperty="userdata.old"> 
-                        <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                        <env key="EC2_HOME" value="${ec2.home}" /> 
-                        <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                        <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                        <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                        <env key="EC2_DIR" value="${ec2.dir}" /> 
-                        <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                        <env key="EC2_SSH_KEY" value="${ec2.ssh.key}" /> 
-                        <arg value="${unit.ec2.instance}" /> 
-                    </exec> 
-                    <echo message="Exit code for get-userdata is ${icode}" /> 
-                    <echo message="Old userdata : ${userdata.old}" /> 
-                    <!-- setup userdata:  set userdataold the userdata string in order to parse and copy to ${neuca.ini.file} --> 
-                    <tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" /> 
-                    <echo message="neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" /> 
-                    <ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${userdata.old}" /> 
-                    <loadfile property="neuca.ini" srcFile="${neuca.ini.file}" /> 
-                    <echo message="neuca.ini: ${neuca.ini}" /> 
-                    <!-- process each iface to add --> 
-                    <exec executable="${ec2.scripts}/neuca-quantum-remove-vm-iface" resultproperty="code" outputproperty="add.iface.output"> 
-                        <env key="EC2_HOME" value="${ec2.home}" /> 
-                        <env key="EC2_DIR" value="${ec2.dir}" /> 
-                        <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                        <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                        <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                        <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                        <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                        <env key="QUANTUM_NET_INSTANCE_NAME" value="${unit.ec2.instance}" /> 
-                        <env key="QUANTUM_NET_IFACE_MAC" value="${modify.@{seqnum}.mac}" /> 
-                        <env key="QUANTUM_NET_NETWORK" value="${modify.@{seqnum}.hosteth}" /> 
-                        <env key="QUANTUM_NET_VLAN" value="${modify.@{seqnum}.vlan.tag}" /> 
-                    </exec> 
-                    <echo>
-                         result code: ${code} 
-                    </echo> 
-                    <echo>
-                         output: ${add.iface.output} 
-                    </echo> 
-                    <!-- add property to userdata file TODO: add actual config values --> 
-                    <ec2.removeproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}" section="interfaces" key="${modify.@{seqnum}.mac}" /> 
-                    <loadfile property="neuca.ini" srcFile="${neuca.ini.file}" /> 
-                    <!-- update the userdata file  --> 
-                    <echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" /> 
-                    <echo message="update userdata instance: ${shirako.save.unit.ec2.instance}" /> 
-                    <var name="code" unset="true"></var> 
-                    <var name="update.userdata.output" unset="true"></var> 
-                    <exec executable="${ec2.scripts}/${cloud.type}-update-userdata" resultproperty="code" outputproperty="update.userdata.output"> 
-                        <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                        <env key="EC2_HOME" value="${ec2.home}" /> 
-                        <env key="EC2_DIR" value="${ec2.dir}" /> 
-                        <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                        <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                        <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                        <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                        <env key="NEUCA_INI" value="${neuca.ini.file}" /> 
-                        <env key="INSTANCE_ID" value="${shirako.save.unit.ec2.instance}" /> 
-                    </exec> 
-                    <echo message="after update userdata: exit code ${code}, ${update.userdata.output}" /> 
-                    <delete file="${neuca.ini.file}" /> 
-                </else> 
-            </if> 
-        </sequential> 
-    </macrodef> 
-    <!-- add network interface --> 
-    <target name="modify.removeiface" depends="resolve.configuration"> 
-        <taskdef resource="orca/handlers/ec2/ec2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <echo message="ec2.site.properties path is ${ec2.site.properties}" /> 
-        <if> 
-            <isset property="ec2.site.properties" /> 
-            <then> 
-                <echo message="Setting ec2.site.properites from ${ec2.site.properties}" /> 
-                <property file="${ec2.site.properties}" /> 
-            </then> 
-        </if> 
-        <var name="code" unset="true"></var> 
-        <var name="message" unset="true"></var> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="EC2 HANDLER: MODIFY.REMOVEIFACE on ${start.TIME}" /> 
-        <echo message="modify.removeiface: ec2 instance=${unit.ec2.instance}, modify sequence number ${shirako.save.unit.modify.sequencenum}" /> 
-        <modify.removeiface seqnum="${shirako.save.unit.modify.sequencenum}" /> 
-        <property name="shirako.target.code" value="0" /> 
-        <echo message="modify.removeiface exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- leave target --> 
-    <target name="leave" depends="resolve.configuration"> 
-        <taskdef resource="orca/handlers/ec2/ec2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="EC2 HANDLER: LEAVE on ${start.TIME}" /> 
-        <echo message="leave: ec2 instance=${unit.ec2.instance}" /> 
-        <!-- set site-specific properties like the VLAN or PHYS mode
+												-->
+												<echo message="configuring ${proxy.type} SSH proxy for ${shirako.save.unit.manage.ip} via host ${proxy.proxy.ip}" />
+												<var name="code" unset="true" />
+												<var name="message" unset="true" />
+												<exec executable="${ec2.scripts}/start-proxy" resultproperty="code" outputproperty="proxy.script.output">
+													<env key="PROXY_TYPE" value="${proxy.type}" />
+													<env key="PROXY_PROXY_IP" value="${proxy.proxy.ip}" />
+													<env key="PROXY_INSTANCE_IP" value="${shirako.save.unit.manage.ip}" />
+													<env key="PROXY_USER" value="${proxy.user}" />
+													<env key="PROXY_SSH_KEY" value="${proxy.ssh.key}" />
+													<env key="PROXY_SCRIPT_PATH" value="${proxy.script.path}" />
+												</exec>
+												<if>
+													<equals arg1="${code}" arg2="0" />
+													<then>
+														<var name="shirako.save.unit.manage.ip" unset="true" />
+														<var name="shirako.save.unit.manage.port" unset="true" />
+														<propertyregex property="shirako.save.unit.manage.ip" input="${proxy.script.output}" regexp="([^:]+):([0123456789]+)" select="\1" casesensitive="false" />
+														<propertyregex property="shirako.save.unit.manage.port" input="${proxy.script.output}" regexp="([^:]+):([0123456789]+)" select="\2" casesensitive="false" />
+														<echo message="proxy configuration created on ${shirako.save.unit.manage.ip}:${shirako.save.unit.manage.port}" />
+													</then>
+													<else>
+														<echo message="start-proxy failed with exit code: ${code} ${proxy.script.output}" />
+														<property name="message" value="start-proxy failed with exit code: ${code} ${proxy.script.output}" />
+														<echo message="terminating instance: ${shirako.save.unit.ec2.instance}" />
+														<!-- be sure not to save exit code (renamed nocode), since we don't care here if stop exits successfully -->
+														<exec executable="${ec2.scripts}/${cloud.type}-stop" resultproperty="nocode" outputproperty="terminate.instance.output">
+															<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+															<env key="EC2_HOME" value="${ec2.home}" />
+															<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+															<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+															<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+															<env key="EC2_DIR" value="${ec2.dir}" />
+															<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+															<env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" />
+															<env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" />
+															<arg value="${shirako.save.unit.ec2.instance}" />
+														</exec>
+													</else>
+												</if>
+											</then>
+										</if>
+									</then>
+								</if>
+	
+								<!-- create the NEUCA INI file -->
+								<tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" />
+								<echo message="neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" />
+								<ec2.generate.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" outputproperty="iface.list" />
+								<echo message="iface.list = ${iface.list}" />
+								<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+								<echo message="neuca.ini: ${neuca.ini}" />
+
+								<!-- if neuca-quantum, add interfaces -->
+								<if>
+									<equals arg1="${cloud.type}" arg2="nova-essex" />
+									<then>
+										<echo message="iface list: ${iface.list}" />
+										<var name="instance.quantum.ifaces" unset="true" />
+										<for list="${iface.list}" param="iface" delimiter=" " parallel="false">
+											<sequential>
+												<var name="iface.net.name" unset="true" />
+												<var name="iface.net.vlan" unset="true" />
+												<var name="iface.mac" unset="true" />
+												<echo>iface @{iface}</echo>
+												<propertyregex property="iface.net.name" input="@{iface}" regexp="(.*)\..*\..*" replace="\1" casesensitive="false" />
+
+												<propertyregex property="iface.net.vlan" input="@{iface}" regexp=".*\.(.*)\..*" replace="\1" casesensitive="false" />
+
+												<propertyregex property="iface.mac" input="@{iface}" regexp=".*\..*\.(.*)" replace="\1" casesensitive="false" />
+												<echo>quantum.tenant.id ${quantum.tenant.id}</echo>
+												<echo>shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance}</echo>
+												<echo>iface.mac ${iface.mac}</echo>
+												<echo>iface.net.vlan ${iface.net.vlan}</echo>
+												<echo>iface.net.name ${iface.net.name}</echo>
+
+												<var name="code" unset="true" />
+												<var name="add.iface.output" unset="true" />
+												<echo message="EC2_HOME ${ec2.home}" />
+												<echo message="EC2_DIR ${ec2.dir}" />
+												<echo message="EUCA_KEY_DIR=${ec2.keys}" />
+												<echo message="EC2_LOG_DIR ${ec2.log.dir}" />
+												<echo message="EC2_LOG_FILE ${ec2.log.file}" />
+												<echo message="EC2_LOG_LEVEL ${ec2.log.level}" />
+												<echo message="QUANTUM_TENANT_ID ${quantum.tenant.id}" />
+												<echo message="QUANTUM_NET_INSTANCE_NAME ${shirako.save.unit.ec2.instance}" />
+												<echo message="QUANTUM_NET_IFACE_MAC ${iface.mac}" />
+												<echo message="QUANTUM_NET_NETWORK ${iface.net.name}" />
+												<echo message="QUANTUM_NET_VLAN ${iface.net.vlan}" />
+
+												<exec executable="${ec2.scripts}/neuca-quantum-add-iface" resultproperty="code" outputproperty="add.iface.output">
+													<env key="EC2_HOME" value="${ec2.home}" />
+													<env key="EC2_DIR" value="${ec2.dir}" />
+													<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+													<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+													<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+													<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+													<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+													<env key="QUANTUM_NET_INSTANCE_NAME" value="${shirako.save.unit.ec2.instance}" />
+													<env key="QUANTUM_NET_IFACE_MAC" value="${iface.mac}" />
+													<env key="QUANTUM_NET_NETWORK" value="${iface.net.name}" />
+													<env key="QUANTUM_NET_VLAN" value="${iface.net.vlan}" />
+												</exec>
+												<echo>result code: ${code}</echo>
+												<echo>output: ${add.iface.output}</echo>
+												<if>
+													<isset property="instance.quantum.ifaces" />
+													<then>
+														<var name="instance.quantum.ifaces.tmp" unset="true" />
+														<property name="instance.quantum.ifaces.tmp" value="${instance.quantum.ifaces}" />
+														<var name="instance.quantum.ifaces" unset="true" />
+														<property name="instance.quantum.ifaces" value="${instance.quantum.ifaces.tmp},${add.iface.output}" />
+													</then>
+													<else>
+														<property name="instance.quantum.ifaces" value="${add.iface.output}" />
+													</else>
+												</if>
+											</sequential>
+										</for>
+										<property name="shirako.save.unit.quantum.ifaces" value="${instance.quantum.ifaces}" />
+										<echo>shirako.save.unit.quantum.ifaces: ${shirako.save.unit.quantum.ifaces}</echo>
+									</then>
+								</if>
+	
+	
+								<!-- update the userdata file  -->
+								<echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" />
+								<echo message="update userdata instance: ${shirako.save.unit.ec2.instance}" />
+								<var name="code" unset="true" />
+								<var name="update.userdata.output" unset="true" />
+								<exec executable="${ec2.scripts}/${cloud.type}-update-userdata" resultproperty="code" outputproperty="update.userdata.output">
+									<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+									<env key="EC2_HOME" value="${ec2.home}" />
+									<env key="EC2_DIR" value="${ec2.dir}" />
+									<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+									<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+									<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+									<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+									<env key="NEUCA_INI" value="${neuca.ini.file}" />
+									<env key="INSTANCE_ID" value="${shirako.save.unit.ec2.instance}" />
+								</exec>
+								<echo message="after update userdata: exit code ${code}, ${update.userdata.output}" />
+
+								<delete file="${neuca.ini.file}" />
+	
+							</else>
+						</if>
+					</else>
+				</if>
+				</else>
+			</if>
+				<property name="shirako.target.code" value="${code}" />
+				<if>
+					<isset property="message" />
+					<then>
+						<property name="shirako.target.code.message" value="${message}" />
+					</then>
+					<else>
+						<property name="shirako.target.code.message" value="none" />
+					</else>
+				</if>
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<!-- Various Modify Operations -->
+	
+	<!-- Useful macros -->
+	<macrodef name="modify.ssh" description="install new SSH keys via modify">
+		<attribute name="seqnum" description="sequence number"/>
+		<sequential>
+			<if>
+				<equals arg1="${emulation}" arg2="true" />
+				<then>
+					<for list="${modify.@{seqnum}.config.ssh.numlogins}" param="iter" delimiter="," parallel="false">
+						<sequential>
+							<var name="loginProperty" unset="true" />
+							<var name="keysProperty" unset="true" />
+							<var name="sudoProperty" unset="true" />
+						
+							<property name="loginProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.login}" />
+							<property name="keysProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.keys}" />
+							<property name="sudoProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.sudo}" />
+						
+							<echo message="About to create account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" />
+						</sequential>
+					</for>
+					<echo message="Running under emulation...exiting" />
+					<property name="shirako.target.code" value="0" />
+				</then>
+				<else>
+					<echo message="installing ${modify.@{seqnum}.config.ssh.numlogins} user keys and accounts in the instance" />
+					<var name="message" unset="true" />
+
+					<!-- re-create the NEUCA INI file -->
+					<echo message="Creating account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" />
+										<echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" />
+										<echo message="LoginProperty : ${loginProperty}" />
+										<echo message="KeysProperty : ${keysProperty}" />
+										<echo message="SudoProperty : ${sudoProperty}" />
+										<exec executable="${ec2.scripts}/${cloud.type}-get-userdata" resultproperty="icode" outputproperty="userdata.old" >
+											  <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+											  <env key="EC2_HOME" value="${ec2.home}" />
+											  <env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+											  <env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+											  <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+											  <env key="EC2_DIR" value="${ec2.dir}" />
+											  <env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+											  <env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
+											  <arg value="${unit.ec2.instance}" />
+										</exec>
+										<echo message="Exit code for get-userdata is ${icode}" />
+					<echo message="Old userdata : ${userdata.old}" />
+					
+					<!-- setup userdata:  set userdataold the userdata string in order to parse and copy to ${neuca.ini.file} -->
+					<tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" />
+										<echo message="neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" />
+										<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${userdata.old}" />
+										<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+										<echo message="neuca.ini: ${neuca.ini}" />
+
+					<!-- add keys -->
+					<echo message="Modify.ssh, numlogins : ${modify.@{seqnum}.config.ssh.numlogins} " />
+					<for list="${modify.@{seqnum}.config.ssh.numlogins}" param="iter" delimiter="," parallel="false">
+
+						<sequential>
+								<var name="icode" unset="true" />
+							<var name="loginProperty" unset="true" />
+							<var name="keysProperty" unset="true" />
+							<var name="sudoProperty" unset="true" />
+				
+							<property name="loginProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.login}" />
+							<property name="keysProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.keys}" />
+							<property name="sudoProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.sudo}" />
+
+							<echo message="Creating account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" />
+							<echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" />
+							<echo message="LoginProperty : ${loginProperty}" />
+							<echo message="KeysProperty : ${keysProperty}" />
+							<echo message="SudoProperty : ${sudoProperty}" />
+
+							<!-- add key to userdata:  setuserdataold to ${neuca.ini.file} to read from file -->
+														<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}"  section="users" key="${loginProperty}" value="${keysProperty}" />
+														<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+														<echo message="neuca.ini: ${neuca.ini}" />
+
+							<!-- add key to VM -->
+							<exec executable="${ec2.scripts}/${cloud.type}-prepare-key" resultproperty="icode">
+								<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+								<env key="EC2_HOME" value="${ec2.home}" />
+								<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+								<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+								<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+								<env key="EC2_DIR" value="${ec2.dir}" />
+								<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+								<env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
+								<env key="EC2_SSH_TIMEOUT" value="${ec2.ssh.timeout}" />
+								<env key="AMI_NAME" value="${ec2.ami.name}" />
+								<env key="AKI_NAME" value="${ec2.aki.name}" />
+								<env key="ARI_NAME" value="${ec2.ari.name}" />
+								<arg value="${unit.manage.ip}" />
+								<arg value="${loginProperty}" />
+								<arg value="${keysProperty}" />
+								<arg value="${sudoProperty}" />
+							</exec>
+							<echo message="Exit code for login ${loginProperty} is ${icode}" />
+							<if>
+								<not>
+									<equals arg1="${icode}" arg2="0" />
+								</not>
+								<then>
+									<fail message="Unable to create account ${loginProperty}, failing" />
+								</then>
+							</if>
+						</sequential>
+					</for>
+
+					<!-- update the userdata file  -->
+					<echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" />
+										<echo message="update userdata instance: ${shirako.save.unit.ec2.instance}" />
+										<var name="code" unset="true" />
+										<var name="update.userdata.output" unset="true" />
+										<exec executable="${ec2.scripts}/${cloud.type}-update-userdata" resultproperty="code" outputproperty="update.userdata.output">
+											 <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+											 <env key="EC2_HOME" value="${ec2.home}" />
+											 <env key="EC2_DIR" value="${ec2.dir}" />
+											 <env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+											 <env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+											 <env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+											 <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+											 <env key="NEUCA_INI" value="${neuca.ini.file}" />
+											 <env key="INSTANCE_ID" value="${shirako.save.unit.ec2.instance}" />
+										</exec>
+										<echo message="after update userdata: exit code ${code}, ${update.userdata.output}" />
+					
+										<delete file="${neuca.ini.file}" />
+
+				</else>
+			</if>
+		</sequential>
+	</macrodef>
+	
+	<!-- add logins -->
+	<target name="modify.ssh"  depends="resolve.configuration">
+		<taskdef resource="orca/handlers/ec2/ec2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+		<echo message="ec2.site.properties path is ${ec2.site.properties}" />
+
+				<if>
+						<isset property="ec2.site.properties" />
+						<then>
+							<echo message="Setting ec2.site.properites from ${ec2.site.properties}" /> 
+							<property file="${ec2.site.properties}" />
+						</then>
+				</if>
+
+		<var name="code" unset="true" />
+				<var name="message" unset="true" />
+
+	
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+	
+		<echo message="EC2 HANDLER: MODIFY.SSH on ${start.TIME}" />
+		<echo message="modify.ssh: ec2 instance=${unit.ec2.instance}, modify sequence number ${shirako.save.unit.modify.sequencenum}" />
+		
+		<modify.ssh seqnum="${shirako.save.unit.modify.sequencenum}"/> 
+		
+		<property name="shirako.target.code" value="0" />
+		<echo message="modify.ssh exit code: ${shirako.target.code}" />
+	</target>
+
+	<!-- add iface macro -->
+	<macrodef name="modify.addiface" description="add a new network iface via modify">
+		<attribute name="seqnum" description="sequence number"/>
+
+		<sequential>
+			<if>
+				<equals arg1="${emulation}" arg2="true" />
+				<then>
+						<var name="iface.net.name" unset="true" />
+					<var name="iface.net.vlan" unset="true" />
+					<var name="iface.mac" unset="true" />
+					<echo>iface @{iface}</echo>
+					<propertyregex property="iface.net.name" input="@{iface}" regexp="(.*)\..*\..*" replace="\1" casesensitive="false" />
+					<propertyregex property="iface.net.vlan" input="@{iface}" regexp=".*\.(.*)\..*" replace="\1" casesensitive="false" />
+					<propertyregex property="iface.mac" input="@{iface}" regexp=".*\..*\.(.*)" replace="\1" casesensitive="false" />
+					<echo>quantum.tenant.id ${quantum.tenant.id}</echo>
+										<echo>shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance}</echo>
+					<echo>iface.mac ${iface.mac}</echo>
+					<echo>iface.net.vlan ${iface.net.vlan}</echo>
+					<echo>iface.net.name ${iface.net.name}</echo>
+					<echo>unit.ec2.instance ${unit.ec2.instance}</echo>
+						
+					<echo message="Running under emulation...exiting" />
+					<property name="shirako.target.code" value="0" />
+				</then>
+				<else>  
+					<!-- Actually do it... no emulation -->
+					<echo message="adding interfaces to instance" />
+					<var name="message" unset="true" />
+
+						   
+					<echo message="vlan.tag = ${modify.@{seqnum}.vlan.tag}" />
+					<echo message="ip = ${modify.@{seqnum}.ip}" />
+					<echo message="mode = ${modify.@{seqnum}.mode}" />
+					<echo message="hosteth = ${modify.@{seqnum}.hosteth}" />
+					<echo message="mac = ${modify.@{seqnum}.mac}" />
+					<echo message="state = ${modify.@{seqnum}.state}" />
+					<echo message="ipversion = ${modify.@{seqnum}.ipversion}" />
+
+
+					<property name="ip" value="${modify.@{seqnum}.ip}" />
+					<property name="state" value="${modify.@{seqnum}.state}" />
+					<property name="ipversion" value="${modify.@{seqnum}.ipversion}" />
+
+					<echo message="ip after setting to modify.x.ip = ${ip}" />
+
+					<!-- set defaults for unset properties -->
+					<!-- <if> <not><isset property="${modify.@{seqnum}.ip}"/></not> -->
+					<if> <contains string="${ip}" substring="modify"/>
+					<then>
+						<echo message="modify.${seqnum}.ip is not net.  Using default value: empty string." />
+						<var name="ip" unset="true" />
+						<property name="ip" value="" />
+					</then>
+					</if>
+
+					<if> <contains string="${state}" substring="modify"/>
+					<then>
+						<echo message="modify.${seqnum}.state is not net.  Using default value: up." />
+						<var name="state" unset="true" />
+						<property name="state" value="up" />
+					</then>
+					</if>
+
+					<if> <contains string="${ipversion}" substring="modify"/>
+					<then>
+						<echo message="modify.${seqnum}.ipversion is not net.  Using default value: ipv4." />
+						<var name="ipversion" unset="true" />
+						<property name="ipversion" value="ipv4" />
+					</then>
+					</if>
+
+
+					<!-- Get old userdata -->
+					<echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" />
+					<echo message="LoginProperty : ${loginProperty}" />
+					<echo message="KeysProperty : ${keysProperty}" />
+					<echo message="SudoProperty : ${sudoProperty}" />
+					<exec executable="${ec2.scripts}/${cloud.type}-get-userdata" resultproperty="icode" outputproperty="userdata.old" >
+						<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+						<env key="EC2_HOME" value="${ec2.home}" />
+						<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+						<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+						<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+						<env key="EC2_DIR" value="${ec2.dir}" />
+						<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+						<env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
+						<arg value="${unit.ec2.instance}" />
+					</exec>
+					<echo message="Exit code for get-userdata is ${icode}" />
+					<echo message="Old userdata : ${userdata.old}" />
+					
+					<!-- setup userdata:  set userdataold the userdata string in order to parse and copy to ${neuca.ini.file} -->
+					<tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" />
+					<echo message="neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" />
+					<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${userdata.old}" />
+					<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+					<echo message="neuca.ini: ${neuca.ini}" />
+
+					
+					<!-- process each iface to add -->
+					<exec executable="${ec2.scripts}/neuca-quantum-add-iface" resultproperty="code" outputproperty="add.iface.output">
+					  	<env key="EC2_HOME" value="${ec2.home}" />
+					  	<env key="EC2_DIR" value="${ec2.dir}" />
+					  	<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+					  	<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+					  	<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+					  	<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+					  	<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+					  	<env key="QUANTUM_NET_INSTANCE_NAME" value="${unit.ec2.instance}" />
+					  	<env key="QUANTUM_NET_IFACE_MAC" value="${modify.@{seqnum}.mac}" />
+					  	<env key="QUANTUM_NET_NETWORK" value="${modify.@{seqnum}.hosteth}" />
+					  	<env key="QUANTUM_NET_VLAN" value="${modify.@{seqnum}.vlan.tag}" />
+					</exec>
+					<echo>result code: ${code}</echo>
+					<echo>output: ${add.iface.output}</echo>
+						  
+					<!-- add properties to userdata file -->
+					<echo message="About to update userdata file: "/>
+					<echo message="mac        :  ${modify.@{seqnum}.mac}" />
+					<echo message="state      :  ${state}" />
+					<echo message="ipversion  :  ${ipversion}" />
+					<echo message="ip         :  ${ip}" />
+
+					<!-- adding network property to userdata -->
+					<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}"  section="interfaces" key="${modify.@{seqnum}.mac}" value="${state}:${ipversion}:${ip}" /> 
+					<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+					
+
+					<!-- Possibly add storage info to userdata -->
+					<echo message="storage_type = ${modify.@{seqnum}.type}" />
+					<echo message="port = ${modify.@{seqnum}.target.port}" />
+					<echo message="target.ip = ${modify.@{seqnum}.target.ip}" />
+
+					<property name="storage_type"  value="${modify.@{seqnum}.type}" />
+					<property name="port"  value="${modify.@{seqnum}.target.port}" />
+					<property name="target.ip"  value="${modify.@{seqnum}.target.ip}" />
+					<if> 
+						<and>
+							<not><contains string="${storage_type}" substring="modify"/></not>
+							<not><contains string="${port}" substring="modify"/></not>
+							<not><contains string="${target.ip}" substring="modify"/></not>
+						</and>
+					<then>
+						<!-- We need to add storage info to userdata -->
+						<echo message="Adding storage info to userdata"/>
+
+						<echo message="chap_password = ${modify.@{seqnum}.target.chap_password}" />
+						<echo message="chap_user = ${modify.@{seqnum}.target.chap_user}" />
+						<echo message="iscsi.initiator.iqn = ${modify.@{seqnum}.iscsi.initiator.iqn}" />
+						<echo message="lun.guid = ${modify.@{seqnum}.target.lun.guid}" />
+						<echo message="mount_point = ${modify.@{seqnum}.target.mount_point}" />
+						<echo message="options = ${modify.@{seqnum}.target.options}" />
+						<echo message="port = ${modify.@{seqnum}.target.port}" />
+						<echo message="should_attach = ${modify.@{seqnum}.target.should_attach}" />
+						<echo message="should_format = ${modify.@{seqnum}.target.should_format}" />
+						<echo message="target.ip = ${modify.@{seqnum}.target.ip}" />
+						<echo message="target.lun.num = ${modify.@{seqnum}.target.lun.num}" />
+						<echo message="storage_type = ${modify.@{seqnum}.type}" />
+
+						<property name="chap_password"  value="${modify.@{seqnum}.target.chap_password}" />
+						<property name="chap_user"  value="${modify.@{seqnum}.target.chap_user}" />
+						<property name="iscsi.initiator.iqn"  value="${modify.@{seqnum}.iscsi.initiator.iqn}" />
+						<property name="lun.guid"  value="${modify.@{seqnum}.target.lun.guid}" />
+						<property name="mount_point"  value="${modify.@{seqnum}.target.mount_point}" />
+						<property name="options"  value="${modify.@{seqnum}.target.options}" />
+						<!-- <property name="port"  value="${modify.@{seqnum}.target.port}" /> -->
+						<property name="should_attach"  value="${modify.@{seqnum}.target.should_attach}" />
+						<property name="should_format"  value="${modify.@{seqnum}.target.should_format}" />
+						<!-- <property name="target.ip"  value="${modify.@{seqnum}.target.ip}" /> -->
+						<property name="target.lun.num"  value="${modify.@{seqnum}.target.lun.num}" />
+						<!-- <property name="type"  value="${modify.@{seqnum}.type}" /> -->
+						<property name="fs.type"  value="${modify.@{seqnum}.fs.type}" /> 
+
+						<!-- set defaults for unset properties -->
+						<if> <contains string="${target.lun.num}" substring="modify"/>
+						<then>
+							<echo message="modify.${seqnum}.target.lun.num  is not net.  Using default value: 0." />
+							<var name="target.lun.num " unset="true" />
+							<property name="target.lun.num " value="0" />
+						</then>
+						</if>
+
+						<if> <contains string="${should_attach}" substring="modify"/>
+						<then>
+							<echo message="modify.${seqnum}.target.should_attach is not net.  Using default value: no." />
+							<var name="should_attach" unset="true" />
+							<property name="should_attach" value="no" />
+						</then>
+						</if>
+
+						<if> <contains string="${chap_user}" substring="modify"/>
+						<then>
+							<echo message="modify.${seqnum}.target.chap_user is not net.  Using default value: empty string." />
+							<var name="chap_user" unset="true" />
+							<property name="chap_user" value="" />
+						</then>
+						</if>
+
+						<if> <contains string="${chap_password}" substring="modify"/>
+						<then>
+							<echo message="modify.${seqnum}.target.chap_password is not net.  Using default value: empty string." />
+							<var name="chap_password" unset="true" />
+							<property name="chap_password" value="" />
+						</then>
+						</if>
+
+						<if> <contains string="${fs.type}" substring="modify"/>
+						<then>
+							<echo message="modify.${seqnum}.fs.type} is not net.  Using default value: empty string." />
+							<var name="fs.type}" unset="true" />
+							<property name="fs.type}" value="" />
+						</then>
+						</if>
+
+						<if> <contains string="${options}" substring="modify"/>
+						<then>
+							<echo message="modify.${seqnum}.target.options is not net.  Using default value: empty string." />
+							<var name="options" unset="true" />
+							<property name="options" value="" />
+						</then>
+						</if>
+
+						<if> <contains string="${should_format}" substring="modify"/>
+						<then>
+							<echo message="modify.${seqnum}.target.should_format is not net.  Using default value: no." />
+							<var name="should_format" unset="true" />
+							<property name="should_format" value="=no" />
+						</then>
+						</if>
+
+						<if> <contains string="${mount_point}" substring="modify"/>
+						<then>
+							<echo message="modify.${seqnum}.target.mount_point is not net.  Using default value: empty string." />
+							<var name="mount_point" unset="true" />
+							<property name="mount_point" value="" />
+						</then>
+						</if>
+
+						<if> <contains string="${iscsi.initiator.iqn}" substring="modify"/>
+						<then>
+							<echo message="modify.${seqnum}.iscsi.initiator.iqn is not net.  Using default value: empty string." />
+							<var name="iscsi.initiator.iqn" unset="true" />
+							<property name="iscsi.initiator.iqn" value="" />
+						</then>
+						</if>
+
+						<!-- adding storage property to userdata -->
+						<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}"  section="storage" key="dev.mod.@{seqnum}" value="${storage_type}:${target.ip}:${port}:${target.lun.num}:${chap_user}:${chap_password}:${should_attach}:${fs.type}:${options}:${should_format}:${mount_point}" /> 
+						<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+
+						<!-- adding iscsi.initiator.iqn property to userdata -->
+						<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}"  section="global" key="iscsi_initiator_iqn" value="${iscsi.initiator.iqn}" /> 
+						<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+
+					</then>
+					</if>
+			
+					<!-- Finally update the userdata file  -->
+					<echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" />
+					<echo message="update userdata instance: ${shirako.save.unit.ec2.instance}" />
+					<var name="code" unset="true" />
+					<var name="update.userdata.output" unset="true" />
+					<exec executable="${ec2.scripts}/${cloud.type}-update-userdata" resultproperty="code" outputproperty="update.userdata.output">
+						<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+						<env key="EC2_HOME" value="${ec2.home}" />
+						<env key="EC2_DIR" value="${ec2.dir}" />
+						<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+						<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+						<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+						<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+						<env key="NEUCA_INI" value="${neuca.ini.file}" />
+						<env key="INSTANCE_ID" value="${shirako.save.unit.ec2.instance}" />
+					</exec>
+					<echo message="after update userdata: exit code ${code}, ${update.userdata.output}" />
+					<delete file="${neuca.ini.file}" />
+
+				</else>
+			</if>
+		</sequential>
+	</macrodef>
+
+
+	<!-- add network interface -->
+	<target name="modify.addiface"  depends="resolve.configuration">
+		<taskdef resource="orca/handlers/ec2/ec2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+
+		<echo message="ec2.site.properties path is ${ec2.site.properties}" />
+
+		<if>
+			<isset property="ec2.site.properties" />
+			<then>
+				<echo message="Setting ec2.site.properites from ${ec2.site.properties}" />
+				<property file="${ec2.site.properties}" />
+			</then>
+		</if>
+
+		<var name="code" unset="true" />
+		<var name="message" unset="true" />
+
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="EC2 HANDLER: MODIFY.ADDIFACE on ${start.TIME}" />
+		<echo message="modify.addiface: ec2 instance=${unit.ec2.instance}, modify sequence number ${shirako.save.unit.modify.sequencenum}" />
+
+		<if>
+			<equals arg1="${ec2.debug}" arg2="true" />
+			<then>
+				<echo message="********************************* modify.addiface (ALL PROPERTIES) *********************************" />
+				<echoproperties/>
+				<echo message="**********************************************************************************" />
+			</then>
+		</if>
+
+		<modify.addiface seqnum="${shirako.save.unit.modify.sequencenum}"/>
+
+		<property name="shirako.target.code" value="0" />
+		<echo message="modify.addiface exit code: ${shirako.target.code}" />
+	</target>
+
+
+	<!-- remove iface macro -->
+	<macrodef name="modify.removeiface" description="remvoe a network iface via modify">
+		<attribute name="seqnum" description="sequence number"/>
+
+		<sequential>
+			<if>
+				<equals arg1="${emulation}" arg2="true" />
+				<then>
+						<var name="iface.net.name" unset="true" />
+					<var name="iface.net.vlan" unset="true" />
+					<var name="iface.mac" unset="true" />
+					<echo>iface @{iface}</echo>
+					<propertyregex property="iface.net.name" input="@{iface}" regexp="(.*)\..*\..*" replace="\1" casesensitive="false" />
+					<propertyregex property="iface.net.vlan" input="@{iface}" regexp=".*\.(.*)\..*" replace="\1" casesensitive="false" />
+					<propertyregex property="iface.mac" input="@{iface}" regexp=".*\..*\.(.*)" replace="\1" casesensitive="false" />
+					<echo>quantum.tenant.id ${quantum.tenant.id}</echo>
+					<echo>shirako.save.unit.ec2.instance ${shirako.save.unit.ec2.instance}</echo>
+					<echo>iface.mac ${iface.mac}</echo>
+					<echo>iface.net.vlan ${iface.net.vlan}</echo>
+					<echo>iface.net.name ${iface.net.name}</echo>
+					<echo>unit.ec2.instance ${unit.ec2.instance}</echo>
+						
+					<echo message="Running under emulation...exiting" />
+					<property name="shirako.target.code" value="0" />
+				</then>
+				<else>  
+					<!-- Actually do it... no emulation -->
+					<echo message="adding interfaces to instance" />
+					<var name="message" unset="true" />
+		   
+					<echo message="vlan.tag = ${modify.@{seqnum}.vlan.tag}" />
+					<echo message="ip = ${modify.@{seqnum}.ip}" />
+					<echo message="mode = ${modify.@{seqnum}.mode}" />
+					<echo message="hosteth = ${modify.@{seqnum}.hosteth}" />
+					<echo message="mac = ${modify.@{seqnum}.mac}" />
+					<echo message="state = ${modify.@{seqnum}.state}" />
+					<echo message="ipversion = ${modify.@{seqnum}.ipversion}" />
+					
+					<!-- Get old userdata -->
+					<echo message="Creating account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" />
+					<echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" />
+					<echo message="LoginProperty : ${loginProperty}" />
+					<echo message="KeysProperty : ${keysProperty}" />
+					<echo message="SudoProperty : ${sudoProperty}" />
+					<exec executable="${ec2.scripts}/${cloud.type}-get-userdata" resultproperty="icode" outputproperty="userdata.old" >
+						<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+						<env key="EC2_HOME" value="${ec2.home}" />
+						<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+						<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+						<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+						<env key="EC2_DIR" value="${ec2.dir}" />
+						<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+						<env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
+						<arg value="${unit.ec2.instance}" />
+					</exec>
+					<echo message="Exit code for get-userdata is ${icode}" />
+					<echo message="Old userdata : ${userdata.old}" />
+					
+					<!-- setup userdata:  set userdataold the userdata string in order to parse and copy to ${neuca.ini.file} -->
+					<tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" prefix="neuca" suffix=".ini" deleteonexit="false" />
+										<echo message="neuca.ini.file: ${neuca.ini.file}, cloud.type: ${cloud.type}" />
+										<ec2.addproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${userdata.old}" />
+										<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+										<echo message="neuca.ini: ${neuca.ini}" />
+					
+					<!-- process each iface to add -->
+					<exec executable="${ec2.scripts}/neuca-quantum-remove-vm-iface" resultproperty="code" outputproperty="add.iface.output">
+					  <env key="EC2_HOME" value="${ec2.home}" />
+					  <env key="EC2_DIR" value="${ec2.dir}" />
+					  <env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+					  <env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+					  <env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+					  <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+					  <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+					  <env key="QUANTUM_NET_INSTANCE_NAME" value="${unit.ec2.instance}" />
+					  <env key="QUANTUM_NET_IFACE_MAC" value="${modify.@{seqnum}.mac}" />
+					  <env key="QUANTUM_NET_NETWORK" value="${modify.@{seqnum}.hosteth}" />
+					  <env key="QUANTUM_NET_VLAN" value="${modify.@{seqnum}.vlan.tag}" />
+					</exec>
+					<echo>result code: ${code}</echo>
+					<echo>output: ${add.iface.output}</echo>
+						  
+					<!-- add property to userdata file TODO: add actual config values -->
+					<ec2.removeproperty.neuca.inf file="${neuca.ini.file}" cloudtype="${cloud.type}" userdataold="${neuca.ini.file}"  section="interfaces" key="${modify.@{seqnum}.mac}" /> 
+										<loadfile property="neuca.ini" srcFile="${neuca.ini.file}" />
+						  
+									
+					<!-- update the userdata file  -->
+					<echo message="EC2_SITE_PROPERTIES=${ec2.site.properties}" />
+					<echo message="update userdata instance: ${shirako.save.unit.ec2.instance}" />
+					<var name="code" unset="true" />
+					<var name="update.userdata.output" unset="true" />
+					<exec executable="${ec2.scripts}/${cloud.type}-update-userdata" resultproperty="code" outputproperty="update.userdata.output">
+						<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+						<env key="EC2_HOME" value="${ec2.home}" />
+						<env key="EC2_DIR" value="${ec2.dir}" />
+						<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+						<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+						<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+						<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+						<env key="NEUCA_INI" value="${neuca.ini.file}" />
+						<env key="INSTANCE_ID" value="${shirako.save.unit.ec2.instance}" />
+					</exec>
+					<echo message="after update userdata: exit code ${code}, ${update.userdata.output}" />
+					
+					<delete file="${neuca.ini.file}" />
+				</else>
+			</if>
+		</sequential>
+	</macrodef>
+
+
+	<!-- add network interface -->
+	<target name="modify.removeiface"  depends="resolve.configuration">
+		<taskdef resource="orca/handlers/ec2/ec2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+		<echo message="ec2.site.properties path is ${ec2.site.properties}" />
+
+		<if>
+			<isset property="ec2.site.properties" />
+			<then>
+				<echo message="Setting ec2.site.properites from ${ec2.site.properties}" />
+				<property file="${ec2.site.properties}" />
+			</then>
+		</if>
+
+		<var name="code" unset="true" />
+		<var name="message" unset="true" />
+
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="EC2 HANDLER: MODIFY.REMOVEIFACE on ${start.TIME}" />
+		<echo message="modify.removeiface: ec2 instance=${unit.ec2.instance}, modify sequence number ${shirako.save.unit.modify.sequencenum}" />
+
+		<modify.removeiface seqnum="${shirako.save.unit.modify.sequencenum}"/>
+
+		<property name="shirako.target.code" value="0" />
+		<echo message="modify.removeiface exit code: ${shirako.target.code}" />
+	</target>
+
+	<!-- leave target -->
+	<target name="leave" depends="resolve.configuration">
+		<taskdef resource="orca/handlers/ec2/ec2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="EC2 HANDLER: LEAVE on ${start.TIME}" />
+		<echo message="leave: ec2 instance=${unit.ec2.instance}" />
+		<!-- set site-specific properties like the VLAN or PHYS mode
 			 and the interface to operate on
-		--> 
-        <if> 
-            <isset property="ec2.site.properties" /> 
-            <then> 
-                <property file="${ec2.site.properties}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <!-- optionally close proxy to this host --> 
-                <if> 
-                    <!-- statically specified in ec2.site.properties --> 
-                    <equals arg1="${ec2.use.proxy}" arg2="true" /> 
-                    <then> 
-                        <echo message="obtaining ip address for instance ${unit.ec2.instance}" /> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <exec executable="${ec2.scripts}/${cloud.type}-get-ip" resultproperty="code" outputproperty="real.ip"> 
-                            <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                            <env key="EC2_HOME" value="${ec2.home}" /> 
-                            <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                            <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                            <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                            <env key="EC2_DIR" value="${ec2.dir}" /> 
-                            <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                            <env key="EC2_SSH_KEY" value="${ec2.ssh.key}" /> 
-                            <arg value="${unit.ec2.instance}" /> 
-                        </exec> 
-                        <echo message="get-ip exit code: ${code} ip=${real.ip}" /> 
-                        <!-- all properties passed to proxy script should be statically specified in ec2.site.properties.
+		-->
+		<if>
+			<isset property="ec2.site.properties" />
+			<then>
+				<property file="${ec2.site.properties}" />
+			</then>
+		</if>
+
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<!-- optionally close proxy to this host -->
+				<if>
+					<!-- statically specified in ec2.site.properties -->
+					<equals arg1="${ec2.use.proxy}" arg2="true" />
+					<then>
+						<echo message="obtaining ip address for instance ${unit.ec2.instance}" />
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<exec executable="${ec2.scripts}/${cloud.type}-get-ip" resultproperty="code" outputproperty="real.ip">
+							<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+							<env key="EC2_HOME" value="${ec2.home}" />
+							<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+							<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+							<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+							<env key="EC2_DIR" value="${ec2.dir}" />
+							<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+							<env key="EC2_SSH_KEY" value="${ec2.ssh.key}" />
+							<arg value="${unit.ec2.instance}" />
+						</exec>
+						<echo message="get-ip exit code: ${code} ip=${real.ip}" />
+						<!-- all properties passed to proxy script should be statically specified in ec2.site.properties.
 							See wiki notes on proxies for meaning of these properties.
-						--> 
-                        <echo message="un-configuring ${proxy.type} proxy via host ${proxy.proxy.ip}" /> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <exec executable="${ec2.scripts}/stop-proxy" resultproperty="code" outputproperty="proxy.script.output"> 
-                            <env key="PROXY_TYPE" value="${proxy.type}" /> 
-                            <env key="PROXY_PROXY_IP" value="${proxy.proxy.ip}" /> 
-                            <env key="PROXY_INSTANCE_IP" value="${real.ip}" /> 
-                            <env key="PROXY_USER" value="${proxy.user}" /> 
-                            <env key="PROXY_SSH_KEY" value="${proxy.ssh.key}" /> 
-                            <env key="PROXY_SCRIPT_PATH" value="${proxy.script.path}" /> 
-                        </exec> 
-                        <var name="real.ip" unset="true"></var> 
-                        <echo message="stop-proxy exit code: ${code} ${proxy.script.output}" /> 
-                    </then> 
-                </if> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <echo message="removing instance ifaces: ${unit.ec2.instance}, ${unit.quantum.ifaces}" /> 
-                <if> 
-                    <equals arg1="${cloud.type}" arg2="nova-essex" /> 
-                    <then> 
-                        <!-- if neuca-quantum, remove all interfaces --> 
-                        <var name="code" unset="true"></var> 
-                        <var name="remove.iface.output" unset="true"></var> 
-                        <exec executable="${ec2.scripts}/neuca-quantum-remove-vm-ifaces" resultproperty="code" outputproperty="remove.iface.output"> 
-                            <env key="EC2_HOME" value="${ec2.home}" /> 
-                            <env key="EC2_DIR" value="${ec2.dir}" /> 
-                            <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                            <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                            <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                            <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                            <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                            <env key="UNIT_EC2_INSTANCE" value="${unit.ec2.instance}" /> 
-                            <env key="UNIT_QUANTUM_IFACES" value="${unit.quantum.ifaces}" /> 
-                        </exec> 
-                        <echo>
-                             result code: ${code} 
-                        </echo> 
-                        <echo>
-                             output: ${remove.iface.output} 
-                        </echo> 
-                    </then> 
-                </if> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <echo message="terminating instance: ${unit.ec2.instance}" /> 
-                <exec executable="${ec2.scripts}/${cloud.type}-stop" resultproperty="code" outputproperty="terminate.instance.output"> 
-                    <env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" /> 
-                    <env key="EC2_HOME" value="${ec2.home}" /> 
-                    <env key="EC2_LOG_DIR" value="${ec2.log.dir}" /> 
-                    <env key="EC2_LOG_FILE" value="${ec2.log.file}" /> 
-                    <env key="EC2_LOG_LEVEL" value="${ec2.log.level}" /> 
-                    <env key="EC2_DIR" value="${ec2.dir}" /> 
-                    <env key="EUCA_KEY_DIR" value="${ec2.keys}" /> 
-                    <env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" /> 
-                    <env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" /> 
-                    <env key="EC2_USE_PUBLIC_ADDRESSING" value="${ec2.use.public.addressing}" /> 
-                    <arg value="${unit.ec2.instance}" /> 
-                </exec> 
-                <echo message="terminate-instance exit code: ${code}; ${terminate.instance.output}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
+						-->
+						<echo message="un-configuring ${proxy.type} proxy via host ${proxy.proxy.ip}" />
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<exec executable="${ec2.scripts}/stop-proxy" resultproperty="code" outputproperty="proxy.script.output">
+							<env key="PROXY_TYPE" value="${proxy.type}" />
+							<env key="PROXY_PROXY_IP" value="${proxy.proxy.ip}" />
+							<env key="PROXY_INSTANCE_IP" value="${real.ip}" />
+							<env key="PROXY_USER" value="${proxy.user}" />
+							<env key="PROXY_SSH_KEY" value="${proxy.ssh.key}" />
+							<env key="PROXY_SCRIPT_PATH" value="${proxy.script.path}" />
+						</exec>
+						<var name="real.ip" unset="true" />
+						<echo message="stop-proxy exit code: ${code} ${proxy.script.output}" />
+					</then>
+				</if>
+
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+				<echo message="removing instance ifaces: ${unit.ec2.instance}, ${unit.quantum.ifaces}" />
+
+				<if>
+					<equals arg1="${cloud.type}" arg2="nova-essex" />
+					<then>
+						<!-- if neuca-quantum, remove all interfaces -->
+						<var name="code" unset="true" />
+						<var name="remove.iface.output" unset="true" />
+						<exec executable="${ec2.scripts}/neuca-quantum-remove-vm-ifaces" resultproperty="code" outputproperty="remove.iface.output">
+							<env key="EC2_HOME" value="${ec2.home}" />
+							<env key="EC2_DIR" value="${ec2.dir}" />
+							<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+							<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+							<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+							<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+							<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+							<env key="UNIT_EC2_INSTANCE" value="${unit.ec2.instance}" />
+							<env key="UNIT_QUANTUM_IFACES" value="${unit.quantum.ifaces}" />
+						</exec>
+						<echo>result code: ${code}</echo>
+						<echo>output: ${remove.iface.output}</echo>
+					</then>
+				</if>
+
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+				<echo message="terminating instance: ${unit.ec2.instance}" />
+				<exec executable="${ec2.scripts}/${cloud.type}-stop" resultproperty="code" outputproperty="terminate.instance.output">
+					<env key="UNIT_HOSTNAME_URL" value="${unit.hostname.url}" />
+					<env key="EC2_HOME" value="${ec2.home}" />
+					<env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
+					<env key="EC2_LOG_FILE" value="${ec2.log.file}" />
+					<env key="EC2_LOG_LEVEL" value="${ec2.log.level}" />
+					<env key="EC2_DIR" value="${ec2.dir}" />
+					<env key="EUCA_KEY_DIR" value="${ec2.keys}" />
+					<env key="EC2_CONNECTION_TIMEOUT" value="${ec2.connection.timeout}" />
+					<env key="EC2_REQUEST_TIMEOUT" value="${ec2.request.timeout}" />
+					<env key="EC2_USE_PUBLIC_ADDRESSING" value="${ec2.use.public.addressing}" />
+					<arg value="${unit.ec2.instance}" />
+				</exec>
+				<echo message="terminate-instance exit code: ${code}; ${terminate.instance.output}" />
+				<property name="shirako.target.code" value="${code}" />
+			</else>
+		</if>
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
 </project>
+

--- a/handlers/ibm_ds/resources/handlers/ibm_ds/handler.xml
+++ b/handlers/ibm_ds/resources/handlers/ibm_ds/handler.xml
@@ -1,153 +1,193 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+]>
 <project name="ibm_ds" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; 
-    <!-- Join operation --> 
-    <target name="join" depends="resolve.configuration"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy HH:mm:ss z" /> 
-        </tstamp> 
-        <echo message="IBM_DS iSCSI STORAGE HANDLER: JOIN on ${start.TIME}" /> 
-        <!--<property file="test.properties" />--> 
-        <if> 
-            <isset property="ibm_ds.site.properties" /> 
-            <then> 
-                <property file="${ibm_ds.site.properties}" /> 
-            </then> 
-        </if> 
-        <!-- Echo statments for log and emulation mode --> 
-        <echo message="IBM_DS_DIR=${ibm_ds.dir}" /> 
-        <echo message="IBM_DS_LOG_DIR=${ibm_ds.log.dir}" /> 
-        <echo message="IBM_DS_LOG_FILE=${ibm_ds.log.file}" /> 
-        <echo message="IBM_DS_LOG_LEVEL=${ibm_ds.log.level}" /> 
-        <echo message="IBM_DS_CONNECTION_TIMEOUT=${ibm_ds.connection.timeout}" /> 
-        <echo message="IBM_DS_REQUEST_TIMEOUT=${ibm_ds.request.timeout}" /> 
-        <echo message="IBM_DS_POOL=${ibm_ds.pool}" /> 
-        <echo message="IBM_DS_RAID_LEVEL=${ibm_ds.raid_level}" /> 
-        <echo message="IBM_DS_OWNER=${ibm_ds.owner}" /> 
-        <echo message="IBM_DS_IP=${ibm_ds.ip}" /> 
-        <echo message="IBM_DS_PASSWORD=${ibm_ds.password}" /> 
-        <echo message="IBM_DS_LOCKFILE=${ibm_ds.lockfile}" /> 
-        <echo message="UNIT_INITIATOR_IQN_PREFIX=${unit.initiator.iqn_prefix}" /> 
-        <echo message="UNIT_TARGET_NAME=${unit.target.name}" /> 
-        <echo message="UNIT_TARGET_LUN=${unit.target.lun}" /> 
-        <echo message="UNIT_TARGET_CHAP_USER=${unit.target.chap_user}" /> 
-        <echo message="UNIT_TARGET_CHAP_PASSWORD=${unit.target.chap_password}" /> 
-        <echo message="UNIT_TARGET_SEGMENT_SIZE=${unit.target.segment_size}" /> 
-        <echo message="UNIT_TARGET_CAPACITY=${unit.target.capacity}" /> 
-        <echo message="UNIT_INITIATOR_OS_TYPE=Linux" /> 
-        <!-- Only Linux for now --> 
-        <echo message="IBM_DS_GROUP_LABEL=${ibm_ds.group_label}" /> 
-        <echo message="UNIT_VM_GUID=${unit.vm.guid}" /> 
-        <echo message="UNIT_LUN_GUID=${unit.lun.guid}" /> 
-        <echo message="UNIT_SLICE_GUID=${unit.slice.guid}" /> 
-        <!-- If in emulation then exit without doing anything --> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="Emulation mode...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <!-- Log some properites for debuging --> 
-                <echo message="creating IBM_DS LUN ...(may take some time)" /> 
-                <var name="create.lun.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <exec executable="${ibm_ds.scripts}/ibm_ds-create-lun" resultproperty="code" outputproperty="create.lun.output"> 
-                    <env key="IBM_DS_DIR" value="${ibm_ds.dir}" /> 
-                    <env key="IBM_DS_LOG_DIR" value="${ibm_ds.log.dir}" /> 
-                    <env key="IBM_DS_LOG_FILE" value="${ibm_ds.log.file}" /> 
-                    <env key="IBM_DS_LOG_LEVEL" value="${ibm_ds.log.level}" /> 
-                    <env key="IBM_DS_CONNECTION_TIMEOUT" value="${ibm_ds.connection.timeout}" /> 
-                    <env key="IBM_DS_REQUEST_TIMEOUT" value="${ibm_ds.request.timeout}" /> 
-                    <env key="IBM_DS_POOL" value="${ibm_ds.pool}" /> 
-                    <env key="IBM_DS_RAID_LEVEL" value="${ibm_ds.raid_level}" /> 
-                    <env key="IBM_DS_OWNER" value="${ibm_ds.owner}" /> 
-                    <env key="IBM_DS_IP" value="${ibm_ds.ip}" /> 
-                    <env key="IBM_DS_PASSWORD" value="${ibm_ds.password}" /> 
-                    <env key="IBM_DS_LOCKFILE" value="${ibm_ds.lockfile}" /> 
-                    <env key="UNIT_INITIATOR_IQN_PREFIX" value="${unit.initiator.iqn_prefix}" /> 
-                    <env key="UNIT_TARGET_NAME" value="${unit.target.name}" /> 
-                    <env key="UNIT_TARGET_LUN" value="${unit.target.lun}" /> 
-                    <env key="UNIT_TARGET_CHAP_USER" value="${unit.target.chap_user}" /> 
-                    <env key="UNIT_TARGET_CHAP_PASSWORD" value="${unit.target.chap_password}" /> 
-                    <env key="UNIT_TARGET_SEGMENT_SIZE" value="${unit.target.segment_size}" /> 
-                    <env key="UNIT_TARGET_CAPACITY" value="${unit.target.capacity}" /> 
-                    <env key="UNIT_INITIATOR_OS_TYPE" value="Linux" /> 
-                    <!-- Only Linux for now --> 
-                    <env key="IBM_DS_GROUP_LABEL" value="${ibm_ds.group_label}" /> 
-                    <env key="UNIT_VM_GUID" value="${unit.vm.guid}" /> 
-                    <env key="UNIT_LUN_GUID" value="${unit.lun.guid}" /> 
-                    <env key="UNIT_SLICE_GUID" value="${unit.slice.guid}" /> 
-                </exec> 
-                <echo message="after create lun: exit code ${code}, ${create.lun.output}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <!-- end of else for emulation --> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- Modify operation is not supported --> 
-    <target name="modify" /> 
-    <!-- Leave operation --> 
-    <target name="leave" depends="resolve.configuration"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="IBM_DS iSCSI STORAGE HANDLER: LEAVE on ${start.TIME}" /> 
-        <!--<property file="test.properties" />--> 
-        <if> 
-            <isset property="ibm_ds.site.properties" /> 
-            <then> 
-                <property file="${ibm_ds.site.properties}" /> 
-            </then> 
-        </if> 
-        <echo message="${ibm_ds.scripts}/ibm_ds-delete-lun" /> 
-        <echo message="IBM_DS_DIR=${ibm_ds.dir}" /> 
-        <echo message="IBM_DS_LOG_DIR=${ibm_ds.log.dir}" /> 
-        <echo message="IBM_DS_LOG_FILE=${ibm_ds.log.file}" /> 
-        <echo message="IBM_DS_LOG_LEVEL=${ibm_ds.log.level}" /> 
-        <echo message="IBM_DS_CONNECTION_TIMEOUT=${ibm_ds.connection.timeout}" /> 
-        <echo message="IBM_DS_REQUEST_TIMEOUT=${ibm_ds.request.timeout}" /> 
-        <echo message="IBM_DS_SITE_PROPERTIES=${ibm_ds.site.properties}" /> 
-        <echo message="IBM_DS_LOCKFILE=${ibm_ds.lockfile}" /> 
-        <echo message="IBM_DS_IP=${ibm_ds.ip}" /> 
-        <echo message="IBM_DS_PASSWORD=${ibm_ds.password}" /> 
-        <echo message="UNIT_LUN_GUID=${unit.lun.guid}" /> 
-        <!-- If in emulation then exit without doing anything --> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="Emulation mode...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <echo message="deleting IBM_DS LUN ...(may take some time)" /> 
-                <var name="delete.lun.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <echo message="before delete lun" /> 
-                <exec executable="${ibm_ds.scripts}/ibm_ds-delete-lun" resultproperty="code" outputproperty="delete.lun.output"> 
-                    <env key="IBM_DS_DIR" value="${ibm_ds.dir}" /> 
-                    <env key="IBM_DS_LOG_DIR" value="${ibm_ds.log.dir}" /> 
-                    <env key="IBM_DS_LOG_FILE" value="${ibm_ds.log.file}" /> 
-                    <env key="IBM_DS_LOG_LEVEL" value="${ibm_ds.log.level}" /> 
-                    <env key="IBM_DS_CONNECTION_TIMEOUT" value="${ibm_ds.connection.timeout}" /> 
-                    <env key="IBM_DS_REQUEST_TIMEOUT" value="${ibm_ds.request.timeout}" /> 
-                    <env key="IBM_DS_SITE_PROPERTIES" value="${ibm_ds.site.properties}" /> 
-                    <env key="IBM_DS_LOCKFILE" value="${ibm_ds.lockfile}" /> 
-                    <env key="IBM_DS_IP" value="${ibm_ds.ip}" /> 
-                    <env key="IBM_DS_PASSWORD" value="${ibm_ds.password}" /> 
-                    <env key="UNIT_LUN_GUID" value="${unit.lun.guid}" /> 
-                </exec> 
-                <echo message="after delete lun: exit code ${code}, ${delete.lun.output}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <!-- end of else for emulation --> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
+
+  &paths;
+  &core;
+  &drivertasks;	
+
+
+
+  <!-- Join operation -->
+  <target name="join" depends="resolve.configuration">
+    <tstamp prefix="start">
+      <format property="TIME" pattern="MM/dd/yyyy HH:mm:ss z" />
+    </tstamp>
+    <echo message="IBM_DS iSCSI STORAGE HANDLER: JOIN on ${start.TIME}" />
+
+     <!--<property file="test.properties" />-->
+     <if>
+      <isset property="ibm_ds.site.properties" />
+       <then>
+        <property file="${ibm_ds.site.properties}" />
+      </then>
+    </if>
+
+
+    <!-- Echo statments for log and emulation mode -->
+    <echo message="IBM_DS_DIR=${ibm_ds.dir}" />
+    <echo message="IBM_DS_LOG_DIR=${ibm_ds.log.dir}" />
+    <echo message="IBM_DS_LOG_FILE=${ibm_ds.log.file}" />
+    <echo message="IBM_DS_LOG_LEVEL=${ibm_ds.log.level}" />
+    <echo message="IBM_DS_CONNECTION_TIMEOUT=${ibm_ds.connection.timeout}" />
+    <echo message="IBM_DS_REQUEST_TIMEOUT=${ibm_ds.request.timeout}" />
+
+    <echo message="IBM_DS_POOL=${ibm_ds.pool}" />
+    <echo message="IBM_DS_RAID_LEVEL=${ibm_ds.raid_level}" />
+    <echo message="IBM_DS_OWNER=${ibm_ds.owner}" />
+    <echo message="IBM_DS_IP=${ibm_ds.ip}" />
+    <echo message="IBM_DS_PASSWORD=${ibm_ds.password}" />
+    <echo message="IBM_DS_LOCKFILE=${ibm_ds.lockfile}" />
+  
+    <echo message="UNIT_INITIATOR_IQN_PREFIX=${unit.initiator.iqn_prefix}" />
+    <echo message="UNIT_TARGET_NAME=${unit.target.name}" />
+    <echo message="UNIT_TARGET_LUN=${unit.target.lun}" />
+    <echo message="UNIT_TARGET_CHAP_USER=${unit.target.chap_user}" />
+    <echo message="UNIT_TARGET_CHAP_PASSWORD=${unit.target.chap_password}" />
+    <echo message="UNIT_TARGET_SEGMENT_SIZE=${unit.target.segment_size}" />
+    <echo message="UNIT_TARGET_CAPACITY=${unit.target.capacity}" />
+
+    <echo message="UNIT_INITIATOR_OS_TYPE=Linux" /> <!-- Only Linux for now -->
+    <echo message="IBM_DS_GROUP_LABEL=${ibm_ds.group_label}" />
+    <echo message="UNIT_VM_GUID=${unit.vm.guid}" />
+    <echo message="UNIT_LUN_GUID=${unit.lun.guid}" />
+    <echo message="UNIT_SLICE_GUID=${unit.slice.guid}" />
+    
+
+
+    <!-- If in emulation then exit without doing anything -->
+    <if>
+      <equals arg1="${emulation}" arg2="true" />
+      <then>
+        <echo message="Emulation mode...exiting" />
+        <property name="shirako.target.code" value="0" />
+      </then>
+    <else>
+
+
+    <!-- Log some properites for debuging -->
+    <echo message="creating IBM_DS LUN ...(may take some time)" />
+    <var name="create.lun.output" unset="true" />
+    <var name="code" unset="true" />
+    <var name="message" unset="true" />
+    
+    <exec executable="${ibm_ds.scripts}/ibm_ds-create-lun" resultproperty="code" outputproperty="create.lun.output">
+      <env key="IBM_DS_DIR" value="${ibm_ds.dir}" />
+      <env key="IBM_DS_LOG_DIR" value="${ibm_ds.log.dir}" />
+      <env key="IBM_DS_LOG_FILE" value="${ibm_ds.log.file}" />
+      <env key="IBM_DS_LOG_LEVEL" value="${ibm_ds.log.level}" />
+      <env key="IBM_DS_CONNECTION_TIMEOUT" value="${ibm_ds.connection.timeout}" />
+      <env key="IBM_DS_REQUEST_TIMEOUT" value="${ibm_ds.request.timeout}" />
+
+      <env key="IBM_DS_POOL" value="${ibm_ds.pool}" />
+      <env key="IBM_DS_RAID_LEVEL" value="${ibm_ds.raid_level}" />
+      <env key="IBM_DS_OWNER" value="${ibm_ds.owner}" />
+      <env key="IBM_DS_IP" value="${ibm_ds.ip}" />
+      <env key="IBM_DS_PASSWORD" value="${ibm_ds.password}" />
+      <env key="IBM_DS_LOCKFILE" value="${ibm_ds.lockfile}" />
+    
+
+      <env key="UNIT_INITIATOR_IQN_PREFIX" value="${unit.initiator.iqn_prefix}" />
+      <env key="UNIT_TARGET_NAME" value="${unit.target.name}" />
+      <env key="UNIT_TARGET_LUN" value="${unit.target.lun}" />
+      <env key="UNIT_TARGET_CHAP_USER" value="${unit.target.chap_user}" />
+      <env key="UNIT_TARGET_CHAP_PASSWORD" value="${unit.target.chap_password}" />
+      <env key="UNIT_TARGET_SEGMENT_SIZE" value="${unit.target.segment_size}" />
+      <env key="UNIT_TARGET_CAPACITY" value="${unit.target.capacity}" />
+	   
+      <env key="UNIT_INITIATOR_OS_TYPE" value="Linux" /> <!-- Only Linux for now -->
+      <env key="IBM_DS_GROUP_LABEL" value="${ibm_ds.group_label}" />
+      <env key="UNIT_VM_GUID" value="${unit.vm.guid}" />
+      <env key="UNIT_LUN_GUID" value="${unit.lun.guid}" />
+      <env key="UNIT_SLICE_GUID" value="${unit.slice.guid}" />
+	     
+    </exec>
+    <echo message="after create lun: exit code ${code}, ${create.lun.output}" />
+    
+    <property name="shirako.target.code" value="${code}" />
+    
+
+    </else></if> <!-- end of else for emulation -->  
+    <echo message="join exit code: ${shirako.target.code}" />
+  </target>
+  
+  <!-- Modify operation is not supported -->
+  <target name="modify" />
+
+  
+  <!-- Leave operation -->
+  <target name="leave" depends="resolve.configuration">
+    <tstamp prefix="start">
+      <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+    </tstamp>
+    
+    <echo message="IBM_DS iSCSI STORAGE HANDLER: LEAVE on ${start.TIME}" />
+
+  <!--<property file="test.properties" />-->
+  <if>
+      <isset property="ibm_ds.site.properties" />
+       <then>
+        <property file="${ibm_ds.site.properties}" />
+      </then>
+    </if>
+
+
+    <echo message="${ibm_ds.scripts}/ibm_ds-delete-lun" />
+    <echo message="IBM_DS_DIR=${ibm_ds.dir}" />
+    <echo message="IBM_DS_LOG_DIR=${ibm_ds.log.dir}" />
+    <echo message="IBM_DS_LOG_FILE=${ibm_ds.log.file}" />
+    <echo message="IBM_DS_LOG_LEVEL=${ibm_ds.log.level}" />
+    <echo message="IBM_DS_CONNECTION_TIMEOUT=${ibm_ds.connection.timeout}" />
+    <echo message="IBM_DS_REQUEST_TIMEOUT=${ibm_ds.request.timeout}" />
+    <echo message="IBM_DS_SITE_PROPERTIES=${ibm_ds.site.properties}" />
+    <echo message="IBM_DS_LOCKFILE=${ibm_ds.lockfile}" />
+    
+
+    <echo message="IBM_DS_IP=${ibm_ds.ip}" />
+    <echo message="IBM_DS_PASSWORD=${ibm_ds.password}" />
+    <echo message="UNIT_LUN_GUID=${unit.lun.guid}" />
+
+    <!-- If in emulation then exit without doing anything -->
+    <if>
+      <equals arg1="${emulation}" arg2="true" />
+      <then>
+        <echo message="Emulation mode...exiting" />
+        <property name="shirako.target.code" value="0" />
+      </then>
+      <else>
+
+
+	<echo message="deleting IBM_DS LUN ...(may take some time)" />
+        <var name="delete.lun.output" unset="true" />
+        <var name="code" unset="true" />
+        <var name="message" unset="true" />
+	
+        <echo message="before delete lun" />
+        <exec executable="${ibm_ds.scripts}/ibm_ds-delete-lun" resultproperty="code" outputproperty="delete.lun.output">
+          
+          <env key="IBM_DS_DIR" value="${ibm_ds.dir}" />
+          <env key="IBM_DS_LOG_DIR" value="${ibm_ds.log.dir}" />
+          <env key="IBM_DS_LOG_FILE" value="${ibm_ds.log.file}" />
+          <env key="IBM_DS_LOG_LEVEL" value="${ibm_ds.log.level}" />
+          <env key="IBM_DS_CONNECTION_TIMEOUT" value="${ibm_ds.connection.timeout}" />
+          <env key="IBM_DS_REQUEST_TIMEOUT" value="${ibm_ds.request.timeout}" />
+          <env key="IBM_DS_SITE_PROPERTIES" value="${ibm_ds.site.properties}" />
+	  <env key="IBM_DS_LOCKFILE" value="${ibm_ds.lockfile}" />
+
+	  
+	  <env key="IBM_DS_IP" value="${ibm_ds.ip}" />
+          <env key="IBM_DS_PASSWORD" value="${ibm_ds.password}" />
+   	  <env key="UNIT_LUN_GUID" value="${unit.lun.guid}" />
+        </exec>
+        <echo message="after delete lun: exit code ${code}, ${delete.lun.output}" />
+	
+	<property name="shirako.target.code" value="${code}" />
+
+    </else> </if> <!-- end of else for emulation -->
+    <echo message="leave exit code: ${shirako.target.code}" />
+  </target>
 </project>
+

--- a/handlers/network/test.xml
+++ b/handlers/network/test.xml
@@ -1,157 +1,554 @@
-<!DOCTYPE project>
- ]&gt; 
-<project name="networkhandlers" basedir="." xmlns:artifact="urn:maven-artifact-ant">
-     &amp;deps; 
-    <target name="help"> 
+<!DOCTYPE project [
+<!ENTITY deps SYSTEM "ant/deps.xml">
+]>
+<project name="networkhandlers"
+         basedir="."
+         xmlns:artifact="urn:maven-artifact-ant">
+	
+    &deps;
+
+	<target name="help">
         <echo>
-             Network handlers test tasks. Use ant -f test.xml -p to list. 
-        </echo> 
-    </target> 
-    <taskdef resource="orca/handlers/network/network.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-    <property resource="orca/handlers/network/network.properties" classpathref="run.classpath" /> 
-    <target name="juniper.ex3200.createQoSVlan.parallel"> 
-        <parallel> 
-            <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.a}" vlanTag="251" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-            <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.a}" vlanTag="252" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-            <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.a}" vlanTag="253" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-            <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.a}" vlanTag="254" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-            <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.a}" vlanTag="255" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-            <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.b}" vlanTag="251" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-            <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.b}" vlanTag="252" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-            <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.b}" vlanTag="253" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-            <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.b}" vlanTag="254" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-            <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.b}" vlanTag="255" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-        </parallel> 
-    </target> 
-    <target name="juniper.ex3200.deleteQoSVlan.parallel"> 
-        <parallel> 
-            <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.a}" vlanWithQos="true" vlanTag="251" /> 
-            <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.a}" vlanWithQos="true" vlanTag="252" /> 
-            <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.a}" vlanWithQos="true" vlanTag="253" /> 
-            <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.a}" vlanWithQos="true" vlanTag="254" /> 
-            <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.a}" vlanWithQos="true" vlanTag="255" /> 
-            <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.b}" vlanWithQos="true" vlanTag="251" /> 
-            <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.b}" vlanWithQos="true" vlanTag="252" /> 
-            <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.b}" vlanWithQos="true" vlanTag="253" /> 
-            <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.b}" vlanWithQos="true" vlanTag="254" /> 
-            <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200.b}" vlanWithQos="true" vlanTag="255" /> 
-        </parallel> 
-    </target> 
-    <target name="juniper.ex3200.createQoSVlan"> 
-        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200}" vlanTag="${vlan.tag}" vlanQosRate="${router.ex3200.qos.rate}" vlanQosBurstSize="${router.ex3200.qos.burstSize}" /> 
-    </target> 
-    <target name="juniper.ex3200.createVlan"> 
-        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="juniper.ex3200.deleteQoSVlan"> 
-        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200}" vlanWithQos="true" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="juniper.ex3200.deleteVlan"> 
-        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200}" vlanWithQos="false" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="ciena.8700.createQoSVlan"> 
-        <network.router.8700.create.vlan deviceInstance="${network.device.ciena8700}" defaultPrompt="${router.8700.prompt}" user="${router.8700.user}" password="${router.8700.password}" adminPassword="${router.8700.adminpassword}" deviceAddress="${router.8700}" vlanTag="${vlan.tag}" vlanQoSBurstSize="${router.8700.qos.burstSize}" vlanQosRate="${router.8700.qos.rate}" /> 
-    </target> 
-    <target name="ciena.8700.createVlan"> 
-        <network.router.8700.create.vlan deviceInstance="${network.device.ciena8700}" defaultPrompt="${router.8700.prompt}" user="${router.8700.user}" password="${router.8700.password}" adminPassword="${router.8700.adminpassword}" deviceAddress="${router.8700}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="ciena.8700.deleteQoSVlan"> 
-        <network.router.8700.delete.vlan deviceInstance="${network.device.ciena8700}" defaultPrompt="${router.8700.prompt}" user="${router.8700.user}" password="${router.8700.password}" adminPassword="${router.8700.adminpassword}" deviceAddress="${router.8700}" vlanWithQos="true" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="ciena.8700.deleteVlan"> 
-        <network.router.8700.delete.vlan deviceInstance="${network.device.ciena8700}" defaultPrompt="${router.8700.prompt}" user="${router.8700.user}" password="${router.8700.password}" adminPassword="${router.8700.adminpassword}" deviceAddress="${router.8700}" vlanWithQos="false" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="ciena.8700.addTrunkPorts"> 
-        <network.router.8700.add.trunkPorts deviceInstance="${network.device.ciena8700}" defaultPrompt="${router.8700.prompt}" user="${router.8700.user}" password="${router.8700.password}" adminPassword="${router.8700.adminpassword}" deviceAddress="${router.8700}" ports="${router.8700.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="ciena.8700.addAccessPorts"> 
-        <network.router.8700.add.accessPorts deviceInstance="${network.device.ciena8700}" defaultPrompt="${router.8700.prompt}" user="${router.8700.user}" password="${router.8700.password}" adminPassword="${router.8700.adminpassword}" deviceAddress="${router.8700}" ports="${router.8700.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="ciena.8700.removeTrunkPorts"> 
-        <network.router.8700.remove.trunkPorts deviceInstance="${network.device.ciena8700}" user="${router.8700.user}" defaultPrompt="${router.8700.prompt}" password="${router.8700.password}" adminPassword="${router.8700.adminpassword}" deviceAddress="${router.8700}" ports="${router.8700.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="ciena.8700.removeAccessPorts"> 
-        <network.router.8700.remove.accessPorts deviceInstance="${network.device.ciena8700}" user="${router.8700.user}" defaultPrompt="${router.8700.prompt}" password="${router.8700.password}" adminPassword="${router.8700.adminpassword}" deviceAddress="${router.8700}" ports="${router.8700.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="ciena.8700.mapVLANs"> 
-        <network.router.8700.map.vlans deviceInstance="${network.device.ciena8700}" user="${router.8700.user}" defaultPrompt="${router.8700.prompt}" password="${router.8700.password}" adminPassword="${router.8700.adminpassword}" deviceAddress="${router.8700}" port="${router.8700.map.port}" destinationTag="${router.8700.dst.vlan.tag}" sourceTag="${router.8700.src.vlan.tag}" /> 
-    </target> 
-    <target name="ciena.8700.unmapVLANs"> 
-        <network.router.8700.unmap.vlans deviceInstance="${network.device.ciena8700}" user="${router.8700.user}" defaultPrompt="${router.8700.prompt}" password="${router.8700.password}" adminPassword="${router.8700.adminpassword}" deviceAddress="${router.8700}" port="${router.8700.map.port}" destinationTag="${router.8700.dst.vlan.tag}" sourceTag="${router.8700.src.vlan.tag}" /> 
-    </target> 
-    <target name="cisco.6509.createQoSVlan"> 
-        <network.router.6509.create.vlan deviceInstance="${network.device.cisco6509}" user="${router.6509.user}" password="${router.6509.password}" adminPassword="${router.6509.adminpassword}" deviceAddress="${router.6509}" vlanTag="${vlan.tag}" vlanQoSBurstSize="${router.6509.qos.burstSize}" vlanQosRate="${router.6509.qos.rate}" /> 
-    </target> 
-    <target name="cisco.6509.createVlan"> 
-        <network.router.6509.create.vlan deviceInstance="${network.device.cisco6509}" user="${router.6509.user}" password="${router.6509.password}" adminPassword="${router.6509.adminpassword}" deviceAddress="${router.6509}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="cisco.6509.deleteQoSVlan"> 
-        <network.router.6509.delete.vlan deviceInstance="${network.device.cisco6509}" user="${router.6509.user}" password="${router.6509.password}" adminPassword="${router.6509.adminpassword}" deviceAddress="${router.6509}" vlanWithQos="true" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="cisco.6509.deleteVlan"> 
-        <network.router.6509.delete.vlan deviceInstance="${network.device.cisco6509}" user="${router.6509.user}" password="${router.6509.password}" adminPassword="${router.6509.adminpassword}" deviceAddress="${router.6509}" vlanWithQos="false" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="cisco.6509.addTrunkPorts"> 
-        <network.router.6509.add.trunkPorts deviceInstance="${network.device.cisco6509}" user="${router.6509.user}" password="${router.6509.password}" adminPassword="${router.6509.adminpassword}" deviceAddress="${router.6509}" ports="${router.6509.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="cisco.6509.removeTrunkPorts"> 
-        <network.router.6509.remove.trunkPorts deviceInstance="${network.device.cisco6509}" user="${router.6509.user}" password="${router.6509.password}" adminPassword="${router.6509.adminpassword}" deviceAddress="${router.6509}" ports="${router.6509.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="juniper.ex3200.addAccessPorts"> 
-        <network.router.ex3200.add.accessPorts deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200}" ports="${router.ex3200.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="juniper.ex3200.removeAccessPorts"> 
-        <network.router.ex3200.remove.accessPorts deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200}" ports="${router.ex3200.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="juniper.ex3200.addTrunkPorts"> 
-        <network.router.ex3200.add.trunkPorts deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200}" ports="${router.ex3200.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="juniper.ex3200.removeTrunkPorts"> 
-        <network.router.ex3200.remove.trunkPorts deviceInstance="${network.device.ex3200}" user="${router.ex3200.user}" password="${router.ex3200.password}" deviceAddress="${router.ex3200}" ports="${router.ex3200.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <!-- Cisco 3400 --> 
-    <target name="cisco.3400.createQoSVlan"> 
-        <network.router.3400.create.vlan deviceInstance="${network.device.cisco3400}" user="${router.3400.user}" password="${router.3400.password}" adminPassword="${router.3400.adminpassword}" deviceAddress="${router.3400}" vlanTag="${vlan.tag}" vlanQoSBurstSize="${router.3400.qos.burstSize}" vlanQosRate="${router.3400.qos.rate}" /> 
-    </target> 
-    <target name="cisco.3400.createVlan"> 
-        <network.router.3400.create.vlan deviceInstance="${network.device.cisco3400}" user="${router.3400.user}" password="${router.3400.password}" adminPassword="${router.3400.adminpassword}" deviceAddress="${router.3400}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="cisco.3400.deleteQoSVlan"> 
-        <network.router.3400.delete.vlan deviceInstance="${network.device.cisco3400}" user="${router.3400.user}" password="${router.3400.password}" adminPassword="${router.3400.adminpassword}" deviceAddress="${router.3400}" vlanWithQos="true" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="cisco.3400.deleteVlan"> 
-        <network.router.3400.delete.vlan deviceInstance="${network.device.cisco3400}" user="${router.3400.user}" password="${router.3400.password}" adminPassword="${router.3400.adminpassword}" deviceAddress="${router.3400}" vlanWithQos="false" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="cisco.3400.addTrunkPorts"> 
-        <network.router.3400.add.trunkPorts deviceInstance="${network.device.cisco3400}" user="${router.3400.user}" password="${router.3400.password}" adminPassword="${router.3400.adminpassword}" deviceAddress="${router.3400}" ports="${router.3400.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <target name="cisco.3400.removeTrunkPorts"> 
-        <network.router.3400.remove.trunkPorts deviceInstance="${network.device.cisco3400}" user="${router.3400.user}" password="${router.3400.password}" adminPassword="${router.3400.adminpassword}" deviceAddress="${router.3400}" ports="${router.3400.ports}" vlanTag="${vlan.tag}" /> 
-    </target> 
-    <!-- Infinera tests --> 
-    <target name="infinera.dtn.createCRS"> 
-        <network.dtn.create.crs deviceInstance="${network.device.infineradtn}" user="${dtn.user}" password="${dtn.password}" deviceAddress="${dtn}" srcPort="${dtn.srcPort}" dstPort="${dtn.dstPort}" payloadType="${dtn.payloadType}" /> 
-    </target> 
-    <target name="infinera.dtn.deleteCRS"> 
-        <network.dtn.create.crs deviceInstance="${network.device.infineradtn}" user="${dtn.user}" password="${dtn.password}" deviceAddress="${dtn}" srcPort="${dtn.srcPort}" dstPort="${dtn.dstPort}" payloadType="${dtn.payloadType}" /> 
-    </target> 
-    <!-- polatis tests --> 
-    <target name="polatis.os.createPatch"> 
-        <network.os.create.patch deviceInstance="${network.device.polatisos}" user="${os.user}" password="${os.password}" deviceAddress="${os}" inputPort="${os.inputPort}" outputPort="${os.outputPort}" /> 
-    </target> 
-    <target name="polatis.os.deletePatch"> 
-        <network.os.delete.patch deviceInstance="${network.device.polatisos}" user="${os.user}" password="${os.password}" deviceAddress="${os}" port="${os.inputPort}" /> 
-    </target> 
-    <target name="openflow.slice.create"> 
-        <network.openflow.slice.create deviceInstance="${network.device.openflow}" user="${flowvisor.user}" password="${flowvisor.passwd}" deviceAddress="${flowvisor.url}" name="${flowvisor.slice.name}" passwd="${flowvisor.slice.passwd}" ctrlUrl="${flowvisor.slice.controller}" email="${flowvisor.slice.email}" /> 
-    </target> 
-    <target name="openflow.slice.ip.flowspace.add"> 
-        <network.openflow.slice.ip.flowspace.add deviceInstance="${network.device.openflow}" user="${flowvisor.user}" password="${flowvisor.passwd}" deviceAddress="${flowvisor.url}" name="${flowvisor.slice.name}" srcIP="${flowvisor.slice.flowspace.src.ip}" dstIP="${flowvisor.slice.flowspace.dst.ip}" /> 
-    </target> 
-    <target name="openflow.slice.vlan.flowspace.add"> 
-        <network.openflow.slice.vlan.flowspace.add deviceInstance="${network.device.openflow}" user="${flowvisor.user}" password="${flowvisor.passwd}" deviceAddress="${flowvisor.url}" name="${flowvisor.slice.name}" tag="${flowvisor.slice.vlan.tag}" switchPorts="${flowvisor.slice.switchPorts}" /> 
-    </target> 
-    <target name="openflow.slice.delete"> 
-        <network.openflow.slice.delete deviceInstance="${network.device.openflow}" user="${flowvisor.user}" password="${flowvisor.passwd}" deviceAddress="${flowvisor.url}" name="${flowvisor.slice.name}" /> 
-    </target> 
+			Network handlers test tasks. Use ant -f test.xml -p to list.
+		</echo>
+    </target>
+    
+    <taskdef resource="orca/handlers/network/network.xml"
+             classpathref="run.classpath"
+             loaderref="run.classpath.loader" />
+    <property resource="orca/handlers/network/network.properties"
+              classpathref="run.classpath" />
+
+    <target name="juniper.ex3200.createQoSVlan.parallel">
+	<parallel>
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.a}"
+                                    vlanTag="251"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.a}"
+                                    vlanTag="252"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.a}"
+                                    vlanTag="253"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.a}"
+                                    vlanTag="254"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.a}"
+                                    vlanTag="255"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.b}"
+                                    vlanTag="251"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.b}"
+                                    vlanTag="252"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.b}"
+                                    vlanTag="253"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.b}"
+                                    vlanTag="254"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.b}"
+                                    vlanTag="255"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+	</parallel>
+    </target>
+
+    <target name="juniper.ex3200.deleteQoSVlan.parallel">
+	<parallel>
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.a}"
+				    vlanWithQos="true"
+                                    vlanTag="251" />
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.a}"
+				    vlanWithQos="true"
+                                    vlanTag="252" />
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.a}"
+				    vlanWithQos="true"
+                                    vlanTag="253" />
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.a}"
+				    vlanWithQos="true"
+                                    vlanTag="254" />
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.a}"
+				    vlanWithQos="true"
+                                    vlanTag="255" />
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.b}"
+				    vlanWithQos="true"
+                                    vlanTag="251" />
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.b}"
+				    vlanWithQos="true"
+                                    vlanTag="252" />
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.b}"
+				    vlanWithQos="true"
+                                    vlanTag="253" />
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.b}"
+				    vlanWithQos="true"
+                                    vlanTag="254" />
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200.b}"
+				    vlanWithQos="true"
+                                    vlanTag="255" />
+	</parallel>
+    </target>
+
+    <target name="juniper.ex3200.createQoSVlan">
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200}"
+                                    vlanTag="${vlan.tag}"
+                                    vlanQosRate="${router.ex3200.qos.rate}"
+                                    vlanQosBurstSize="${router.ex3200.qos.burstSize}" />
+    </target>
+
+    <target name="juniper.ex3200.createVlan">
+        <network.router.ex3200.create.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="juniper.ex3200.deleteQoSVlan">
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200}"
+				    vlanWithQos="true"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="juniper.ex3200.deleteVlan">
+        <network.router.ex3200.delete.vlan deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200}"
+				    vlanWithQos="false"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="ciena.8700.createQoSVlan">
+        <network.router.8700.create.vlan deviceInstance="${network.device.ciena8700}"
+                                         defaultPrompt="${router.8700.prompt}"
+                                         user="${router.8700.user}"
+                                         password="${router.8700.password}"
+                                         adminPassword="${router.8700.adminpassword}"
+                                         deviceAddress="${router.8700}"
+                                         vlanTag="${vlan.tag}"
+                                         vlanQoSBurstSize="${router.8700.qos.burstSize}"
+                                         vlanQosRate="${router.8700.qos.rate}" />
+    </target>
+
+    <target name="ciena.8700.createVlan">
+        <network.router.8700.create.vlan deviceInstance="${network.device.ciena8700}"
+                                         defaultPrompt="${router.8700.prompt}"
+                                         user="${router.8700.user}"
+                                         password="${router.8700.password}"
+                                         adminPassword="${router.8700.adminpassword}"
+                                         deviceAddress="${router.8700}"
+                                         vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="ciena.8700.deleteQoSVlan">
+        <network.router.8700.delete.vlan deviceInstance="${network.device.ciena8700}"
+                                         defaultPrompt="${router.8700.prompt}"
+                                         user="${router.8700.user}"
+                                         password="${router.8700.password}"
+                                         adminPassword="${router.8700.adminpassword}"
+                                         deviceAddress="${router.8700}"
+                                         vlanWithQos="true"
+                                         vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="ciena.8700.deleteVlan">
+        <network.router.8700.delete.vlan deviceInstance="${network.device.ciena8700}"
+                                         defaultPrompt="${router.8700.prompt}"
+                                         user="${router.8700.user}"
+                                         password="${router.8700.password}"
+                                         adminPassword="${router.8700.adminpassword}"
+                                         deviceAddress="${router.8700}"
+                                         vlanWithQos="false"
+                                         vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="ciena.8700.addTrunkPorts">
+        <network.router.8700.add.trunkPorts deviceInstance="${network.device.ciena8700}"
+                                            defaultPrompt="${router.8700.prompt}"
+                                            user="${router.8700.user}"
+                                            password="${router.8700.password}"
+                                            adminPassword="${router.8700.adminpassword}"
+                                            deviceAddress="${router.8700}"
+                                            ports="${router.8700.ports}"
+                                            vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="ciena.8700.addAccessPorts">
+        <network.router.8700.add.accessPorts deviceInstance="${network.device.ciena8700}"
+                                            defaultPrompt="${router.8700.prompt}"
+                                            user="${router.8700.user}"
+                                            password="${router.8700.password}"
+                                            adminPassword="${router.8700.adminpassword}"
+                                            deviceAddress="${router.8700}"
+                                            ports="${router.8700.ports}"
+                                            vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="ciena.8700.removeTrunkPorts">
+        <network.router.8700.remove.trunkPorts deviceInstance="${network.device.ciena8700}"
+                                               user="${router.8700.user}"
+                                               defaultPrompt="${router.8700.prompt}"
+                                               password="${router.8700.password}"
+                                               adminPassword="${router.8700.adminpassword}"
+                                               deviceAddress="${router.8700}"
+                                               ports="${router.8700.ports}"
+                                               vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="ciena.8700.removeAccessPorts">
+        <network.router.8700.remove.accessPorts deviceInstance="${network.device.ciena8700}"
+                                               user="${router.8700.user}"
+                                               defaultPrompt="${router.8700.prompt}"
+                                               password="${router.8700.password}"
+                                               adminPassword="${router.8700.adminpassword}"
+                                               deviceAddress="${router.8700}"
+                                               ports="${router.8700.ports}"
+                                               vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="ciena.8700.mapVLANs">
+        <network.router.8700.map.vlans deviceInstance="${network.device.ciena8700}"
+                                               user="${router.8700.user}"
+                                               defaultPrompt="${router.8700.prompt}"
+                                               password="${router.8700.password}"
+                                               adminPassword="${router.8700.adminpassword}"
+                                               deviceAddress="${router.8700}"
+                                               port="${router.8700.map.port}"
+                                               destinationTag="${router.8700.dst.vlan.tag}"
+                                               sourceTag="${router.8700.src.vlan.tag}" />
+    </target>
+
+    <target name="ciena.8700.unmapVLANs">
+        <network.router.8700.unmap.vlans deviceInstance="${network.device.ciena8700}"
+                                       user="${router.8700.user}"
+                                       defaultPrompt="${router.8700.prompt}"
+                                       password="${router.8700.password}"
+                                       adminPassword="${router.8700.adminpassword}"
+                                       deviceAddress="${router.8700}"
+                                       port="${router.8700.map.port}"
+                                       destinationTag="${router.8700.dst.vlan.tag}"
+                                       sourceTag="${router.8700.src.vlan.tag}" />
+    </target>
+
+    <target name="cisco.6509.createQoSVlan">
+        <network.router.6509.create.vlan deviceInstance="${network.device.cisco6509}"
+                                    user="${router.6509.user}"
+                                    password="${router.6509.password}"
+                                    adminPassword="${router.6509.adminpassword}"
+                                    deviceAddress="${router.6509}"
+                                    vlanTag="${vlan.tag}"
+				                    vlanQoSBurstSize="${router.6509.qos.burstSize}"
+                                    vlanQosRate="${router.6509.qos.rate}" />
+    </target>
+
+    <target name="cisco.6509.createVlan">
+        <network.router.6509.create.vlan deviceInstance="${network.device.cisco6509}"
+                                    user="${router.6509.user}"
+                                    password="${router.6509.password}"
+                                    adminPassword="${router.6509.adminpassword}"
+                                    deviceAddress="${router.6509}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="cisco.6509.deleteQoSVlan">
+        <network.router.6509.delete.vlan deviceInstance="${network.device.cisco6509}"
+                                    user="${router.6509.user}"
+                                    password="${router.6509.password}"
+                                    adminPassword="${router.6509.adminpassword}"
+                                    deviceAddress="${router.6509}"
+				    vlanWithQos="true"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="cisco.6509.deleteVlan">
+        <network.router.6509.delete.vlan deviceInstance="${network.device.cisco6509}"
+                                    user="${router.6509.user}"
+                                    password="${router.6509.password}"
+                                    adminPassword="${router.6509.adminpassword}"
+                                    deviceAddress="${router.6509}"
+				    vlanWithQos="false"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="cisco.6509.addTrunkPorts">
+        <network.router.6509.add.trunkPorts deviceInstance="${network.device.cisco6509}"
+                                    user="${router.6509.user}"
+                                    password="${router.6509.password}"
+                                    adminPassword="${router.6509.adminpassword}"
+                                    deviceAddress="${router.6509}"
+				    ports="${router.6509.ports}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="cisco.6509.removeTrunkPorts">
+        <network.router.6509.remove.trunkPorts deviceInstance="${network.device.cisco6509}"
+                                    user="${router.6509.user}"
+                                    password="${router.6509.password}"
+                                    adminPassword="${router.6509.adminpassword}"
+                                    deviceAddress="${router.6509}"
+				    ports="${router.6509.ports}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+	
+    <target name="juniper.ex3200.addAccessPorts">
+        <network.router.ex3200.add.accessPorts deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200}"
+				    ports="${router.ex3200.ports}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="juniper.ex3200.removeAccessPorts">
+        <network.router.ex3200.remove.accessPorts deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200}"
+				    ports="${router.ex3200.ports}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="juniper.ex3200.addTrunkPorts">
+        <network.router.ex3200.add.trunkPorts deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200}"
+				    ports="${router.ex3200.ports}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="juniper.ex3200.removeTrunkPorts">
+        <network.router.ex3200.remove.trunkPorts deviceInstance="${network.device.ex3200}"
+                                    user="${router.ex3200.user}"
+                                    password="${router.ex3200.password}"
+                                    deviceAddress="${router.ex3200}"
+				    ports="${router.ex3200.ports}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+	<!-- Cisco 3400 -->
+    <target name="cisco.3400.createQoSVlan">
+        <network.router.3400.create.vlan deviceInstance="${network.device.cisco3400}"
+                                    user="${router.3400.user}"
+                                    password="${router.3400.password}"
+                                    adminPassword="${router.3400.adminpassword}"
+                                    deviceAddress="${router.3400}"
+                                    vlanTag="${vlan.tag}"
+				    vlanQoSBurstSize="${router.3400.qos.burstSize}"
+                                    vlanQosRate="${router.3400.qos.rate}" />
+    </target>
+
+    <target name="cisco.3400.createVlan">
+        <network.router.3400.create.vlan deviceInstance="${network.device.cisco3400}"
+                                    user="${router.3400.user}"
+                                    password="${router.3400.password}"
+                                    adminPassword="${router.3400.adminpassword}"
+                                    deviceAddress="${router.3400}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="cisco.3400.deleteQoSVlan">
+        <network.router.3400.delete.vlan deviceInstance="${network.device.cisco3400}"
+                                    user="${router.3400.user}"
+                                    password="${router.3400.password}"
+                                    adminPassword="${router.3400.adminpassword}"
+                                    deviceAddress="${router.3400}"
+				    vlanWithQos="true"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="cisco.3400.deleteVlan">
+        <network.router.3400.delete.vlan deviceInstance="${network.device.cisco3400}"
+                                    user="${router.3400.user}"
+                                    password="${router.3400.password}"
+                                    adminPassword="${router.3400.adminpassword}"
+                                    deviceAddress="${router.3400}"
+				    vlanWithQos="false"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="cisco.3400.addTrunkPorts">
+        <network.router.3400.add.trunkPorts deviceInstance="${network.device.cisco3400}"
+                                    user="${router.3400.user}"
+                                    password="${router.3400.password}"
+                                    adminPassword="${router.3400.adminpassword}"
+                                    deviceAddress="${router.3400}"
+				    ports="${router.3400.ports}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+
+    <target name="cisco.3400.removeTrunkPorts">
+        <network.router.3400.remove.trunkPorts deviceInstance="${network.device.cisco3400}"
+                                    user="${router.3400.user}"
+                                    password="${router.3400.password}"
+                                    adminPassword="${router.3400.adminpassword}"
+                                    deviceAddress="${router.3400}"
+				    ports="${router.3400.ports}"
+                                    vlanTag="${vlan.tag}" />
+    </target>
+	
+	<!-- Infinera tests -->
+	
+    <target name="infinera.dtn.createCRS">
+        <network.dtn.create.crs deviceInstance="${network.device.infineradtn}"
+                                user="${dtn.user}"
+                                password="${dtn.password}"
+            					deviceAddress="${dtn}"
+                                srcPort="${dtn.srcPort}"
+                                dstPort="${dtn.dstPort}"
+                                payloadType="${dtn.payloadType}" />
+    </target>
+
+    <target name="infinera.dtn.deleteCRS">
+        <network.dtn.create.crs deviceInstance="${network.device.infineradtn}"
+                                user="${dtn.user}"
+                                password="${dtn.password}"
+            					deviceAddress="${dtn}"
+                                srcPort="${dtn.srcPort}"
+                                dstPort="${dtn.dstPort}"
+                                payloadType="${dtn.payloadType}" />
+    </target>
+    
+	<!-- polatis tests -->
+	
+    <target name="polatis.os.createPatch">
+        <network.os.create.patch deviceInstance="${network.device.polatisos}"
+            user="${os.user}"
+        	password="${os.password}"
+        	deviceAddress="${os}"
+            inputPort="${os.inputPort}"
+            outputPort="${os.outputPort}"
+        />
+    </target>
+
+    <target name="polatis.os.deletePatch">
+        <network.os.delete.patch deviceInstance="${network.device.polatisos}"
+            user="${os.user}"
+        	password="${os.password}"
+        	deviceAddress="${os}"
+            port="${os.inputPort}"
+        />
+    </target>
+
+    <target name="openflow.slice.create">
+        <network.openflow.slice.create deviceInstance="${network.device.openflow}"
+            user="${flowvisor.user}"
+            password="${flowvisor.passwd}"
+            deviceAddress="${flowvisor.url}"
+            name="${flowvisor.slice.name}"
+            passwd="${flowvisor.slice.passwd}"
+            ctrlUrl="${flowvisor.slice.controller}"
+            email="${flowvisor.slice.email}"
+        />
+    </target>
+
+    <target name="openflow.slice.ip.flowspace.add">
+        <network.openflow.slice.ip.flowspace.add deviceInstance="${network.device.openflow}"
+            user="${flowvisor.user}"
+            password="${flowvisor.passwd}"
+            deviceAddress="${flowvisor.url}"
+            name="${flowvisor.slice.name}"
+            srcIP="${flowvisor.slice.flowspace.src.ip}"
+            dstIP="${flowvisor.slice.flowspace.dst.ip}"
+        />
+    </target>
+
+    <target name="openflow.slice.vlan.flowspace.add">
+        <network.openflow.slice.vlan.flowspace.add deviceInstance="${network.device.openflow}"
+            user="${flowvisor.user}"
+            password="${flowvisor.passwd}"
+            deviceAddress="${flowvisor.url}"
+            name="${flowvisor.slice.name}"
+            tag="${flowvisor.slice.vlan.tag}"
+            switchPorts="${flowvisor.slice.switchPorts}"
+        />
+    </target>
+
+    <target name="openflow.slice.delete">
+        <network.openflow.slice.delete deviceInstance="${network.device.openflow}"
+            user="${flowvisor.user}"
+            password="${flowvisor.passwd}"
+            deviceAddress="${flowvisor.url}"
+            name="${flowvisor.slice.name}"
+        />
+    </target>
+
+
 </project>

--- a/handlers/nlr/resources/handlers/nlr/handler-nosherpa.xml
+++ b/handlers/nlr/resources/handlers/nlr/handler-nosherpa.xml
@@ -1,91 +1,109 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+]>
+
 <project name="nlrsherpa" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;    
+	&drivertasks;
+
+	
+	<!-- Uncomment for handler testing
 	<property file="nlr.test.properties"/>
-	--> 
-    <target name="load.nlr.tasks" depends="set.classpath"> 
-        <taskdef resource="orca/handlers/nlr/NLRSherpa.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-    </target> 
-    <target name="join" depends="resolve.configuration,load.nlr.tasks"> 
-        <if> 
-            <not> 
-                <isset property="NLRSherpa.endpointA" /> 
-            </not> 
-            <then> 
-                <property name="NLRSherpa.endpointA" value="${config.interface.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="NLRSherpa.endpointZ" /> 
-            </not> 
-            <then> 
-                <property name="NLRSherpa.endpointZ" value="${config.interface.2}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="NLRSherpa.bandwidth" /> 
-            </not> 
-            <then> 
-                <property name="NLRSherpa.bandwidth" value="${resource.bandwidth}" /> 
-            </then> 
-            <else> 
-                <property name="NLRSherpa.bandwidth" value="" /> 
-            </else> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="unit.vlan.tag" /> 
-            </not> 
-            <then> 
-                <property name="unit.vlan.tag" value="" /> 
-            </then> 
-        </if> 
-        <!-- 
+	-->
+
+	<target name="load.nlr.tasks" depends="set.classpath">
+		<taskdef resource="orca/handlers/nlr/NLRSherpa.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+	</target>
+	
+	<target name="join" depends="resolve.configuration,load.nlr.tasks">
+		<if>
+			<not>
+				<isset property="NLRSherpa.endpointA" />
+			</not>
+			<then>
+				<property name="NLRSherpa.endpointA" value="${config.interface.1}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="NLRSherpa.endpointZ" />
+			</not>
+			<then>
+				<property name="NLRSherpa.endpointZ" value="${config.interface.2}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="NLRSherpa.bandwidth" />
+			</not>
+			<then>
+				<property name="NLRSherpa.bandwidth" value="${resource.bandwidth}" />
+			</then>
+			<else>
+				<property name="NLRSherpa.bandwidth" value="" />
+			</else>
+		</if>
+
+		<if>
+			<not>
+				<isset property="unit.vlan.tag" />
+			</not>
+			<then>
+				<property name="unit.vlan.tag" value="" />
+			</then>
+		</if>
+	
+		<!-- 
 		input parameters are credentials, endpointA, endpointZ (NLR hostname:interface), bandwidth and optionally unit.vlan.tag
-		--> 
-        <!-- 
+		-->
+		<!-- 
 		output parameter is property shirako.save.unit.vlan.tag - indicates the reserved vlan 
-		--> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="NLR HANDLER (NO SHERPA): JOIN" /> 
-        <echo message="Creating NLR vlan from: ${NLRSherpa.endpointA} to: ${NLRSherpa.endpointZ} bandwidth=${NLRSherpa.bandwidth} for tag=${unit.vlan.tag} on ${start.TIME}" /> 
-        <var name="shirako.save.unit.vlan.tag" unset="true"></var> 
-        <var name="shirako.save.unit.status" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.reservation" unset="true"></var> 
-        <property name="shirako.save.unit.status" value="0" /> 
-        <property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" /> 
-        <property name="shirako.save.unit.vlan.reservation" value="${unit.vlan.tag}|${NLRSherpa.endpointA}|${unit.vlan.tag}|${NLRSherpa.endpointZ}|${unit.vlan.tag}" /> 
-        <property name="shirako.target.code" value="0" /> 
-        <echo message="Vlan ${shirako.save.unit.vlan.tag} provisioned with status ${shirako.save.unit.status} and reservation id ${shirako.save.unit.vlan.reservation}" /> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,load.nlr.tasks"> 
-        <!-- input parameter is property unit.vlan.tag, unit.vlan.reservation + credentials --> 
-        <echo message="NLR HANDLER (NO SHERPA): LEAVE" /> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Removing vlan ${unit.vlan.tag} with reservation ${unit.vlan.reservation} on ${start.TIME}" /> 
-        <echo message="Vlan ${unit.vlan.tag} with reservation ${unit.vlan.reservation} destroyed successfully" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
-    <target name="modify"> 
-        <echo message="NLR HANDLER (NO SHERPA): MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+		-->
+        <tstamp prefix="start">
+                <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+        </tstamp>
+
+		<echo message="NLR HANDLER (NO SHERPA): JOIN" />
+		<echo message="Creating NLR vlan from: ${NLRSherpa.endpointA} to: ${NLRSherpa.endpointZ} bandwidth=${NLRSherpa.bandwidth} for tag=${unit.vlan.tag} on ${start.TIME}" />
+		<var name="shirako.save.unit.vlan.tag" unset="true" />
+		<var name="shirako.save.unit.status" unset="true" />
+		<var name="shirako.save.unit.vlan.reservation" unset="true" />
+	
+		<property name="shirako.save.unit.status" value="0" />
+		<property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" />
+		<property name="shirako.save.unit.vlan.reservation" value="${unit.vlan.tag}|${NLRSherpa.endpointA}|${unit.vlan.tag}|${NLRSherpa.endpointZ}|${unit.vlan.tag}" />
+		<property name="shirako.target.code" value="0" />
+		<echo message="Vlan ${shirako.save.unit.vlan.tag} provisioned with status ${shirako.save.unit.status} and reservation id ${shirako.save.unit.vlan.reservation}"/>
+        <!-- hairpin -->
+   	 	<var name="shirako.save.unit.vlan.url" unset="true" />
+    	<if>
+            	<isset property="unit.vlan.url" />
+            	<then>
+                    	<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+            	</then>
+    	</if>
+	</target>
+
+	<target name="leave" depends="resolve.configuration,load.nlr.tasks">
+		<!-- input parameter is property unit.vlan.tag, unit.vlan.reservation + credentials -->
+		<echo message="NLR HANDLER (NO SHERPA): LEAVE" />
+        <tstamp prefix="start">
+                <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+        </tstamp>
+
+		<echo message="Removing vlan ${unit.vlan.tag} with reservation ${unit.vlan.reservation} on ${start.TIME}" />
+		<echo message="Vlan ${unit.vlan.tag} with reservation ${unit.vlan.reservation} destroyed successfully"/>
+		<property name="shirako.target.code" value="0" />
+	</target>
+
+	<target name="modify">
+		<echo message="NLR HANDLER (NO SHERPA): MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/handlers/nlr/resources/handlers/nlr/handler.xml
+++ b/handlers/nlr/resources/handlers/nlr/handler.xml
@@ -1,126 +1,163 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+]>
+
 <project name="nlrsherpa" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;    
+	&drivertasks;
+
+	
+	<!-- Uncomment for handler testing
 	<property file="nlr.test.properties"/>
-	--> 
-    <target name="load.nlr.tasks" depends="set.classpath"> 
-        <taskdef resource="orca/handlers/nlr/NLRSherpa.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-    </target> 
-    <target name="join" depends="resolve.configuration,load.nlr.tasks"> 
-        <!-- get the credentials from a file, if needed --> 
-        <if> 
-            <isset property="nlr.site.properties" /> 
-            <then> 
-                <property file="${nlr.site.properties}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="NLRSherpa.endpointA" /> 
-            </not> 
-            <then> 
-                <property name="NLRSherpa.endpointA" value="${config.interface.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="NLRSherpa.endpointZ" /> 
-            </not> 
-            <then> 
-                <property name="NLRSherpa.endpointZ" value="${config.interface.2}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="NLRSherpa.bandwidth" /> 
-            </not> 
-            <then> 
-                <property name="NLRSherpa.bandwidth" value="${resource.bandwidth}" /> 
-            </then> 
-            <else> 
-                <property name="NLRSherpa.bandwidth" value="" /> 
-            </else> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="unit.vlan.tag" /> 
-            </not> 
-            <then> 
-                <property name="unit.vlan.tag" value="" /> 
-            </then> 
-        </if> 
-        <!-- 
+	-->
+
+	<target name="load.nlr.tasks" depends="set.classpath">
+		<taskdef resource="orca/handlers/nlr/NLRSherpa.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+	</target>
+	
+	<target name="join" depends="resolve.configuration,load.nlr.tasks">
+		<!-- get the credentials from a file, if needed -->
+		<if>
+			<isset property="nlr.site.properties" />
+			<then>
+				<property file="${nlr.site.properties}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="NLRSherpa.endpointA" />
+			</not>
+			<then>
+				<property name="NLRSherpa.endpointA" value="${config.interface.1}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="NLRSherpa.endpointZ" />
+			</not>
+			<then>
+				<property name="NLRSherpa.endpointZ" value="${config.interface.2}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="NLRSherpa.bandwidth" />
+			</not>
+			<then>
+				<property name="NLRSherpa.bandwidth" value="${resource.bandwidth}" />
+			</then>
+			<else>
+				<property name="NLRSherpa.bandwidth" value="" />
+			</else>
+		</if>
+
+		<if>
+			<not>
+				<isset property="unit.vlan.tag" />
+			</not>
+			<then>
+				<property name="unit.vlan.tag" value="" />
+			</then>
+		</if>
+	
+		<!-- 
 		input parameters are credentials, endpointA, endpointZ (NLR hostname:interface), bandwidth and optionally unit.vlan.tag
-		--> 
-        <!-- 
+		-->
+		<!-- 
 		output parameter is property shirako.save.unit.vlan.tag - indicates the reserved vlan 
-		--> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="NLR HANDLER: JOIN" /> 
-        <echo message="Creating NLR vlan from: ${NLRSherpa.endpointA} to: ${NLRSherpa.endpointZ} bandwidth=${NLRSherpa.bandwidth} for tag=${unit.vlan.tag} on ${start.TIME}" /> 
-        <var name="shirako.save.unit.vlan.tag" unset="true"></var> 
-        <var name="shirako.save.unit.status" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.reservation" unset="true"></var> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.tag" value="256" /> 
-                <property name="shirako.save.unit.vlan.reservation" value="265|rale.layer2.nlr.net:TenGigabitEthernet2/2|265|chic.layer2.nlr.net:GigabitEthernet9/10|265" /> 
-                <property name="shirako.target.code" value="0" /> 
-                <echo message="running under emulation...exiting" /> 
-                <echo message="Vlan ${shirako.save.unit.vlan.tag} provisioned successfully with reservation ${shirako.save.unit.vlan.reservation}" /> 
-            </then> 
-            <else> 
-                <NLRSherpa.SmartProvisionVlan login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" endpointA="${NLRSherpa.endpointA}" endpointZ="${NLRSherpa.endpointZ}" bandwidth="${NLRSherpa.bandwidth}" vlanId="${unit.vlan.tag}" vlanStatusProperty="shirako.save.unit.status" reservedVlanProperty="shirako.save.unit.vlan.tag" reservationIdProperty="shirako.save.unit.vlan.reservation" exitCodeProperty="NLRSherpa.exitCode" /> 
-                <echo message="Vlan ${shirako.save.unit.vlan.tag} provisioned with status ${shirako.save.unit.status} and reservation id ${shirako.save.unit.vlan.reservation}" /> 
-                <property name="shirako.target.code" value="${NLRSherpa.exitCode}" /> 
-                <property name="shirako.target.code.message" value="Vlan ${shirako.save.unit.vlan.tag} provisioned with status ${shirako.save.unit.status} and reservation id ${shirako.save.unit.vlan.reservation}" /> 
-            </else> 
-        </if> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,load.nlr.tasks"> 
-        <if> 
-            <isset property="nlr.site.properties" /> 
-            <then> 
-                <property file="${nlr.site.properties}" /> 
-            </then> 
-        </if> 
-        <!-- input parameter is property unit.vlan.tag, unit.vlan.reservation + credentials --> 
-        <echo message="NLR HANDLER: LEAVE" /> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Removing vlan ${unit.vlan.tag} with reservation ${unit.vlan.reservation} on ${start.TIME}" /> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <echo message="Vlan ${unit.vlan.tag} with reservation ${unit.vlan.reservation} destroyed successfully" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <NLRSherpa.SmartRemoveVlan login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" vlanId="${unit.vlan.tag}" vlanReservationId="${unit.vlan.reservation}" exitCodeProperty="NLRSherpa.removeVlanCode" /> 
-                <echo message="Removed vlan ${unit.vlan.tag} reservation ${unit.vlan.reservation} with exit code ${NLRSherpa.removeVlanCode}" /> 
-                <property name="shirako.target.code" value="${NLRSherpa.removeVlanCode}" /> 
-            </else> 
-        </if> 
-    </target> 
-    <target name="modify"> 
-        <echo message="NLR HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+		-->
+                <tstamp prefix="start">
+                        <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+                </tstamp>
+
+		<echo message="NLR HANDLER: JOIN" />
+		<echo message="Creating NLR vlan from: ${NLRSherpa.endpointA} to: ${NLRSherpa.endpointZ} bandwidth=${NLRSherpa.bandwidth} for tag=${unit.vlan.tag} on ${start.TIME}" />
+		<var name="shirako.save.unit.vlan.tag" unset="true" />
+		<var name="shirako.save.unit.status" unset="true" />
+		<var name="shirako.save.unit.vlan.reservation" unset="true" />
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<property name="shirako.save.unit.vlan.tag" value="256" />
+				<property name="shirako.save.unit.vlan.reservation" value="265|rale.layer2.nlr.net:TenGigabitEthernet2/2|265|chic.layer2.nlr.net:GigabitEthernet9/10|265" />
+				<property name="shirako.target.code" value="0" />
+				<echo message="running under emulation...exiting" />
+				<echo message="Vlan ${shirako.save.unit.vlan.tag} provisioned successfully with reservation ${shirako.save.unit.vlan.reservation}"/>
+			</then>
+			<else>
+				<NLRSherpa.SmartProvisionVlan 
+					login="${NLRSherpa.login}"
+					password="${NLRSherpa.password}"
+					wg="${NLRSherpa.wg}"
+					endpointA="${NLRSherpa.endpointA}"
+					endpointZ="${NLRSherpa.endpointZ}"
+					bandwidth="${NLRSherpa.bandwidth}"
+					vlanId="${unit.vlan.tag}"
+					vlanStatusProperty="shirako.save.unit.status"
+					reservedVlanProperty="shirako.save.unit.vlan.tag"
+					reservationIdProperty="shirako.save.unit.vlan.reservation"
+					exitCodeProperty="NLRSherpa.exitCode" />
+				<echo message="Vlan ${shirako.save.unit.vlan.tag} provisioned with status ${shirako.save.unit.status} and reservation id ${shirako.save.unit.vlan.reservation}"/>
+				<property name="shirako.target.code" value="${NLRSherpa.exitCode}" />
+				<property name="shirako.target.code.message" value="Vlan ${shirako.save.unit.vlan.tag} provisioned with status ${shirako.save.unit.status} and reservation id ${shirako.save.unit.vlan.reservation}" />
+			</else>
+		</if>
+	        <!-- hairpin -->
+       	 	<var name="shirako.save.unit.vlan.url" unset="true" />
+        	<if>
+                	<isset property="unit.vlan.url" />
+                	<then>
+                        	<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+                	</then>
+        	</if>
+
+	</target>
+
+	<target name="leave" depends="resolve.configuration,load.nlr.tasks">
+		<if>
+			<isset property="nlr.site.properties" />
+			<then>
+				<property file="${nlr.site.properties}" />
+			</then>
+		</if>
+
+		<!-- input parameter is property unit.vlan.tag, unit.vlan.reservation + credentials -->
+		<echo message="NLR HANDLER: LEAVE" />
+                <tstamp prefix="start">
+                        <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+                </tstamp>
+
+		<echo message="Removing vlan ${unit.vlan.tag} with reservation ${unit.vlan.reservation} on ${start.TIME}" />
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<echo message="Vlan ${unit.vlan.tag} with reservation ${unit.vlan.reservation} destroyed successfully"/>
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<NLRSherpa.SmartRemoveVlan
+					login="${NLRSherpa.login}"
+					password="${NLRSherpa.password}"
+					wg="${NLRSherpa.wg}"
+					vlanId="${unit.vlan.tag}"
+					vlanReservationId="${unit.vlan.reservation}"
+					exitCodeProperty="NLRSherpa.removeVlanCode" />
+				<echo message="Removed vlan ${unit.vlan.tag} reservation ${unit.vlan.reservation} with exit code ${NLRSherpa.removeVlanCode}"/>
+				<property name="shirako.target.code" value="${NLRSherpa.removeVlanCode}" />
+			</else>
+		</if>
+	</target>
+
+	<target name="modify">
+		<echo message="NLR HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/handlers/nlr/test.xml
+++ b/handlers/nlr/test.xml
@@ -1,82 +1,153 @@
-<!DOCTYPE project>
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY deps SYSTEM "ant/deps.xml">
+]>
 <project name="networkhandlers" basedir="." xmlns:artifact="urn:maven-artifact-ant">
-     &amp;deps; 
-    <target name="help"> 
-        <echo>
-             Test tasks for NLR Sherpa driver. Use ant -f test.xml -p to list. 
-        </echo> 
-    </target> 
-    <taskdef resource="orca/handlers/nlr/NLRSherpa.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-    <!--
+    &deps;
+
+    <target name="help">
+	<echo>
+		Test tasks for NLR Sherpa driver. Use ant -f test.xml -p to list.
+	</echo>
+    </target>
+    <taskdef resource="orca/handlers/nlr/NLRSherpa.xml"
+             classpathref="run.classpath"
+             loaderref="run.classpath.loader" />
+<!--
 	REMOVE ALL VLANS
---> 
-    <property file="${nlr.properties}" /> 
-    <target name="removeAllVlans" description="Remove all ORCA-provisioned VLANs from the system (use with caution)!"> 
-        <NLRSherpa.RemoveAllVlans login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" exitCodeProperty="exitCode" /> 
-        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message}" /> 
-    </target> 
-    <!--
+-->
+    <property file="${nlr.properties}" />
+
+    <target name="removeAllVlans" description="Remove all ORCA-provisioned VLANs from the system (use with caution)!">
+        <NLRSherpa.RemoveAllVlans
+			   login="${NLRSherpa.login}"
+			   password="${NLRSherpa.password}"
+			   wg="${NLRSherpa.wg}"
+                           exitCodeProperty="exitCode" />
+        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message}" />
+    </target>
+<!--
 	REMOVE ALL VLAN RESERVATIONS
---> 
-    <target name="removeAllReservations" description="Remave all vlan tag reservations from the system (use with caution)!"> 
-        <NLRSherpa.RemoveAllReservations login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" exitCodeProperty="exitCode" /> 
-        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message}" /> 
-    </target> 
-    <!--
+-->
+    <target name="removeAllReservations" description="Remave all vlan tag reservations from the system (use with caution)!">
+        <NLRSherpa.RemoveAllReservations 
+			   login="${NLRSherpa.login}"
+			   password="${NLRSherpa.password}"
+			   wg="${NLRSherpa.wg}"
+                           exitCodeProperty="exitCode" />
+        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message}" />
+    </target>
+<!--
 	RESERVE FIRST AVAILABEL VLAN ID
---> 
-    <target name="reserveAnyVlanId" description="Reserve first available vlan id. Safe to use."> 
-        <NLRSherpa.ReserveAnyVlanId login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" reservedVlanProperty="NLRSherpa.reservedVlan" exitCodeProperty="exitCode" /> 
-        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} reserved vlan: ${NLRSherpa.reservedVlan}" /> 
-    </target> 
-    <!--
+-->
+    <target name="reserveAnyVlanId" description="Reserve first available vlan id. Safe to use.">
+        <NLRSherpa.ReserveAnyVlanId 
+			   login="${NLRSherpa.login}"
+			   password="${NLRSherpa.password}"
+			   wg="${NLRSherpa.wg}"
+			   reservedVlanProperty="NLRSherpa.reservedVlan"
+                           exitCodeProperty="exitCode" />
+        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} reserved vlan: ${NLRSherpa.reservedVlan}" />
+    </target>
+<!--
 	UNRESERVE VLAN ID
---> 
-    <target name="unreserveVlanId" description="Unreserve given vlan id."> 
-        <NLRSherpa.UnreserveVlanId login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" vlanId="${NLRSherpa.vlan_id}" exitCodeProperty="exitCode" /> 
-        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} unreserved vlan: ${NLRSherpa.vlan_id}" /> 
-    </target> 
-    <!--
+-->
+    <target name="unreserveVlanId" description="Unreserve given vlan id.">
+        <NLRSherpa.UnreserveVlanId 
+			   login="${NLRSherpa.login}"
+			   password="${NLRSherpa.password}"
+			   wg="${NLRSherpa.wg}"
+			   vlanId="${NLRSherpa.vlan_id}"
+                           exitCodeProperty="exitCode" />
+        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} unreserved vlan: ${NLRSherpa.vlan_id}" />
+    </target>
+<!--
 	RESERVE SPECIFIC VLAN ID
---> 
-    <target name="reserveVlanId" description="Reserve given vlan id."> 
-        <NLRSherpa.ReserveVlanId login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" vlanId="${NLRSherpa.vlan_id}" exitCodeProperty="exitCode" /> 
-        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} reserved vlan: ${NLRSherpa.vlan_id}" /> 
-    </target> 
-    <!--
+-->
+    <target name="reserveVlanId" description="Reserve given vlan id.">
+        <NLRSherpa.ReserveVlanId 
+			   login="${NLRSherpa.login}"
+			   password="${NLRSherpa.password}"
+			   wg="${NLRSherpa.wg}"
+			   vlanId="${NLRSherpa.vlan_id}"
+                           exitCodeProperty="exitCode" />
+        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} reserved vlan: ${NLRSherpa.vlan_id}" />
+    </target>
+<!--
 	PROVISION A GIVEN VLAN
---> 
-    <target name="provisionVlan" description="Provision a vlan with a given tag between two ports on NLR (use with caution!)"> 
-        <NLRSherpa.ProvisionVlan login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" vlanId="${NLRSherpa.vlan_id}" endpointA="${NLRSherpa.endpointA}" endpointZ="${NLRSherpa.endpointZ}" bandwidth="${NLRSherpa.bandwidth}" vlanStatusProperty="NLRSherpa.vlanStatus" reservedVlanProperty="NLRSherpa.reservedVlan" exitCodeProperty="exitCode" /> 
-        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} vlan status: ${NLRSherpa.vlanStatus} reserved vlan: ${NLRSherpa.reservedVlan}" /> 
-    </target> 
-    <!--
+-->
+    <target name="provisionVlan" description="Provision a vlan with a given tag between two ports on NLR (use with caution!)">
+
+        <NLRSherpa.ProvisionVlan 
+			   login="${NLRSherpa.login}"
+			   password="${NLRSherpa.password}"
+			   wg="${NLRSherpa.wg}"
+			   vlanId="${NLRSherpa.vlan_id}"
+			   endpointA="${NLRSherpa.endpointA}"
+			   endpointZ="${NLRSherpa.endpointZ}"
+			   bandwidth="${NLRSherpa.bandwidth}"
+			   vlanStatusProperty="NLRSherpa.vlanStatus"
+			   reservedVlanProperty="NLRSherpa.reservedVlan"
+                           exitCodeProperty="exitCode" />
+        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} vlan status: ${NLRSherpa.vlanStatus} reserved vlan: ${NLRSherpa.reservedVlan}" />
+    </target>
+<!--
 	SMAR PROVISION A GIVEN VLAN (VLAN TAG IS OPTIONAL)
---> 
-    <target name="smartProvisionVlan" description="Provision a vlan (with a tag if given) between two ports on NLR (use with caution!)"> 
-        <NLRSherpa.SmartProvisionVlan login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" endpointA="${NLRSherpa.endpointA}" endpointZ="${NLRSherpa.endpointZ}" bandwidth="${NLRSherpa.bandwidth}" vlanId="265" vlanStatusProperty="NLRSherpa.vlanStatus" reservedVlanProperty="NLRSherpa.reservedVlan" exitCodeProperty="exitCode" /> 
-        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} vlan status: ${NLRSherpa.vlanStatus} reserved vlan: ${NLRSherpa.reservedVlan}" /> 
-    </target> 
-    <!--
+-->
+    <target name="smartProvisionVlan" description="Provision a vlan (with a tag if given) between two ports on NLR (use with caution!)">
+
+        <NLRSherpa.SmartProvisionVlan 
+			   login="${NLRSherpa.login}"
+			   password="${NLRSherpa.password}"
+			   wg="${NLRSherpa.wg}"
+			   endpointA="${NLRSherpa.endpointA}"
+			   endpointZ="${NLRSherpa.endpointZ}"
+			   bandwidth="${NLRSherpa.bandwidth}"
+			   vlanId="265"
+			   vlanStatusProperty="NLRSherpa.vlanStatus"
+			   reservedVlanProperty="NLRSherpa.reservedVlan"
+                           exitCodeProperty="exitCode" />
+        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} vlan status: ${NLRSherpa.vlanStatus} reserved vlan: ${NLRSherpa.reservedVlan}" />
+    </target>
+<!--
 	PROVISION ANY VLAN
---> 
-    <target name="provisionAnyVlan" description="Provision a vlan between two ports on NLR. Return provisioned vlan id as a property. (use with caution!)"> 
-        <NLRSherpa.ProvisionAnyVlan login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" endpointA="${NLRSherpa.endpointA}" endpointZ="${NLRSherpa.endpointZ}" bandwidth="${NLRSherpa.bandwidth}" vlanStatusProperty="NLRSherpa.vlanStatus" reservedVlanProperty="NLRSherpa.reservedVlan" exitCodeProperty="exitCode" /> 
-        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message}, vlan status: ${NLRSherpa.vlanStatus} reserved vlan: ${NLRSherpa.reservedVlan}" /> 
-    </target> 
-    <!--
+-->
+    <target name="provisionAnyVlan" description="Provision a vlan between two ports on NLR. Return provisioned vlan id as a property. (use with caution!)">
+
+        <NLRSherpa.ProvisionAnyVlan 
+			   login="${NLRSherpa.login}"
+			   password="${NLRSherpa.password}"
+			   wg="${NLRSherpa.wg}"
+			   endpointA="${NLRSherpa.endpointA}"
+			   endpointZ="${NLRSherpa.endpointZ}"
+			   bandwidth="${NLRSherpa.bandwidth}"
+			   vlanStatusProperty="NLRSherpa.vlanStatus"
+			   reservedVlanProperty="NLRSherpa.reservedVlan"
+                           exitCodeProperty="exitCode" />
+        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message}, vlan status: ${NLRSherpa.vlanStatus} reserved vlan: ${NLRSherpa.reservedVlan}" />
+    </target>
+<!--
 	REMOVE A PROVISIONED VLAN
---> 
-    <target name="removeVlan" description="Remove a provisioned vlan with a given tag on NLR (use with caution!)"> 
-        <NLRSherpa.RemoveVlan login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" vlanId="${NLRSherpa.vlan_id}" exitCodeProperty="exitCode" /> 
-        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} " /> 
-    </target> 
-    <!--
+-->
+    <target name="removeVlan" description="Remove a provisioned vlan with a given tag on NLR (use with caution!)">
+        <NLRSherpa.RemoveVlan
+			   login="${NLRSherpa.login}"
+			   password="${NLRSherpa.password}"
+			   wg="${NLRSherpa.wg}"
+			   vlanId="${NLRSherpa.vlan_id}"
+                           exitCodeProperty="exitCode" />
+        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} " />
+    </target>
+<!--
 	SMART REMOVE A PROVISIONED VLAN
---> 
-    <target name="smartRemoveVlan" description="Smart remove a provisioned vlan with a given tag on NLR  and attempt to re-reserve the tag (use with caution!)"> 
-        <NLRSherpa.SmartRemoveVlan login="${NLRSherpa.login}" password="${NLRSherpa.password}" wg="${NLRSherpa.wg}" vlanId="${NLRSherpa.vlan_id}" exitCodeProperty="exitCode" /> 
-        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} " /> 
-    </target> 
+-->
+    <target name="smartRemoveVlan" description="Smart remove a provisioned vlan with a given tag on NLR  and attempt to re-reserve the tag (use with caution!)">
+        <NLRSherpa.SmartRemoveVlan
+			   login="${NLRSherpa.login}"
+			   password="${NLRSherpa.password}"
+			   wg="${NLRSherpa.wg}"
+			   vlanId="${NLRSherpa.vlan_id}"
+                           exitCodeProperty="exitCode" />
+        <echo message="exitCode: ${exitCode}, exitMessage: ${exitCode.message} " />
+    </target>
+
 </project>

--- a/handlers/nsi/resources/handlers/nsi/handler.xml
+++ b/handlers/nsi/resources/handlers/nsi/handler.xml
@@ -1,259 +1,302 @@
-<!DOCTYPE project> 
-<!--ENTITY core SYSTEM "../common/core.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml"--> 
-<!-- for development ($ORCA_HOME/tools/cmdline/handlers) --> 
-<!-- <!ENTITY core SYSTEM "../../../../../../../core/handlers/resources/handlers/common/core.xml"> --> 
-<!-- <!ENTITY drivertasks SYSTEM "../../../../../../../core/handlers/resources/handlers/common/drivertasks.xml"> --> 
-<!-- <!ENTITY paths SYSTEM "../../../../../../../core/handlers/resources/handlers/common/paths.xml"> --> 
+<!DOCTYPE project [
+<!-- switch to this ones when placing in $ORCA_HOME/handlers -->
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml">
+
+<!-- for development ($ORCA_HOME/tools/cmdline/handlers) -->
+<!-- <!ENTITY core SYSTEM "../../../../../../../core/handlers/resources/handlers/common/core.xml"> -->
+<!-- <!ENTITY drivertasks SYSTEM "../../../../../../../core/handlers/resources/handlers/common/drivertasks.xml"> -->
+<!-- <!ENTITY paths SYSTEM "../../../../../../../core/handlers/resources/handlers/common/paths.xml"> -->
 <!-- <!ENTITY bentasks SYSTEM "../../../../../../../handlers/providers/resources/handler/providers/ben.no-na.tasks.xml"> -->
- ]&gt; 
+
+]>
 <project name="nsi" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="NSI HANDLER: JOIN" /> 
-        <if> 
-            <isset property="nsi.site.properties" /> 
-            <then> 
-                <property file="${nsi.site.properties}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="nsi.endpointA" /> 
-            </not> 
-            <then> 
-                <property name="nsi.endpointA" value="${config.interface.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="nsi.endpointZ" /> 
-            </not> 
-            <then> 
-                <property name="nsi.endpointZ" value="${config.interface.2}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="nsi.duration" /> 
-            </not> 
-            <then> 
-                <property name="nsi.duration" value="${config.duration}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="nsi.start_time" /> 
-            </not> 
-            <then> 
-                <property name="nsi.start_time" value="${config.start_time}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="nsi.end_time" /> 
-            </not> 
-            <then> 
-                <property name="nsi.end_time" value="${config.end_time}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="nsi.bw" /> 
-            </not> 
-            <then> 
-                <if> 
-                    <isset property="resource.bandwidth" /> 
-                    <then> 
-                        <property name="nsi.bw" value="${resource.bandwidth}" /> 
-                    </then> 
-                    <else> 
-                        <property name="nsi.bw" value="100000000" /> 
-                    </else> 
-                </if> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="nsi.vlan_tags" /> 
-            </not> 
-            <then> 
-                <if> 
-                    <isset property="config.unit.tag" /> 
-                    <then> 
-                        <property name="nsi.vlan_tags" value="${config.unit.tag}" /> 
-                        <echo message="nsi.vlan_tags: ${nsi.vlan_tags} from config.unit.tag" /> 
-                    </then> 
-                    <else> 
-                        <if> 
-                            <isset property="unit.vlan.tags" /> 
-                            <then> 
-                                <property name="nsi.vlan_tags" value="${unit.vlan.tags}" /> 
-                                <echo message="nsi.vlan_tags: ${nsi.vlan_tags} from unit.vlan.tags" /> 
-                            </then> 
-                            <else> 
-                                <property name="nsi.vlan_tags" value="${nsi.default.vlan.tags}" /> 
-                                <echo message="nsi.vlan_tags: ${nsi.vlan_tags} from nsi.default.vlan.tags" /> 
-                            </else> 
-                        </if> 
-                    </else> 
-                </if> 
-            </then> 
-        </if> 
-        <echo message="creating NSI circuit from ${nsi.endpointA} to ${nsi.endpointZ} with bandwidth ${nsi.bw} bps" /> 
-        <var name="shirako.save.unit.vlan.tag" unset="true"></var> 
-        <var name="shirako.save.unit.status" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.reservation" unset="true"></var> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="RUNNING UNDER EMULATION... EXITING" /> 
-                <echo message="Passed in available tag list:${nsi.vlan_tags}" /> 
-                <echo message="Passed in connection duration:${nsi.duration},start_time:${nsi.start_time},end_time:${nsi.end_time},bandwidth:${nsi.bw},endpointA:${nsi.endpointA},endPointB:${nsi.endpointZ}" /> 
-                <property name="shirako.save.unit.vlan.reservation" value="some-reservation-id|${nsi.endpointA}|${nsi.tagA}|${nsi.endpointZ}|${nsi.tagZ}" /> 
-                <property name="shirako.save.unit.vlan.tag" value="${config.unit.tag}" /> 
-                <property name="shirako.save.unit.status" value="ACTIVE" /> 
-                <echo message="unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <var name="create.circuit.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <atomic.sequence.start.macro device="NSIHandler" /> 
-                <exec executable="${nsi.scripts}/start-nsi.sh" resultproperty="code" outputproperty="create.circuit.output" errorproperty="create.circuit.error"> 
-                    <env key="NSI_SCRIPTS_DIR" value="${nsi.scripts}" /> 
-                    <env key="NSI_HOSTKEY" value="${nsi.hostkey}" /> 
-                    <env key="NSI_HOSTCERT" value="${nsi.hostcert}" /> 
-                    <env key="NSI_CERTDIR" value="${nsi.certdir}" /> 
-                    <env key="NSI_TLS" value="${nsi.tls}" /> 
-                    <env key="NSI_VERIFY" value="${nsi.verify}" /> 
-                    <env key="NSI_SERVICE" value="${nsi.service}" /> 
-                    <env key="NSI_PROVIDER" value="${nsi.provider}" /> 
-                    <env key="NSI_REQUESTER" value="${nsi.requester}" /> 
-                    <env key="NSI_USER" value="${nsi.user}" /> 
-                    <env key="NSI_DEBUG" value="${nsi.debug}" /> 
-                    <env key="NSI_ONSA" value="${nsi.onsa}" /> 
-                    <env key="NSI_PYTHON" value="${nsi.python}" /> 
-                    <env key="NSI_VLANNAS" value="${nsi.vlan.notavail.string}" /> 
-                    <env key="NSI_PROVISIONEDS" value="${nsi.provisioned.string}" /> 
-                    <env key="NSI_ADDRINUSE" value="${nsi.addr.inuse.string}" /> 
-                    <!-- controller-supplied properties --> 
-                    <env key="NSI_L2_SRC" value="${nsi.endpointA}" /> 
-                    <env key="NSI_L2_DST" value="${nsi.endpointZ}" /> 
-                    <env key="NSI_BW" value="${nsi.bw}" /> 
-                    <env key="NSI_DURATION" value="${nsi.duration}" /> 
-                    <env key="NSI_START_TIME" value="${nsi.start_time}" /> 
-                    <env key="NSI_END_TIME" value="${nsi.end_time}" /> 
-                    <env key="NSI_TAGS" value="${nsi.vlan_tags}" /> 
-                </exec> 
-                <atomic.sequence.stop.macro device="NSIHandler" /> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="Unable to create circuit: ${create.circuit.error}" /> 
-                        <property name="message" value="Unable to create circuit: ${create.circuit.error}" /> 
-                    </then> 
-                    <else> 
-                        <exec executable="/bin/bash" outputproperty="connection.id"> 
-                            <arg value="-c" /> 
-                            <arg value="echo ${create.circuit.output} | awk '{print $1}'" /> 
-                        </exec> 
-                        <exec executable="/bin/bash" outputproperty="vlan.tag"> 
-                            <arg value="-c" /> 
-                            <arg value="echo ${create.circuit.output} | awk '{print $2}'" /> 
-                        </exec> 
-                        <property name="shirako.save.unit.connection.id" value="${connection.id}" /> 
-                        <property name="shirako.save.unit.vlan.tag" value="${vlan.tag}" /> 
-                        <property name="shirako.save.unit.status" value="ACTIVE" /> 
-                        <echo message="Created connection with id: ${connection.id} and VLAN ${vlan.tag}." /> 
-                        <property name="message" value="Created connection with id: ${connection.id} and VLAN ${vlan.tag}." /> 
-                    </else> 
-                </if> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <property name="shirako.target.code.message" value="${message}" /> 
-            </else> 
-        </if> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- Modify operation is not supported --> 
-    <target name="modify" /> 
+
+        &paths;
+        &core; 
+        &drivertasks;
+        &bentasks;
+	
+        <target name="join" depends="resolve.configuration,ben.load.tasks"  > 
+
+    	<echo message="NSI HANDLER: JOIN" />
+		<if>
+			<isset property="nsi.site.properties" />
+			<then>
+				<property file="${nsi.site.properties}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="nsi.endpointA" />
+			</not>
+			<then>
+				<property name="nsi.endpointA" value="${config.interface.1}" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="nsi.endpointZ" />
+			</not>
+			<then>
+				<property name="nsi.endpointZ" value="${config.interface.2}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="nsi.duration" />
+			</not>
+			<then>
+				<property name="nsi.duration" value="${config.duration}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="nsi.start_time" />
+			</not>
+			<then>
+				<property name="nsi.start_time" value="${config.start_time}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="nsi.end_time" />
+			</not>
+			<then>
+				<property name="nsi.end_time" value="${config.end_time}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="nsi.bw" />
+			</not>
+			<then>
+				<if>
+					<isset property="resource.bandwidth" />
+					<then>
+						<property name="nsi.bw" value="${resource.bandwidth}" />
+					</then>
+					<else>
+						<property name="nsi.bw" value="100000000" />
+					</else>
+				</if>
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="nsi.vlan_tags" />
+			</not>
+			<then>
+				<if>
+					<isset property="config.unit.tag" />
+					<then>
+						<property name="nsi.vlan_tags" value="${config.unit.tag}" />
+						<echo message="nsi.vlan_tags: ${nsi.vlan_tags} from config.unit.tag" />
+					</then>
+					<else>
+						<if>
+							<isset property="unit.vlan.tags" />
+							<then>
+								<property name="nsi.vlan_tags" value="${unit.vlan.tags}" />
+								<echo message="nsi.vlan_tags: ${nsi.vlan_tags} from unit.vlan.tags" />
+							</then>
+							<else>
+								<property name="nsi.vlan_tags" value="${nsi.default.vlan.tags}" />
+								<echo message="nsi.vlan_tags: ${nsi.vlan_tags} from nsi.default.vlan.tags" />
+							</else>
+						</if>
+					</else>	
+				</if>
+			</then>
+		</if>
+
+		<echo message="creating NSI circuit from ${nsi.endpointA} to ${nsi.endpointZ} with bandwidth ${nsi.bw} bps" />
+		<var name="shirako.save.unit.vlan.tag" unset="true" />
+		<var name="shirako.save.unit.status" unset="true" />
+		<var name="shirako.save.unit.vlan.reservation" unset="true" />
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="RUNNING UNDER EMULATION... EXITING" />
+				<echo message="Passed in available tag list:${nsi.vlan_tags}"/>
+                <echo message="Passed in connection duration:${nsi.duration},start_time:${nsi.start_time},end_time:${nsi.end_time},bandwidth:${nsi.bw},endpointA:${nsi.endpointA},endPointB:${nsi.endpointZ}"/>
+				<property name="shirako.save.unit.vlan.reservation" value="some-reservation-id|${nsi.endpointA}|${nsi.tagA}|${nsi.endpointZ}|${nsi.tagZ}" />
+				<property name="shirako.save.unit.vlan.tag" value="${config.unit.tag}" />
+				<property name="shirako.save.unit.status" value="ACTIVE" />
+				<echo message="unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<var name="create.circuit.output" unset="true" />
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+
+				<atomic.sequence.start.macro device="NSIHandler"/>
+
+				<exec executable="${nsi.scripts}/start-nsi.sh" resultproperty="code" outputproperty="create.circuit.output" errorproperty="create.circuit.error">
+				  	<env key="NSI_SCRIPTS_DIR" value="${nsi.scripts}" />
+				  	<env key="NSI_HOSTKEY" value="${nsi.hostkey}" />
+					<env key="NSI_HOSTCERT" value="${nsi.hostcert}" />
+					<env key="NSI_CERTDIR" value="${nsi.certdir}" />
+					<env key="NSI_TLS" value="${nsi.tls}" />
+					<env key="NSI_VERIFY" value="${nsi.verify}" />
+					<env key="NSI_SERVICE" value="${nsi.service}" />
+					<env key="NSI_PROVIDER" value="${nsi.provider}" />
+					<env key="NSI_REQUESTER" value="${nsi.requester}" />
+					<env key="NSI_USER" value="${nsi.user}" />
+					<env key="NSI_DEBUG" value="${nsi.debug}" />
+					<env key="NSI_ONSA" value="${nsi.onsa}" />
+					<env key="NSI_PYTHON" value="${nsi.python}" />
+					<env key="NSI_VLANNAS" value="${nsi.vlan.notavail.string}" />
+					<env key="NSI_PROVISIONEDS" value="${nsi.provisioned.string}" />
+					<env key="NSI_ADDRINUSE" value="${nsi.addr.inuse.string}" />
+	
+					<!-- controller-supplied properties -->
+				  	<env key="NSI_L2_SRC" value="${nsi.endpointA}" />
+				  	<env key="NSI_L2_DST" value="${nsi.endpointZ}" />
+				  	<env key="NSI_BW" value="${nsi.bw}" />
+				  	<env key="NSI_DURATION" value="${nsi.duration}" />
+				  	<env key="NSI_START_TIME" value="${nsi.start_time}" />
+				  	<env key="NSI_END_TIME" value="${nsi.end_time}" />
+
+				  	<env key="NSI_TAGS" value="${nsi.vlan_tags}" />
+				
+				</exec>
+				
+				<atomic.sequence.stop.macro device="NSIHandler"/>
+
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo message="Unable to create circuit: ${create.circuit.error}" />
+						<property name="message" value="Unable to create circuit: ${create.circuit.error}" />
+					</then>
+					<else>
+						<exec executable="/bin/bash" outputproperty="connection.id">
+							<arg value="-c"/>
+							<arg value="echo ${create.circuit.output} | awk '{print $1}'"/>
+						</exec>
+				  		<exec executable="/bin/bash" outputproperty="vlan.tag">
+				  			<arg value="-c"/>
+							<arg value="echo ${create.circuit.output} | awk '{print $2}'"/>
+				  		</exec>
+
+						<property name="shirako.save.unit.connection.id" value="${connection.id}" />
+						<property name="shirako.save.unit.vlan.tag" value="${vlan.tag}" />
+						<property name="shirako.save.unit.status" value="ACTIVE" />
+						<echo message="Created connection with id: ${connection.id} and VLAN ${vlan.tag}." />
+						<property name="message" value="Created connection with id: ${connection.id} and VLAN ${vlan.tag}." />
+					</else>
+				</if>
+			<property name="shirako.target.code" value="${code}" />
+			<property name="shirako.target.code.message" value="${message}" />
+
+		</else>
+	</if>
+
+
+        <!-- hairpin -->
+        <var name="shirako.save.unit.vlan.url" unset="true" />
+        <if>
+                <isset property="unit.vlan.url" />
+                <then>
+                        <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+                </then>
+        </if>
+
+	<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+
+	<!-- Modify operation is not supported -->
+	<target name="modify" />
+
+
     <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="NSI HANDLER: LEAVE" /> 
-        <if> 
-            <isset property="nsi.site.properties" /> 
-            <then> 
-                <property file="${nsi.site.properties}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="nsi.connection.id" /> 
-            </not> 
-            <then> 
-                <property name="nsi.connection.id" value="${unit.connection.id}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="RUNNING UNDER EMULATION...EXITING" /> 
-                <echo message="Terminating NSI circuit: ${nsi.connection.id}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <var name="code" unset="true"></var> 
-                <echo message="Terminating NSI circuit: ${nsi.connection.id}" /> 
-                <atomic.sequence.start.macro device="NSIHandler" /> 
-                <exec executable="${nsi.scripts}/stop-nsi.sh" resultproperty="code" outputproperty="terminate.circuit.output" errorproperty="create.circuit.error"> 
-                    <env key="NSI_SCRIPTS_DIR" value="${nsi.scripts}" /> 
-                    <env key="NSI_HOSTKEY" value="${nsi.hostkey}" /> 
-                    <env key="NSI_HOSTCERT" value="${nsi.hostcert}" /> 
-                    <env key="NSI_CERTDIR" value="${nsi.certdir}" /> 
-                    <env key="NSI_TLS" value="${nsi.tls}" /> 
-                    <env key="NSI_VERIFY" value="${nsi.verify}" /> 
-                    <env key="NSI_SERVICE" value="${nsi.service}" /> 
-                    <env key="NSI_PROVIDER" value="${nsi.provider}" /> 
-                    <env key="NSI_REQUESTER" value="${nsi.requester}" /> 
-                    <env key="NSI_VERBOSE" value="${nsi.verbose}" /> 
-                    <env key="NSI_ONSA" value="${nsi.onsa}" /> 
-                    <env key="NSI_PYTHON" value="${nsi.python}" /> 
-                    <env key="NSI_TERMINATEDS" value="${nsi.terminated.string}" /> 
-                    <env key="NSI_ADDRINUSE" value="${nsi.addr.inuse.string}" /> 
-                    <!-- controller-supplied properties --> 
-                    <env key="NSI_CONNECTION_ID" value="${nsi.connection.id}" /> 
-                </exec> 
-                <atomic.sequence.stop.macro device="NSIHandler" /> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="Unable to terminate circuit: ${create.circuit.error}" /> 
-                        <property name="message" value="Unable to terminate circuit: ${create.circuit.error}" /> 
-                    </then> 
-                    <else> 
-                        <echo message="Connection ${nsi.connection.id} terminated." /> 
-                        <property name="message" value="Connection ${nsi.connection.id} terminated." /> 
-                    </else> 
-                </if> 
-                <echo message="nsi-stop.sh exit code: ${code}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <property name="shirako.target.code.message" value="${message}" /> 
-            </else> 
-        </if> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
+		<echo message="NSI HANDLER: LEAVE" />
+
+		<if>
+			<isset property="nsi.site.properties" />
+			<then>
+				<property file="${nsi.site.properties}" />
+			</then>
+		</if>
+
+		<if>
+			<not>
+				<isset property="nsi.connection.id" />
+			</not>
+			<then>
+				<property name="nsi.connection.id" value="${unit.connection.id}" />
+			</then>
+		</if>
+	
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="RUNNING UNDER EMULATION...EXITING" />
+				<echo message="Terminating NSI circuit: ${nsi.connection.id}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<var name="code" unset="true" />				
+				<echo message="Terminating NSI circuit: ${nsi.connection.id}" />
+
+				<atomic.sequence.start.macro device="NSIHandler"/>
+
+				<exec executable="${nsi.scripts}/stop-nsi.sh" resultproperty="code" outputproperty="terminate.circuit.output" errorproperty="create.circuit.error">
+				  	<env key="NSI_SCRIPTS_DIR" value="${nsi.scripts}" />
+				  	<env key="NSI_HOSTKEY" value="${nsi.hostkey}" />
+					<env key="NSI_HOSTCERT" value="${nsi.hostcert}" />
+					<env key="NSI_CERTDIR" value="${nsi.certdir}" />
+					<env key="NSI_TLS" value="${nsi.tls}" />
+					<env key="NSI_VERIFY" value="${nsi.verify}" />
+					<env key="NSI_SERVICE" value="${nsi.service}" />
+					<env key="NSI_PROVIDER" value="${nsi.provider}" />
+					<env key="NSI_REQUESTER" value="${nsi.requester}" />
+					<env key="NSI_VERBOSE" value="${nsi.verbose}" />
+					<env key="NSI_ONSA" value="${nsi.onsa}" />
+					<env key="NSI_PYTHON" value="${nsi.python}" />
+					<env key="NSI_TERMINATEDS" value="${nsi.terminated.string}" />
+					<env key="NSI_ADDRINUSE" value="${nsi.addr.inuse.string}" />
+
+					<!-- controller-supplied properties -->
+				  	<env key="NSI_CONNECTION_ID" value="${nsi.connection.id}" />
+
+				</exec>
+
+				<atomic.sequence.stop.macro device="NSIHandler"/>
+
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo message="Unable to terminate circuit: ${create.circuit.error}" />
+						<property name="message" value="Unable to terminate circuit: ${create.circuit.error}" />
+					</then>
+					<else>
+						<echo message="Connection ${nsi.connection.id} terminated." />
+						<property name="message" value="Connection ${nsi.connection.id} terminated." />
+					</else>
+				</if>
+				<echo message="nsi-stop.sh exit code: ${code}" />	
+				<property name="shirako.target.code" value="${code}" />
+				<property name="shirako.target.code.message" value="${message}" />
+			</else>
+		</if>
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
 </project>
+

--- a/handlers/oess/resources/handlers/oess/handler.xml
+++ b/handlers/oess/resources/handlers/oess/handler.xml
@@ -1,27 +1,38 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml">
+]>
 <project name="oess" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;	
+	&bentasks;
+	
+	<!-- Uncomment for handler testing
 	<property file="oess.test.properties"/>
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <taskdef resource="orca/handlers/nodeagent2/nodeagent2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <taskdef resource="orca/handlers/network/oess/oess.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <echo message="OESS NA2 HANDLER: JOIN" /> 
-        <!-- see oess.site.sample.properties and wiki for description
+	-->
+	
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+
+		<taskdef resource="orca/handlers/nodeagent2/nodeagent2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+		<taskdef resource="orca/handlers/network/oess/oess.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+	
+    	<echo message="OESS NA2 HANDLER: JOIN" />
+		<!-- see oess.site.sample.properties and wiki for description
 		of static properties that can be specified in oess.site.properties
-		--> 
-        <if> 
-            <isset property="oess.site.properties" /> 
-            <then> 
-                <property file="${oess.site.properties}" /> 
-            </then> 
-        </if> 
-        <!-- This handler requires the following static properties:
+		-->
+		<if>
+			<isset property="oess.site.properties" />
+			<then>
+				<property file="${oess.site.properties}" />
+			</then>
+		</if>
+	
+	
+		<!-- This handler requires the following static properties:
 			na2.oess.plugin=oess-plugin    	- name of the OESS plugin in NA2 configuration
 			na2.url=http://localhost:8080  	- URL of NA2
 			na2.password=pass              	- password to NA2
@@ -29,134 +40,159 @@
 			urn.map=					   	- optional map for URNs, same as in OSCARS
 			
 			The NA2 plugin is assumed to be configured for a particular OESS endpoint with credentials and URL
-	    --> 
-        <!-- The following properties are provided by the invoking AM:
+	    -->
+		<!-- The following properties are provided by the invoking AM:
 			config.interface.1   	 		- a URN of OESS endpoint in the form of urn:ogf:network:domain=al2s.net.internet2.edu:node=sdn-sw.houh.net.internet2.edu:port=et-0/3/0.0
 			config.interface.2				- a URN of OESS endpoint
 			resource.bandwidth				- bandwidth in bps
 			config.vlan.tag.1				- tag on 1
 			config.vlan.tag.2				- tag on 2
-		--> 
-        <if> 
-            <not> 
-                <isset property="oess.endpointA" /> 
-            </not> 
-            <then> 
-                <property name="oess.endpointA" value="${config.interface.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oess.endpointZ" /> 
-            </not> 
-            <then> 
-                <property name="oess.endpointZ" value="${config.interface.2}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oess.bw" /> 
-            </not> 
-            <then> 
-                <if> 
-                    <isset property="resource.bandwidth" /> 
-                    <then> 
-                        <property name="oess.bw" value="${resource.bandwidth}" /> 
-                    </then> 
-                    <else> 
-                        <property name="oess.bw" value="" /> 
-                    </else> 
-                </if> 
-            </then> 
-        </if> 
-        <if> 
-            <isset property="config.vlan.tag.1" /> 
-            <then> 
-                <property name="oess.tagA" value="${config.vlan.tag.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <isset property="config.vlan.tag.2" /> 
-            <then> 
-                <property name="oess.tagZ" value="${config.vlan.tag.2}" /> 
-            </then> 
-        </if> 
-        <echo message="creating OESS circuit from ${oess.endpointA}/${oess.tagA} to ${oess.endpointZ}/${oess.tagZ} with bw=${oess.bw}" /> 
-        <var name="oess.new.endpointA" unset="true"></var> 
-        <var name="oess.new.endpointZ" unset="true"></var> 
-        <oess.remap.urn oldUrn="${oess.endpointA}" newUrnProp="oess.new.endpointA" mapFile="${oess.site.properties}" mapProperty="urn.map" /> 
-        <oess.remap.urn oldUrn="${oess.endpointZ}" newUrnProp="oess.new.endpointZ" mapFile="${oess.site.properties}" mapProperty="urn.map" /> 
-        <var name="oess.endpointA" unset="true"></var> 
-        <var name="oess.endpointZ" unset="true"></var> 
-        <property name="oess.endpointA" value="${oess.new.endpointA}" /> 
-        <property name="oess.endpointZ" value="${oess.new.endpointZ}" /> 
-        <var name="oess.new.endpointA" unset="true"></var> 
-        <var name="oess.new.endpointZ" unset="true"></var> 
-        <echo message="after remap from ${oess.endpointA}/${oess.tagA} to ${oess.endpointZ}/${oess.tagZ} with bw=${oess.bw}" /> 
-        <var name="shirako.save.unit.vlan.tag" unset="true"></var> 
-        <var name="shirako.save.unit.status" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.reservation" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.idc" unset="true"></var> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="RUNNING UNDER EMULATION... EXITING" /> 
-                <property name="shirako.save.unit.vlan.reservation" value="some-reservation-id|${oess.endpointA}|${oess.tagA}|${oess.endpointZ}|${oess.tagZ}" /> 
-                <property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" /> 
-                <property name="shirako.save.unit.status" value="ACTIVE" /> 
-                <echo message="unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <echo message="Invoking JOIN on NA2 plugin ${na2.oess.plugin} at ${na2.url}" /> 
-                <var name="oess.join.reservation" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <!-- NA2 and the plugin do their own locking --> 
-                <!-- this collects all properties that start with "oess" and sends them to the NA2 OESS plugin --> 
-                <nodeagent2.join baseUrl="${na2.url}" prefix="oess" returnPrefix="oess.return" password="${na2.password}" plugin="${na2.oess.plugin}" statusProperty="code" errorMsgProperty="message" reservationIdProperty="oess.join.reservation" /> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="NA2 unable to create OESS circuit: ${message}" /> 
-                        <property name="message" value="NodeAgent unable to create OESS circuit: ${message}" /> 
-                    </then> 
-                    <else> 
-                        <property name="shirako.save.unit.vlan.reservation" value="${oess.join.reservation}" /> 
-                        <property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" /> 
-                        <property name="shirako.save.unit.status" value="ACTIVE" /> 
-                        <echo message="NA2 created reservation unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" /> 
-                    </else> 
-                </if> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <property name="shirako.target.code.message" value="${message}" /> 
-            </else> 
-        </if> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- Modify operation is not supported --> 
-    <target name="modify" /> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <taskdef resource="orca/handlers/nodeagent2/nodeagent2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <taskdef resource="orca/handlers/network/oess/oess.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <echo message="OESS NA2 HANDLER: LEAVE" /> 
-        <if> 
-            <isset property="oess.site.properties" /> 
-            <then> 
-                <property file="${oess.site.properties}" /> 
-            </then> 
-        </if> 
-        <!-- This handler requires the following static properties:
+		-->
+			
+		<if>
+			<not>
+				<isset property="oess.endpointA" />
+			</not>
+			<then>
+				<property name="oess.endpointA" value="${config.interface.1}" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oess.endpointZ" />
+			</not>
+			<then>
+				<property name="oess.endpointZ" value="${config.interface.2}" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oess.bw" />
+			</not>
+			<then>
+				<if>
+					<isset property="resource.bandwidth" />
+					<then>
+						<property name="oess.bw" value="${resource.bandwidth}" />
+					</then>
+					<else>
+						<property name="oess.bw" value="" />
+					</else>
+				</if>
+			</then>
+		</if>
+	
+		<if>
+			<isset property="config.vlan.tag.1" />
+			<then>
+				<property name="oess.tagA" value="${config.vlan.tag.1}" />
+			</then>
+		</if>
+	
+		<if>
+			<isset property="config.vlan.tag.2" />
+			<then>
+				<property name="oess.tagZ" value="${config.vlan.tag.2}" />
+			</then>
+		</if>
+	
+		<echo message="creating OESS circuit from ${oess.endpointA}/${oess.tagA} to ${oess.endpointZ}/${oess.tagZ} with bw=${oess.bw}" />
+	
+		<var name="oess.new.endpointA" unset="true" />
+		<var name="oess.new.endpointZ" unset="true" />
+		<oess.remap.urn oldUrn="${oess.endpointA}" newUrnProp="oess.new.endpointA" mapFile="${oess.site.properties}" mapProperty="urn.map" />	
+		<oess.remap.urn oldUrn="${oess.endpointZ}" newUrnProp="oess.new.endpointZ" mapFile="${oess.site.properties}" mapProperty="urn.map" />
+		
+		<var name="oess.endpointA" unset="true" />
+		<var name="oess.endpointZ" unset="true" />
+		<property name="oess.endpointA" value="${oess.new.endpointA}" />
+		<property name="oess.endpointZ" value="${oess.new.endpointZ}" />
+		<var name="oess.new.endpointA" unset="true" />
+		<var name="oess.new.endpointZ" unset="true" />
+	
+		<echo message="after remap from ${oess.endpointA}/${oess.tagA} to ${oess.endpointZ}/${oess.tagZ} with bw=${oess.bw}" />	
+	
+		<var name="shirako.save.unit.vlan.tag" unset="true" />
+		<var name="shirako.save.unit.status" unset="true" />
+		<var name="shirako.save.unit.vlan.reservation" unset="true" />
+		<var name="shirako.save.unit.vlan.idc" unset="true" />
+	
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+
+	
+				<echo message="RUNNING UNDER EMULATION... EXITING" />
+
+				<property name="shirako.save.unit.vlan.reservation" value="some-reservation-id|${oess.endpointA}|${oess.tagA}|${oess.endpointZ}|${oess.tagZ}" />
+				<property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" />
+				<property name="shirako.save.unit.status" value="ACTIVE" />
+				<echo message="unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>			
+				<echo message="Invoking JOIN on NA2 plugin ${na2.oess.plugin} at ${na2.url}"/>
+	
+				<var name="oess.join.reservation" unset="true" />
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+	
+				<!-- NA2 and the plugin do their own locking -->
+				<!-- this collects all properties that start with "oess" and sends them to the NA2 OESS plugin -->
+				<nodeagent2.join baseUrl="${na2.url}" prefix="oess" returnPrefix="oess.return" password="${na2.password}" plugin="${na2.oess.plugin}" 
+						statusProperty="code" errorMsgProperty="message" reservationIdProperty="oess.join.reservation" />
+
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo message="NA2 unable to create OESS circuit: ${message}" />
+						<property name="message" value="NodeAgent unable to create OESS circuit: ${message}" />
+					</then>
+					<else>
+						<property name="shirako.save.unit.vlan.reservation" value="${oess.join.reservation}" />
+						<property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" />
+						<property name="shirako.save.unit.status" value="ACTIVE" />
+						<echo message="NA2 created reservation unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" />
+					</else>
+				</if>
+			<property name="shirako.target.code" value="${code}" />
+			<property name="shirako.target.code.message" value="${message}" />
+		</else>
+	</if>
+        <!-- hairpin -->
+        <var name="shirako.save.unit.vlan.url" unset="true" />
+        <if>
+                <isset property="unit.vlan.url" />
+                <then>
+                        <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+                </then>
+        </if>
+
+	<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<!-- Modify operation is not supported -->
+	<target name="modify" />
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+	
+		<taskdef resource="orca/handlers/nodeagent2/nodeagent2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+		<taskdef resource="orca/handlers/network/oess/oess.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+	
+		<echo message="OESS NA2 HANDLER: LEAVE" />
+
+		<if>
+			<isset property="oess.site.properties" />
+			<then>
+				<property file="${oess.site.properties}" />
+			</then>
+		</if>
+
+		<!-- This handler requires the following static properties:
 			na2.oess.plugin=oess-plugin    	- name of the OESS plugin in NA2 configuration
 			na2.url=http://localhost:8080  	- URL of NA2
 			na2.password=pass              	- password to NA2
@@ -164,29 +200,35 @@
 			urn.map=					   	- optional map for URNs, same as in OSCARS
 			
 			The NA2 plugin is assumed to be configured for a particular OESS endpoint with credentials and URL
-	    --> 
-        <!-- The following properties are provided by the invoking AM:
+	    -->
+		<!-- The following properties are provided by the invoking AM:
 			unit.vlan.reservation 			- OESS circuit ID
-		--> 
-        <echo message="Removing vlan ${unit.vlan.tag} reservation ${unit.vlan.reservation}" /> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="RUNNING UNDER EMULATION...EXITING" /> 
-                <echo message="terminating OESS circuit: ${unit.vlan.reservation}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <echo message="Invoking LEAVE on NA2 plugin ${na2.oess.plugin} at ${na2.url} for reservation ${unit.vlan.reservation}" /> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <!-- na2 does its own locking --> 
-                <!-- this collects all properties that start with "unit" and sends them to the NA2 OESS plugin --> 
-                <nodeagent2.leave baseUrl="${na2.url}" prefix="unit" returnPrefix="oess.return" password="${na2.password}" plugin="${na2.oess.plugin}" reservationId="${unit.vlan.reservation}" statusProperty="code" errorMsgProperty="message" reservationIdProperty="oess.leave.reservation" /> 
-                <echo message="NA2 exit code: ${code} with message ${message}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
+		-->
+	
+		<echo message="Removing vlan ${unit.vlan.tag} reservation ${unit.vlan.reservation}" />
+	
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="RUNNING UNDER EMULATION...EXITING" />
+				<echo message="terminating OESS circuit: ${unit.vlan.reservation}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<echo message="Invoking LEAVE on NA2 plugin ${na2.oess.plugin} at ${na2.url} for reservation ${unit.vlan.reservation}"/>
+				<var name="code" unset="true" />	
+				<var name="message" unset="true" />
+	
+				<!-- na2 does its own locking -->
+				<!-- this collects all properties that start with "unit" and sends them to the NA2 OESS plugin -->
+				<nodeagent2.leave baseUrl="${na2.url}" prefix="unit" returnPrefix="oess.return" password="${na2.password}" plugin="${na2.oess.plugin}" 
+					reservationId="${unit.vlan.reservation}" statusProperty="code" errorMsgProperty="message" reservationIdProperty="oess.leave.reservation" />
+	
+				<echo message="NA2 exit code: ${code} with message ${message}" />	
+				<property name="shirako.target.code" value="${code}" />
+			</else>
+		</if>
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
 </project>
+

--- a/handlers/oscars/resources/handlers/oscars/handler-nona.xml
+++ b/handlers/oscars/resources/handlers/oscars/handler-nona.xml
@@ -1,248 +1,297 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml">
+]>
 <project name="oscars" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;	
+	&bentasks;
+	
+	<!-- Uncomment for handler testing
 	<property file="oscars.test.properties"/>
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <taskdef resource="orca/handlers/network/oscars/oscars.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <echo message="OSCARS/ION HANDLER: JOIN" /> 
-        <!-- see oscars.site.sample.properties and wiki for description
+	-->
+	
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+
+		<taskdef resource="orca/handlers/network/oscars/oscars.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+    	<echo message="OSCARS/ION HANDLER: JOIN" />
+		<!-- see oscars.site.sample.properties and wiki for description
 		of static properties that can be specified in oscars.site.properties
-		--> 
-        <if> 
-            <isset property="oscars.site.properties" /> 
-            <then> 
-                <property file="${oscars.site.properties}" /> 
-            </then> 
-        </if> 
-        <!-- default to OSCARS v06 (other option is v05) --> 
-        <if> 
-            <not> 
-                <isset property="oscars.version" /> 
-            </not> 
-            <then> 
-                <property name="oscars.version" value="v06" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oscars.endpointA" /> 
-            </not> 
-            <then> 
-                <property name="oscars.endpointA" value="${config.interface.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oscars.endpointZ" /> 
-            </not> 
-            <then> 
-                <property name="oscars.endpointZ" value="${config.interface.2}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oscars.bw" /> 
-            </not> 
-            <then> 
-                <if> 
-                    <isset property="resource.bandwidth" /> 
-                    <then> 
-                        <property name="oscars.bw" value="${resource.bandwidth}" /> 
-                    </then> 
-                    <else> 
-                        <property name="oscars.bw" value="" /> 
-                    </else> 
-                </if> 
-            </then> 
-        </if> 
-        <if> 
-            <isset property="config.vlan.tag.1" /> 
-            <then> 
-                <property name="oscars.tagA" value="${config.vlan.tag.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <isset property="config.vlan.tag.2" /> 
-            <then> 
-                <property name="oscars.tagZ" value="${config.vlan.tag.2}" /> 
-            </then> 
-        </if> 
-        <echo message="creating OSCARS circuit from ${oscars.endpointA}/${oscars.tagA} to ${oscars.endpointZ}/${oscars.tagZ} for ${config.duration} (sec) with bw=${oscars.bw}" /> 
-        <var name="oscars.new.endpointA" unset="true"></var> 
-        <var name="oscars.new.endpointZ" unset="true"></var> 
-        <oscars.remap.urn oldUrn="${oscars.endpointA}" newUrnProp="oscars.new.endpointA" mapFile="${oscars.site.properties}" mapProperty="urn.map" /> 
-        <oscars.remap.urn oldUrn="${oscars.endpointZ}" newUrnProp="oscars.new.endpointZ" mapFile="${oscars.site.properties}" mapProperty="urn.map" /> 
-        <var name="oscars.endpointA" unset="true"></var> 
-        <var name="oscars.endpointZ" unset="true"></var> 
-        <property name="oscars.endpointA" value="${oscars.new.endpointA}" /> 
-        <property name="oscars.endpointZ" value="${oscars.new.endpointZ}" /> 
-        <var name="oscars.new.endpointA" unset="true"></var> 
-        <var name="oscars.new.endpointZ" unset="true"></var> 
-        <echo message="after remap from ${oscars.endpointA}/${oscars.tagA} to ${oscars.endpointZ}/${oscars.tagZ} for ${config.duration} (sec) with bw=${oscars.bw}" /> 
-        <var name="shirako.save.unit.vlan.tag" unset="true"></var> 
-        <var name="shirako.save.unit.status" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.reservation" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.idc" unset="true"></var> 
-        <!-- determine the controller to call --> 
-        <var name="ctrl.domain.A" unset="true"></var> 
-        <propertyregex property="ctrl.domain.A" input="${oscars.endpointA}" regexp="urn:ogf:network:domain=([^\.]*)\.*" select="\1" casesensitive="false" /> 
-        <var name="ctrl.domain.Z" unset="true"></var> 
-        <propertyregex property="ctrl.domain.Z" input="${oscars.endpointZ}" regexp="urn:ogf:network:domain=([^\.]*)\.*" select="\1" casesensitive="false" /> 
-        <var name="ctrl.to.call" unset="true"></var> 
-        <if> 
-            <equals arg1="${ctrl.domain.A}" arg2="al2s" /> 
-            <then> 
-                <property name="ctrl.to.call" value="${oscars.idc.al2s}" /> 
-            </then> 
-            <else> 
-                <if> 
-                    <equals arg1="${ctrl.domain.A}" arg2="es" /> 
-                    <then> 
-                        <property name="ctrl.to.call" value="${oscars.idc.es}" /> 
-                    </then> 
-                    <else> 
-                        <if> 
-                            <equals arg1="${ctrl.domain.A}" arg2="ion" /> 
-                            <then> 
-                                <property name="ctrl.to.call" value="${oscars.idc.ion}" /> 
-                            </then> 
-                            <else> 
-                                <if> 
-                                    <equals arg1="${ctrl.domain.A}" arg2="tb" /> 
-                                    <then> 
-                                        <property name="ctrl.to.call" value="${oscars.idc.tb}" /> 
-                                    </then> 
-                                    <else> 
-                                        <echo message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" /> 
-                                        <fail message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" /> 
-                                    </else> 
-                                </if> 
-                            </else> 
-                        </if> 
-                    </else> 
-                </if> 
-            </else> 
-        </if> 
-        <echo message="Calling OSCARS controller ${ctrl.to.call}" /> 
-        <property name="shirako.save.unit.vlan.idc" value="${ctrl.to.call}" /> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="RUNNING UNDER EMULATION... EXITING" /> 
-                <property name="shirako.save.unit.vlan.reservation" value="some-reservation-id|${oscars.endpointA}|${oscars.tagA}|${oscars.endpointZ}|${oscars.tagZ}" /> 
-                <property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" /> 
-                <property name="shirako.save.unit.status" value="ACTIVE" /> 
-                <echo message="unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <var name="create.circuit.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <!-- per evangelos on 03/07/14 - asked to serialize requests to oscars --> 
-                <atomic.sequence.start.macro device="${ctrl.to.call}" /> 
-                <exec executable="${oscars.scripts}/start-oscars-${oscars.version}.sh" resultproperty="code" outputproperty="create.circuit.output"> 
-                    <env key="OSCARS_SCRIPTS_DIR" value="${oscars.scripts}" /> 
-                    <env key="OSCARS_HOME" value="${oscars.home}" /> 
-                    <env key="OSCARS_IDC" value="${ctrl.to.call}" /> 
-                    <env key="OSCARS_QUERY_INTERVAL" value="${oscars.query.interval}" /> 
-                    <env key="OSCARS_DESC" value="${oscars.desc}" /> 
-                    <env key="OSCARS_PATHSETUP" value="${oscars.pathsetup}" /> 
-                    <env key="OSCARS_TRUSTSTORE" value="${oscars.truststore}" /> 
-                    <env key="OSCARS_KEYSTORE" value="${oscars.keystore}" /> 
-                    <env key="OSCARS_ALIAS" value="${oscars.alias}" /> 
-                    <env key="OSCARS_KEYSTOREPASS" value="${oscars.keystorepass}" /> 
-                    <!-- controller-supplied properties --> 
-                    <env key="OSCARS_L2_SRC" value="${oscars.endpointA}" /> 
-                    <env key="OSCARS_L2_DST" value="${oscars.endpointZ}" /> 
-                    <env key="OSCARS_BW" value="${oscars.bw}" /> 
-                    <env key="OSCARS_DURATION" value="${config.duration}" /> 
-                    <env key="OSCARS_L2_SRC_TAG" value="${oscars.tagA}" /> 
-                    <env key="OSCARS_L2_DST_TAG" value="${oscars.tagZ}" /> 
-                </exec> 
-                <atomic.sequence.stop.macro device="${ctrl.to.call}" /> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="Unable to create circuit: ${create.circuit.output}" /> 
-                        <property name="message" value="Unable to create circuit: ${create.circuit.output}" /> 
-                    </then> 
-                    <else> 
-                        <property name="shirako.save.unit.vlan.reservation" value="${create.circuit.output}" /> 
-                        <property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" /> 
-                        <property name="shirako.save.unit.status" value="ACTIVE" /> 
-                        <echo message="Reserved unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" /> 
-                    </else> 
-                </if> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <property name="shirako.target.code.message" value="${message}" /> 
-            </else> 
-        </if> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- Modify operation is not supported --> 
-    <target name="modify" /> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="OSCARS/ION HANDLER: LEAVE" /> 
-        <if> 
-            <isset property="oscars.site.properties" /> 
-            <then> 
-                <property file="${oscars.site.properties}" /> 
-            </then> 
-        </if> 
-        <echo message="Removing vlan ${unit.vlan.tag} reservation ${unit.vlan.reservation}" /> 
-        <if> 
-            <not> 
-                <isset property="unit.vlan.idc" /> 
-            </not> 
-            <then> 
-                <property name="unit.vlan.idc" value="${oscars.idc.ion}" /> 
-            </then> 
-        </if> 
-        <echo message="Calling OSCARS controller ${unit.vlan.idc}" /> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="RUNNING UNDER EMULATION...EXITING" /> 
-                <echo message="terminating OSCARS circuit: ${unit.vlan.reservation}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <var name="code" unset="true"></var> 
-                <echo message="terminating OSCARS circuit: ${unit.vlan.reservation}" /> 
-                <atomic.sequence.start.macro device="${unit.vlan.idc}" /> 
-                <exec executable="${oscars.scripts}/stop-oscars-${oscars.version}.sh" resultproperty="code" outputproperty="terminate.circuit.output"> 
-                    <env key="OSCARS_SCRIPTS_DIR" value="${oscars.scripts}" /> 
-                    <env key="OSCARS_HOME" value="${oscars.home}" /> 
-                    <env key="OSCARS_IDC" value="${unit.vlan.idc}" /> 
-                    <env key="OSCARS_TRUSTSTORE" value="${oscars.truststore}" /> 
-                    <env key="OSCARS_KEYSTORE" value="${oscars.keystore}" /> 
-                    <env key="OSCARS_ALIAS" value="${oscars.alias}" /> 
-                    <env key="OSCARS_KEYSTOREPASS" value="${oscars.keystorepass}" /> 
-                    <!-- controller-supplied properties --> 
-                    <env key="OSCARS_UNIT_VLAN_RESERVATION" value="${unit.vlan.reservation}" /> 
-                </exec> 
-                <atomic.sequence.stop.macro device="${unit.vlan.idc}" /> 
-                <echo message="oscars-stop.sh exit code: ${code}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
+		-->
+		<if>
+			<isset property="oscars.site.properties" />
+			<then>
+				<property file="${oscars.site.properties}" />
+			</then>
+		</if>
+
+		<!-- default to OSCARS v06 (other option is v05) -->
+		<if>
+			<not>
+				<isset property="oscars.version" />
+			</not>
+			<then>
+				<property name="oscars.version" value="v06" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oscars.endpointA" />
+			</not>
+			<then>
+				<property name="oscars.endpointA" value="${config.interface.1}" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oscars.endpointZ" />
+			</not>
+			<then>
+				<property name="oscars.endpointZ" value="${config.interface.2}" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oscars.bw" />
+			</not>
+			<then>
+				<if>
+					<isset property="resource.bandwidth" />
+					<then>
+						<property name="oscars.bw" value="${resource.bandwidth}" />
+					</then>
+					<else>
+						<property name="oscars.bw" value="" />
+					</else>
+				</if>
+			</then>
+		</if>
+	
+		<if>
+			<isset property="config.vlan.tag.1" />
+			<then>
+				<property name="oscars.tagA" value="${config.vlan.tag.1}" />
+			</then>
+		</if>
+	
+		<if>
+			<isset property="config.vlan.tag.2" />
+			<then>
+				<property name="oscars.tagZ" value="${config.vlan.tag.2}" />
+			</then>
+		</if>
+	
+		<echo message="creating OSCARS circuit from ${oscars.endpointA}/${oscars.tagA} to ${oscars.endpointZ}/${oscars.tagZ} for ${config.duration} (sec) with bw=${oscars.bw}" />
+	
+		<var name="oscars.new.endpointA" unset="true" />
+		<var name="oscars.new.endpointZ" unset="true" />
+		<oscars.remap.urn oldUrn="${oscars.endpointA}" newUrnProp="oscars.new.endpointA" mapFile="${oscars.site.properties}" mapProperty="urn.map" />	
+		<oscars.remap.urn oldUrn="${oscars.endpointZ}" newUrnProp="oscars.new.endpointZ" mapFile="${oscars.site.properties}" mapProperty="urn.map" />
+		
+		<var name="oscars.endpointA" unset="true" />
+		<var name="oscars.endpointZ" unset="true" />
+		<property name="oscars.endpointA" value="${oscars.new.endpointA}" />
+		<property name="oscars.endpointZ" value="${oscars.new.endpointZ}" />
+		<var name="oscars.new.endpointA" unset="true" />
+		<var name="oscars.new.endpointZ" unset="true" />
+	
+		<echo message="after remap from ${oscars.endpointA}/${oscars.tagA} to ${oscars.endpointZ}/${oscars.tagZ} for ${config.duration} (sec) with bw=${oscars.bw}" />	
+	
+		<var name="shirako.save.unit.vlan.tag" unset="true" />
+		<var name="shirako.save.unit.status" unset="true" />
+		<var name="shirako.save.unit.vlan.reservation" unset="true" />
+		<var name="shirako.save.unit.vlan.idc" unset="true" />
+	
+		<!-- determine the controller to call -->
+		<var name="ctrl.domain.A" unset="true"/>
+		<propertyregex property="ctrl.domain.A"
+	    	input="${oscars.endpointA}"
+	    	regexp="urn:ogf:network:domain=([^\.]*)\.*"
+	    	select="\1"
+	    	casesensitive="false" />
+	
+		<var name="ctrl.domain.Z" unset="true"/>
+		<propertyregex property="ctrl.domain.Z"
+	    	input="${oscars.endpointZ}"
+	    	regexp="urn:ogf:network:domain=([^\.]*)\.*"
+	    	select="\1"
+	    	casesensitive="false" />
+
+		<var name="ctrl.to.call" unset="true"/>
+
+		<if>
+			<equals arg1="${ctrl.domain.A}" arg2="al2s" />
+			<then>
+				<property name="ctrl.to.call" value="${oscars.idc.al2s}" />
+			</then>
+			<else>
+				<if>
+					<equals arg1="${ctrl.domain.A}" arg2="es" />
+					<then>
+						<property name="ctrl.to.call" value="${oscars.idc.es}" />
+					</then>
+					<else>
+						<if>
+							<equals arg1="${ctrl.domain.A}" arg2="ion" />
+							<then>
+								<property name="ctrl.to.call" value="${oscars.idc.ion}" />
+							</then>
+							<else>
+								<if>
+									<equals arg1="${ctrl.domain.A}" arg2="tb" />
+									<then>
+										<property name="ctrl.to.call" value="${oscars.idc.tb}" />
+									</then>
+									<else>
+										<echo message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" />
+										<fail message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" />
+									</else>
+								</if>
+							</else>
+						</if>
+					</else>
+				</if>
+			</else>
+		</if>
+		<echo message="Calling OSCARS controller ${ctrl.to.call}" />
+		<property name="shirako.save.unit.vlan.idc" value="${ctrl.to.call}" />
+	
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+
+	
+				<echo message="RUNNING UNDER EMULATION... EXITING" />
+
+				<property name="shirako.save.unit.vlan.reservation" value="some-reservation-id|${oscars.endpointA}|${oscars.tagA}|${oscars.endpointZ}|${oscars.tagZ}" />
+				<property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" />
+				<property name="shirako.save.unit.status" value="ACTIVE" />
+				<echo message="unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>				
+				<var name="create.circuit.output" unset="true" />
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+	
+				<!-- per evangelos on 03/07/14 - asked to serialize requests to oscars -->
+				<atomic.sequence.start.macro
+					device="${ctrl.to.call}" />
+				<exec executable="${oscars.scripts}/start-oscars-${oscars.version}.sh" resultproperty="code" outputproperty="create.circuit.output">
+				  	<env key="OSCARS_SCRIPTS_DIR" value="${oscars.scripts}" />
+				  	<env key="OSCARS_HOME" value="${oscars.home}" />
+				  	<env key="OSCARS_IDC" value="${ctrl.to.call}" />
+				  	<env key="OSCARS_QUERY_INTERVAL" value="${oscars.query.interval}" />
+				  	<env key="OSCARS_DESC" value="${oscars.desc}" />
+				  	<env key="OSCARS_PATHSETUP" value="${oscars.pathsetup}" />
+					<env key="OSCARS_TRUSTSTORE" value="${oscars.truststore}" />
+					<env key="OSCARS_KEYSTORE" value="${oscars.keystore}" />
+					<env key="OSCARS_ALIAS" value="${oscars.alias}" />
+					<env key="OSCARS_KEYSTOREPASS" value="${oscars.keystorepass}" />
+					<!-- controller-supplied properties -->
+				  	<env key="OSCARS_L2_SRC" value="${oscars.endpointA}" />
+				  	<env key="OSCARS_L2_DST" value="${oscars.endpointZ}" />
+				  	<env key="OSCARS_BW" value="${oscars.bw}" />
+				  	<env key="OSCARS_DURATION" value="${config.duration}" />
+					<env key="OSCARS_L2_SRC_TAG" value="${oscars.tagA}" />
+					<env key="OSCARS_L2_DST_TAG" value="${oscars.tagZ}" />
+				</exec>
+				<atomic.sequence.stop.macro
+						device="${ctrl.to.call}" />
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo message="Unable to create circuit: ${create.circuit.output}" />
+						<property name="message" value="Unable to create circuit: ${create.circuit.output}" />
+					</then>
+					<else>
+						<property name="shirako.save.unit.vlan.reservation" value="${create.circuit.output}" />
+						<property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" />
+						<property name="shirako.save.unit.status" value="ACTIVE" />
+						<echo message="Reserved unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" />
+					</else>
+				</if>
+			<property name="shirako.target.code" value="${code}" />
+			<property name="shirako.target.code.message" value="${message}" />
+		</else>
+	</if>
+        <!-- hairpin -->
+        <var name="shirako.save.unit.vlan.url" unset="true" />
+        <if>
+                <isset property="unit.vlan.url" />
+                <then>
+                        <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+                </then>
+        </if>
+
+	<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<!-- Modify operation is not supported -->
+	<target name="modify" />
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="OSCARS/ION HANDLER: LEAVE" />
+
+		<if>
+			<isset property="oscars.site.properties" />
+			<then>
+				<property file="${oscars.site.properties}" />
+			</then>
+		</if>
+
+		<echo message="Removing vlan ${unit.vlan.tag} reservation ${unit.vlan.reservation}" />
+	
+		<if>
+			<not>
+				<isset property="unit.vlan.idc"/>
+			</not>
+			<then>
+				<property name="unit.vlan.idc" value="${oscars.idc.ion}" />
+			</then>
+		</if>
+	
+		<echo message="Calling OSCARS controller ${unit.vlan.idc}" />
+	
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="RUNNING UNDER EMULATION...EXITING" />
+				<echo message="terminating OSCARS circuit: ${unit.vlan.reservation}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<var name="code" unset="true" />				
+				<echo message="terminating OSCARS circuit: ${unit.vlan.reservation}" />
+				<atomic.sequence.start.macro
+					device="${unit.vlan.idc}" />
+				<exec executable="${oscars.scripts}/stop-oscars-${oscars.version}.sh" resultproperty="code" outputproperty="terminate.circuit.output" >
+				  	<env key="OSCARS_SCRIPTS_DIR" value="${oscars.scripts}" />
+				  	<env key="OSCARS_HOME" value="${oscars.home}" />
+				  	<env key="OSCARS_IDC" value="${unit.vlan.idc}" />
+					<env key="OSCARS_TRUSTSTORE" value="${oscars.truststore}" />
+					<env key="OSCARS_KEYSTORE" value="${oscars.keystore}" />
+					<env key="OSCARS_ALIAS" value="${oscars.alias}" />
+					<env key="OSCARS_KEYSTOREPASS" value="${oscars.keystorepass}" />
+					<!-- controller-supplied properties -->
+					<env key="OSCARS_UNIT_VLAN_RESERVATION" value="${unit.vlan.reservation}" />
+				</exec>
+				<atomic.sequence.stop.macro
+					device="${unit.vlan.idc}" />
+				<echo message="oscars-stop.sh exit code: ${code}" />	
+				<property name="shirako.target.code" value="${code}" />
+			</else>
+		</if>
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
 </project>
+

--- a/handlers/oscars/resources/handlers/oscars/handler-noop.xml
+++ b/handlers/oscars/resources/handlers/oscars/handler-noop.xml
@@ -1,191 +1,236 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml">
+]>
 <project name="oscars" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;	
+	&bentasks;
+	
+	<!-- Uncomment for handler testing
 	<property file="oscars.test.properties"/>
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <taskdef resource="orca/handlers/network/oscars/oscars.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <echo message="OSCARS/ION HANDLER: JOIN" /> 
-        <!-- see oscars.site.sample.properties and wiki for description
+	-->
+	
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+
+		<taskdef resource="orca/handlers/network/oscars/oscars.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+    	<echo message="OSCARS/ION HANDLER: JOIN" />
+		<!-- see oscars.site.sample.properties and wiki for description
 		of static properties that can be specified in oscars.site.properties
-		--> 
-        <if> 
-            <isset property="oscars.site.properties" /> 
-            <then> 
-                <property file="${oscars.site.properties}" /> 
-            </then> 
-        </if> 
-        <!-- default to OSCARS v06 (other option is v05) --> 
-        <if> 
-            <not> 
-                <isset property="oscars.version" /> 
-            </not> 
-            <then> 
-                <property name="oscars.version" value="v06" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oscars.endpointA" /> 
-            </not> 
-            <then> 
-                <property name="oscars.endpointA" value="${config.interface.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oscars.endpointZ" /> 
-            </not> 
-            <then> 
-                <property name="oscars.endpointZ" value="${config.interface.2}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oscars.bw" /> 
-            </not> 
-            <then> 
-                <if> 
-                    <isset property="resource.bandwidth" /> 
-                    <then> 
-                        <property name="oscars.bw" value="${resource.bandwidth}" /> 
-                    </then> 
-                    <else> 
-                        <property name="oscars.bw" value="" /> 
-                    </else> 
-                </if> 
-            </then> 
-        </if> 
-        <if> 
-            <isset property="config.vlan.tag.1" /> 
-            <then> 
-                <property name="oscars.tagA" value="${config.vlan.tag.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <isset property="config.vlan.tag.2" /> 
-            <then> 
-                <property name="oscars.tagZ" value="${config.vlan.tag.2}" /> 
-            </then> 
-        </if> 
-        <echo message="creating OSCARS circuit from ${oscars.endpointA}/${oscars.tagA} to ${oscars.endpointZ}/${oscars.tagZ} for ${config.duration} (sec) with bw=${oscars.bw}" /> 
-        <var name="shirako.save.unit.vlan.tag" unset="true"></var> 
-        <var name="shirako.save.unit.status" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.reservation" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.idc" unset="true"></var> 
-        <!-- determine the controller to call --> 
-        <var name="ctrl.domain.A" unset="true"></var> 
-        <propertyregex property="ctrl.domain.A" input="${oscars.endpointA}" regexp="urn:ogf:network:domain=([^\.]*)\.*" select="\1" casesensitive="false" /> 
-        <var name="ctrl.domain.Z" unset="true"></var> 
-        <propertyregex property="ctrl.domain.Z" input="${oscars.endpointZ}" regexp="urn:ogf:network:domain=([^\.]*)\.*" select="\1" casesensitive="false" /> 
-        <var name="ctrl.to.call" unset="true"></var> 
-        <if> 
-            <equals arg1="${ctrl.domain.A}" arg2="al2s" /> 
-            <then> 
-                <property name="ctrl.to.call" value="${oscars.idc.al2s}" /> 
-            </then> 
-            <else> 
-                <if> 
-                    <equals arg1="${ctrl.domain.A}" arg2="es" /> 
-                    <then> 
-                        <property name="ctrl.to.call" value="${oscars.idc.es}" /> 
-                    </then> 
-                    <else> 
-                        <if> 
-                            <equals arg1="${ctrl.domain.A}" arg2="ion" /> 
-                            <then> 
-                                <property name="ctrl.to.call" value="${oscars.idc.ion}" /> 
-                            </then> 
-                            <else> 
-                                <if> 
-                                    <equals arg1="${ctrl.domain.A}" arg2="tb" /> 
-                                    <then> 
-                                        <property name="ctrl.to.call" value="${oscars.idc.tb}" /> 
-                                    </then> 
-                                    <else> 
-                                        <echo message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" /> 
-                                        <fail message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" /> 
-                                    </else> 
-                                </if> 
-                            </else> 
-                        </if> 
-                    </else> 
-                </if> 
-            </else> 
-        </if> 
-        <echo message="Calling OSCARS controller ${ctrl.to.call}" /> 
-        <property name="shirako.save.unit.vlan.idc" value="${ctrl.to.call}" /> 
-        <var name="create.circuit.output" unset="true"></var> 
-        <var name="code" unset="true"></var> 
-        <var name="message" unset="true"></var> 
-        <!-- per evangelos on 03/07/14 - asked to serialize requests to oscars --> 
-        <atomic.sequence.start.macro device="${ctrl.to.call}" /> 
-        <echo message="Sleeping for 60000 milliseconds" /> 
-        <sleep milliseconds="60000" /> 
-        <property name="code" value="0" /> 
-        <property name="message" value="ALL OK" /> 
-        <atomic.sequence.stop.macro device="${ctrl.to.call}" /> 
-        <if> 
-            <not> 
-                <equals arg1="${code}" arg2="0" /> 
-            </not> 
-            <then> 
-                <echo message="Unable to create circuit: ${create.circuit.output}" /> 
-                <property name="message" value="Unable to create circuit: ${create.circuit.output}" /> 
-            </then> 
-            <else> 
-                <property name="shirako.save.unit.vlan.reservation" value="${create.circuit.output}" /> 
-                <property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" /> 
-                <property name="shirako.save.unit.status" value="ACTIVE" /> 
-                <echo message="Reserved unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" /> 
-            </else> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <property name="shirako.target.code.message" value="${message}" /> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- Modify operation is not supported --> 
-    <target name="modify" /> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="OSCARS/ION HANDLER: LEAVE" /> 
-        <if> 
-            <isset property="oscars.site.properties" /> 
-            <then> 
-                <property file="${oscars.site.properties}" /> 
-            </then> 
-        </if> 
-        <echo message="Removing vlan ${unit.vlan.tag} reservation ${unit.vlan.reservation}" /> 
-        <if> 
-            <not> 
-                <isset property="unit.vlan.idc" /> 
-            </not> 
-            <then> 
-                <property name="unit.vlan.idc" value="${oscars.idc.ion}" /> 
-            </then> 
-        </if> 
-        <echo message="Calling OSCARS controller ${unit.vlan.idc}" /> 
-        <var name="code" unset="true"></var> 
-        <echo message="terminating OSCARS circuit: ${unit.vlan.reservation}" /> 
-        <atomic.sequence.start.macro device="${unit.vlan.idc}" /> 
-        <echo message="Sleeping for 5000 milliseconds" /> 
-        <sleep milliseconds="5000" /> 
-        <property name="code" value="0" /> 
-        <atomic.sequence.stop.macro device="${unit.vlan.idc}" /> 
-        <echo message="oscars-stop.sh exit code: ${code}" /> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
+		-->
+		<if>
+			<isset property="oscars.site.properties" />
+			<then>
+				<property file="${oscars.site.properties}" />
+			</then>
+		</if>
+
+		<!-- default to OSCARS v06 (other option is v05) -->
+		<if>
+			<not>
+				<isset property="oscars.version" />
+			</not>
+			<then>
+				<property name="oscars.version" value="v06" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oscars.endpointA" />
+			</not>
+			<then>
+				<property name="oscars.endpointA" value="${config.interface.1}" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oscars.endpointZ" />
+			</not>
+			<then>
+				<property name="oscars.endpointZ" value="${config.interface.2}" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oscars.bw" />
+			</not>
+			<then>
+				<if>
+					<isset property="resource.bandwidth" />
+					<then>
+						<property name="oscars.bw" value="${resource.bandwidth}" />
+					</then>
+					<else>
+						<property name="oscars.bw" value="" />
+					</else>
+				</if>
+			</then>
+		</if>
+	
+		<if>
+			<isset property="config.vlan.tag.1" />
+			<then>
+				<property name="oscars.tagA" value="${config.vlan.tag.1}" />
+			</then>
+		</if>
+	
+		<if>
+			<isset property="config.vlan.tag.2" />
+			<then>
+				<property name="oscars.tagZ" value="${config.vlan.tag.2}" />
+			</then>
+		</if>
+	
+		<echo message="creating OSCARS circuit from ${oscars.endpointA}/${oscars.tagA} to ${oscars.endpointZ}/${oscars.tagZ} for ${config.duration} (sec) with bw=${oscars.bw}" />
+	
+		<var name="shirako.save.unit.vlan.tag" unset="true" />
+		<var name="shirako.save.unit.status" unset="true" />
+		<var name="shirako.save.unit.vlan.reservation" unset="true" />
+		<var name="shirako.save.unit.vlan.idc" unset="true" />
+	
+		<!-- determine the controller to call -->
+		<var name="ctrl.domain.A" unset="true"/>
+		<propertyregex property="ctrl.domain.A"
+	    	input="${oscars.endpointA}"
+	    	regexp="urn:ogf:network:domain=([^\.]*)\.*"
+	    	select="\1"
+	    	casesensitive="false" />
+	
+		<var name="ctrl.domain.Z" unset="true"/>
+		<propertyregex property="ctrl.domain.Z"
+	    	input="${oscars.endpointZ}"
+	    	regexp="urn:ogf:network:domain=([^\.]*)\.*"
+	    	select="\1"
+	    	casesensitive="false" />
+
+		<var name="ctrl.to.call" unset="true"/>
+
+		<if>
+			<equals arg1="${ctrl.domain.A}" arg2="al2s" />
+			<then>
+				<property name="ctrl.to.call" value="${oscars.idc.al2s}" />
+			</then>
+			<else>
+				<if>
+					<equals arg1="${ctrl.domain.A}" arg2="es" />
+					<then>
+						<property name="ctrl.to.call" value="${oscars.idc.es}" />
+					</then>
+					<else>
+						<if>
+							<equals arg1="${ctrl.domain.A}" arg2="ion" />
+							<then>
+								<property name="ctrl.to.call" value="${oscars.idc.ion}" />
+							</then>
+							<else>
+								<if>
+									<equals arg1="${ctrl.domain.A}" arg2="tb" />
+									<then>
+										<property name="ctrl.to.call" value="${oscars.idc.tb}" />
+									</then>
+									<else>
+										<echo message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" />
+										<fail message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" />
+									</else>
+								</if>
+							</else>
+						</if>
+					</else>
+				</if>
+			</else>
+		</if>
+		<echo message="Calling OSCARS controller ${ctrl.to.call}" />
+		<property name="shirako.save.unit.vlan.idc" value="${ctrl.to.call}" />
+	
+				<var name="create.circuit.output" unset="true" />
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+	
+				<!-- per evangelos on 03/07/14 - asked to serialize requests to oscars -->
+				<atomic.sequence.start.macro
+					device="${ctrl.to.call}" />
+					<echo message="Sleeping for 60000 milliseconds"/>
+					<sleep milliseconds="60000"/>
+					<property name="code" value="0" />
+					<property name="message" value="ALL OK" />
+
+				<atomic.sequence.stop.macro
+						device="${ctrl.to.call}" />
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo message="Unable to create circuit: ${create.circuit.output}" />
+						<property name="message" value="Unable to create circuit: ${create.circuit.output}" />
+					</then>
+					<else>
+						<property name="shirako.save.unit.vlan.reservation" value="${create.circuit.output}" />
+						<property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" />
+						<property name="shirako.save.unit.status" value="ACTIVE" />
+						<echo message="Reserved unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" />
+					</else>
+				</if>
+			<property name="shirako.target.code" value="${code}" />
+			<property name="shirako.target.code.message" value="${message}" />
+        <!-- hairpin -->
+        <var name="shirako.save.unit.vlan.url" unset="true" />
+        <if>
+                <isset property="unit.vlan.url" />
+                <then>
+                        <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+                </then>
+        </if>
+
+	<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<!-- Modify operation is not supported -->
+	<target name="modify" />
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="OSCARS/ION HANDLER: LEAVE" />
+
+		<if>
+			<isset property="oscars.site.properties" />
+			<then>
+				<property file="${oscars.site.properties}" />
+			</then>
+		</if>
+
+		<echo message="Removing vlan ${unit.vlan.tag} reservation ${unit.vlan.reservation}" />
+	
+		<if>
+			<not>
+				<isset property="unit.vlan.idc"/>
+			</not>
+			<then>
+				<property name="unit.vlan.idc" value="${oscars.idc.ion}" />
+			</then>
+		</if>
+	
+		<echo message="Calling OSCARS controller ${unit.vlan.idc}" />
+	
+				<var name="code" unset="true" />				
+				<echo message="terminating OSCARS circuit: ${unit.vlan.reservation}" />
+				<atomic.sequence.start.macro
+					device="${unit.vlan.idc}" />
+					<echo message="Sleeping for 5000 milliseconds"/>
+				        <sleep milliseconds="5000"/>
+				        <property name="code" value="0"/>
+
+				<atomic.sequence.stop.macro
+					device="${unit.vlan.idc}" />
+				<echo message="oscars-stop.sh exit code: ${code}" />	
+				<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
 </project>
+

--- a/handlers/oscars/resources/handlers/oscars/handler.xml
+++ b/handlers/oscars/resources/handlers/oscars/handler.xml
@@ -1,215 +1,268 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml">
+]>
 <project name="oscars" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;	
+	&bentasks;
+	
+	<!-- Uncomment for handler testing
 	<property file="oscars.test.properties"/>
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <taskdef resource="orca/handlers/nodeagent2/nodeagent2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <taskdef resource="orca/handlers/network/oscars/oscars.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <echo message="OSCARS/ION NA2 HANDLER: JOIN" /> 
-        <!-- see oscars.site.sample.properties and wiki for description
+	-->
+	
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+
+		<taskdef resource="orca/handlers/nodeagent2/nodeagent2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+		<taskdef resource="orca/handlers/network/oscars/oscars.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+	
+    	<echo message="OSCARS/ION NA2 HANDLER: JOIN" />
+		<!-- see oscars.site.sample.properties and wiki for description
 		of static properties that can be specified in oscars.site.properties
-		--> 
-        <if> 
-            <isset property="oscars.site.properties" /> 
-            <then> 
-                <property file="${oscars.site.properties}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oscars.endpointA" /> 
-            </not> 
-            <then> 
-                <property name="oscars.endpointA" value="${config.interface.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oscars.endpointZ" /> 
-            </not> 
-            <then> 
-                <property name="oscars.endpointZ" value="${config.interface.2}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <not> 
-                <isset property="oscars.bw" /> 
-            </not> 
-            <then> 
-                <if> 
-                    <isset property="resource.bandwidth" /> 
-                    <then> 
-                        <property name="oscars.bw" value="${resource.bandwidth}" /> 
-                    </then> 
-                    <else> 
-                        <property name="oscars.bw" value="" /> 
-                    </else> 
-                </if> 
-            </then> 
-        </if> 
-        <if> 
-            <isset property="config.vlan.tag.1" /> 
-            <then> 
-                <property name="oscars.tagA" value="${config.vlan.tag.1}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <isset property="config.vlan.tag.2" /> 
-            <then> 
-                <property name="oscars.tagZ" value="${config.vlan.tag.2}" /> 
-            </then> 
-        </if> 
-        <echo message="creating OSCARS circuit from ${oscars.endpointA}/${oscars.tagA} to ${oscars.endpointZ}/${oscars.tagZ} with bw=${oscars.bw}" /> 
-        <var name="oscars.new.endpointA" unset="true"></var> 
-        <var name="oscars.new.endpointZ" unset="true"></var> 
-        <oscars.remap.urn oldUrn="${oscars.endpointA}" newUrnProp="oscars.new.endpointA" mapFile="${oscars.site.properties}" mapProperty="urn.map" /> 
-        <oscars.remap.urn oldUrn="${oscars.endpointZ}" newUrnProp="oscars.new.endpointZ" mapFile="${oscars.site.properties}" mapProperty="urn.map" /> 
-        <var name="oscars.endpointA" unset="true"></var> 
-        <var name="oscars.endpointZ" unset="true"></var> 
-        <property name="oscars.endpointA" value="${oscars.new.endpointA}" /> 
-        <property name="oscars.endpointZ" value="${oscars.new.endpointZ}" /> 
-        <var name="oscars.new.endpointA" unset="true"></var> 
-        <var name="oscars.new.endpointZ" unset="true"></var> 
-        <echo message="after remap from ${oscars.endpointA}/${oscars.tagA} to ${oscars.endpointZ}/${oscars.tagZ} with bw=${oscars.bw}" /> 
-        <var name="shirako.save.unit.vlan.tag" unset="true"></var> 
-        <var name="shirako.save.unit.status" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.reservation" unset="true"></var> 
-        <var name="shirako.save.unit.vlan.idc" unset="true"></var> 
-        <!-- determine the controller to call --> 
-        <var name="ctrl.domain.A" unset="true"></var> 
-        <propertyregex property="ctrl.domain.A" input="${oscars.endpointA}" regexp="urn:ogf:network:domain=([^\.]*)\.*" select="\1" casesensitive="false" /> 
-        <var name="ctrl.domain.Z" unset="true"></var> 
-        <propertyregex property="ctrl.domain.Z" input="${oscars.endpointZ}" regexp="urn:ogf:network:domain=([^\.]*)\.*" select="\1" casesensitive="false" /> 
-        <var name="oscars.ctrl.to.call" unset="true"></var> 
-        <if> 
-            <equals arg1="${ctrl.domain.A}" arg2="al2s" /> 
-            <then> 
-                <property name="oscars.ctrl.to.call" value="${oscars.idc.al2s}" /> 
-            </then> 
-            <else> 
-                <if> 
-                    <equals arg1="${ctrl.domain.A}" arg2="es" /> 
-                    <then> 
-                        <property name="oscars.ctrl.to.call" value="${oscars.idc.es}" /> 
-                    </then> 
-                    <else> 
-                        <if> 
-                            <equals arg1="${ctrl.domain.A}" arg2="ion" /> 
-                            <then> 
-                                <property name="oscars.ctrl.to.call" value="${oscars.idc.ion}" /> 
-                            </then> 
-                            <else> 
-                                <if> 
-                                    <equals arg1="${ctrl.domain.A}" arg2="tb" /> 
-                                    <then> 
-                                        <property name="oscars.ctrl.to.call" value="${oscars.idc.tb}" /> 
-                                    </then> 
-                                    <else> 
-                                        <echo message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" /> 
-                                        <fail message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" /> 
-                                    </else> 
-                                </if> 
-                            </else> 
-                        </if> 
-                    </else> 
-                </if> 
-            </else> 
-        </if> 
-        <echo message="Calling OSCARS controller ${oscars.ctrl.to.call}" /> 
-        <property name="shirako.save.unit.vlan.idc" value="${oscars.ctrl.to.call}" /> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="RUNNING UNDER EMULATION... EXITING" /> 
-                <property name="shirako.save.unit.vlan.reservation" value="some-reservation-id|${oscars.endpointA}|${oscars.tagA}|${oscars.endpointZ}|${oscars.tagZ}" /> 
-                <property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" /> 
-                <property name="shirako.save.unit.status" value="ACTIVE" /> 
-                <echo message="unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <echo message="Invoking JOIN on NA2 plugin ${na2.oscars.plugin} at ${na2.url}" /> 
-                <var name="oscars.join.reservation" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <!-- NA2 and the plugin do their own locking --> 
-                <!-- this collects all properties that start with "oscars" and sends them to the NA2 OSCARS plugin --> 
-                <nodeagent2.join baseUrl="${na2.url}" prefix="oscars" returnPrefix="oscars.return" password="${na2.password}" plugin="${na2.oscars.plugin}" statusProperty="code" errorMsgProperty="message" reservationIdProperty="oscars.join.reservation" /> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="NA2 unable to create OSCARS circuit: ${message}" /> 
-                        <property name="message" value="NodeAgent unable to create OSCARS circuit: ${message}" /> 
-                    </then> 
-                    <else> 
-                        <property name="shirako.save.unit.vlan.reservation" value="${oscars.join.reservation}" /> 
-                        <property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" /> 
-                        <property name="shirako.save.unit.status" value="ACTIVE" /> 
-                        <echo message="NA2 created reservation unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" /> 
-                    </else> 
-                </if> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <property name="shirako.target.code.message" value="${message}" /> 
-            </else> 
-        </if> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- Modify operation is not supported --> 
-    <target name="modify" /> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <taskdef resource="orca/handlers/nodeagent2/nodeagent2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <taskdef resource="orca/handlers/network/oscars/oscars.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <echo message="OSCARS/ION NA2 HANDLER: LEAVE" /> 
-        <if> 
-            <isset property="oscars.site.properties" /> 
-            <then> 
-                <property file="${oscars.site.properties}" /> 
-            </then> 
-        </if> 
-        <echo message="Removing vlan ${unit.vlan.tag} reservation ${unit.vlan.reservation}" /> 
-        <if> 
-            <not> 
-                <isset property="unit.vlan.idc" /> 
-            </not> 
-            <then> 
-                <property name="unit.vlan.idc" value="${oscars.idc.al2s}" /> 
-            </then> 
-        </if> 
-        <echo message="Calling OSCARS controller ${unit.vlan.idc}" /> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="RUNNING UNDER EMULATION...EXITING" /> 
-                <echo message="terminating OSCARS circuit: ${unit.vlan.reservation}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <echo message="Invoking LEAVE on NA2 plugin ${na2.oscars.plugin} at ${na2.url} for reservation ${unit.vlan.reservation}" /> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <!-- na2 does its own locking --> 
-                <!-- this collects all properties that start with "unit" and sends them to the NA2 OSCARS plugin --> 
-                <nodeagent2.leave baseUrl="${na2.url}" prefix="unit" returnPrefix="oscars.return" password="${na2.password}" plugin="${na2.oscars.plugin}" reservationId="${unit.vlan.reservation}" statusProperty="code" errorMsgProperty="message" reservationIdProperty="oscars.leave.reservation" /> 
-                <echo message="NA2 exit code: ${code} with message ${message}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
+		-->
+		<if>
+			<isset property="oscars.site.properties" />
+			<then>
+				<property file="${oscars.site.properties}" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oscars.endpointA" />
+			</not>
+			<then>
+				<property name="oscars.endpointA" value="${config.interface.1}" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oscars.endpointZ" />
+			</not>
+			<then>
+				<property name="oscars.endpointZ" value="${config.interface.2}" />
+			</then>
+		</if>
+	
+		<if>
+			<not>
+				<isset property="oscars.bw" />
+			</not>
+			<then>
+				<if>
+					<isset property="resource.bandwidth" />
+					<then>
+						<property name="oscars.bw" value="${resource.bandwidth}" />
+					</then>
+					<else>
+						<property name="oscars.bw" value="" />
+					</else>
+				</if>
+			</then>
+		</if>
+	
+		<if>
+			<isset property="config.vlan.tag.1" />
+			<then>
+				<property name="oscars.tagA" value="${config.vlan.tag.1}" />
+			</then>
+		</if>
+	
+		<if>
+			<isset property="config.vlan.tag.2" />
+			<then>
+				<property name="oscars.tagZ" value="${config.vlan.tag.2}" />
+			</then>
+		</if>
+	
+		<echo message="creating OSCARS circuit from ${oscars.endpointA}/${oscars.tagA} to ${oscars.endpointZ}/${oscars.tagZ} with bw=${oscars.bw}" />
+	
+		<var name="oscars.new.endpointA" unset="true" />
+		<var name="oscars.new.endpointZ" unset="true" />
+		<oscars.remap.urn oldUrn="${oscars.endpointA}" newUrnProp="oscars.new.endpointA" mapFile="${oscars.site.properties}" mapProperty="urn.map" />	
+		<oscars.remap.urn oldUrn="${oscars.endpointZ}" newUrnProp="oscars.new.endpointZ" mapFile="${oscars.site.properties}" mapProperty="urn.map" />
+		
+		<var name="oscars.endpointA" unset="true" />
+		<var name="oscars.endpointZ" unset="true" />
+		<property name="oscars.endpointA" value="${oscars.new.endpointA}" />
+		<property name="oscars.endpointZ" value="${oscars.new.endpointZ}" />
+		<var name="oscars.new.endpointA" unset="true" />
+		<var name="oscars.new.endpointZ" unset="true" />
+	
+		<echo message="after remap from ${oscars.endpointA}/${oscars.tagA} to ${oscars.endpointZ}/${oscars.tagZ} with bw=${oscars.bw}" />	
+	
+		<var name="shirako.save.unit.vlan.tag" unset="true" />
+		<var name="shirako.save.unit.status" unset="true" />
+		<var name="shirako.save.unit.vlan.reservation" unset="true" />
+		<var name="shirako.save.unit.vlan.idc" unset="true" />
+	
+		<!-- determine the controller to call -->
+		<var name="ctrl.domain.A" unset="true"/>
+		<propertyregex property="ctrl.domain.A"
+	    	input="${oscars.endpointA}"
+	    	regexp="urn:ogf:network:domain=([^\.]*)\.*"
+	    	select="\1"
+	    	casesensitive="false" />
+	
+		<var name="ctrl.domain.Z" unset="true"/>
+		<propertyregex property="ctrl.domain.Z"
+	    	input="${oscars.endpointZ}"
+	    	regexp="urn:ogf:network:domain=([^\.]*)\.*"
+	    	select="\1"
+	    	casesensitive="false" />
+
+		<var name="oscars.ctrl.to.call" unset="true"/>
+
+		<if>
+			<equals arg1="${ctrl.domain.A}" arg2="al2s" />
+			<then>
+				<property name="oscars.ctrl.to.call" value="${oscars.idc.al2s}" />
+			</then>
+			<else>
+				<if>
+					<equals arg1="${ctrl.domain.A}" arg2="es" />
+					<then>
+						<property name="oscars.ctrl.to.call" value="${oscars.idc.es}" />
+					</then>
+					<else>
+						<if>
+							<equals arg1="${ctrl.domain.A}" arg2="ion" />
+							<then>
+								<property name="oscars.ctrl.to.call" value="${oscars.idc.ion}" />
+							</then>
+							<else>
+								<if>
+									<equals arg1="${ctrl.domain.A}" arg2="tb" />
+									<then>
+										<property name="oscars.ctrl.to.call" value="${oscars.idc.tb}" />
+									</then>
+									<else>
+										<echo message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" />
+										<fail message="Unknown OSCARS domain ${ctrl.domain.A} in one of the interfaces" />
+									</else>
+								</if>
+							</else>
+						</if>
+					</else>
+				</if>
+			</else>
+		</if>
+		<echo message="Calling OSCARS controller ${oscars.ctrl.to.call}" />
+		<property name="shirako.save.unit.vlan.idc" value="${oscars.ctrl.to.call}" />
+	
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+
+	
+				<echo message="RUNNING UNDER EMULATION... EXITING" />
+
+				<property name="shirako.save.unit.vlan.reservation" value="some-reservation-id|${oscars.endpointA}|${oscars.tagA}|${oscars.endpointZ}|${oscars.tagZ}" />
+				<property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" />
+				<property name="shirako.save.unit.status" value="ACTIVE" />
+				<echo message="unit.vlan.tag=${shirako.save.unit.vlan.tag} unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>			
+				<echo message="Invoking JOIN on NA2 plugin ${na2.oscars.plugin} at ${na2.url}"/>
+	
+				<var name="oscars.join.reservation" unset="true" />
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+	
+				<!-- NA2 and the plugin do their own locking -->
+				<!-- this collects all properties that start with "oscars" and sends them to the NA2 OSCARS plugin -->
+				<nodeagent2.join baseUrl="${na2.url}" prefix="oscars" returnPrefix="oscars.return" password="${na2.password}" plugin="${na2.oscars.plugin}" 
+						statusProperty="code" errorMsgProperty="message" reservationIdProperty="oscars.join.reservation" />
+
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo message="NA2 unable to create OSCARS circuit: ${message}" />
+						<property name="message" value="NodeAgent unable to create OSCARS circuit: ${message}" />
+					</then>
+					<else>
+						<property name="shirako.save.unit.vlan.reservation" value="${oscars.join.reservation}" />
+						<property name="shirako.save.unit.vlan.tag" value="${unit.vlan.tag}" />
+						<property name="shirako.save.unit.status" value="ACTIVE" />
+						<echo message="NA2 created reservation unit.vlan.reservation=${shirako.save.unit.vlan.reservation}" />
+					</else>
+				</if>
+			<property name="shirako.target.code" value="${code}" />
+			<property name="shirako.target.code.message" value="${message}" />
+		</else>
+	</if>
+        <!-- hairpin -->
+        <var name="shirako.save.unit.vlan.url" unset="true" />
+        <if>
+                <isset property="unit.vlan.url" />
+                <then>
+                        <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+                </then>
+        </if>
+
+	<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<!-- Modify operation is not supported -->
+	<target name="modify" />
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+	
+		<taskdef resource="orca/handlers/nodeagent2/nodeagent2.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+		<taskdef resource="orca/handlers/network/oscars/oscars.xml" classpathref="run.classpath" loaderref="run.classpath.loader" />
+	
+		<echo message="OSCARS/ION NA2 HANDLER: LEAVE" />
+
+		<if>
+			<isset property="oscars.site.properties" />
+			<then>
+				<property file="${oscars.site.properties}" />
+			</then>
+		</if>
+
+		<echo message="Removing vlan ${unit.vlan.tag} reservation ${unit.vlan.reservation}" />
+	
+		<if>
+			<not>
+				<isset property="unit.vlan.idc"/>
+			</not>
+			<then>
+				<property name="unit.vlan.idc" value="${oscars.idc.al2s}" />
+			</then>
+		</if>
+	
+		<echo message="Calling OSCARS controller ${unit.vlan.idc}" />
+	
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="RUNNING UNDER EMULATION...EXITING" />
+				<echo message="terminating OSCARS circuit: ${unit.vlan.reservation}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<echo message="Invoking LEAVE on NA2 plugin ${na2.oscars.plugin} at ${na2.url} for reservation ${unit.vlan.reservation}"/>
+				<var name="code" unset="true" />	
+				<var name="message" unset="true" />
+	
+				<!-- na2 does its own locking -->
+				<!-- this collects all properties that start with "unit" and sends them to the NA2 OSCARS plugin -->
+				<nodeagent2.leave baseUrl="${na2.url}" prefix="unit" returnPrefix="oscars.return" password="${na2.password}" plugin="${na2.oscars.plugin}" 
+					reservationId="${unit.vlan.reservation}" statusProperty="code" errorMsgProperty="message" reservationIdProperty="oscars.leave.reservation" />
+	
+				<echo message="NA2 exit code: ${code} with message ${message}" />	
+				<property name="shirako.target.code" value="${code}" />
+			</else>
+		</if>
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
 </project>
+

--- a/handlers/providers/resources/handler/providers/ben/ben.xml
+++ b/handlers/providers/resources/handler/providers/ben/ben.xml
@@ -1,258 +1,415 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="bencomplex" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+    <property file="../ben.properties" />
+	<!-- Uncomment for handler testing
 	<property file="ben.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="BEN HANDLER: SETUP on ${start.TIME}" /> 
-        <if> 
-            <isset property="ben.credentials" /> 
-            <then> 
-                <property file="${ben.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="BEN credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <var name="code" value="0"></var> 
-        <!-- make BEN configuration atomic --> 
-        <atomic.sequence.start.macro device="ALL-OF-BEN" /> 
-        <!-- create the BEN vlan --> 
-        <for list="renci unc duke ncsu" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <echo message="performing setup at @{site}" /> 
-                <!-- check if we need to setup Polatis --> 
-                <if> 
-                    <isset property="@{site}.polatis.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <polatis.connect polatis="${@{site}.polatis}" src.port="${@{site}.polatis.action.@{anum}.sport}" dst.port="${@{site}.polatis.action.@{anum}.dport}" user="${polatis.user}" password="${polatis.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to setup DTN --> 
-                <if> 
-                    <isset property="@{site}.dtn.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <dtn.connect dtn="${@{site}.dtn}" dtn.payload.type="${dtn.payloadType}" src.port="${@{site}.dtn.action.@{anum}.sport}" dst.port="${@{site}.dtn.action.@{anum}.dport}" user="${dtn.user}" password="${dtn.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to setup 6509/layer2 --> 
-                <if> 
-                    <isset property="@{site}.6509.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <sequential> 
-                                            <create.vlan router="${@{site}.router}" router.type="${@{site}.router.type}" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                                            <add.trunk.ports router="${@{site}.router}" router.type="${@{site}.router.type}" vlan.tag="${unit.vlan.tag}" ports="${@{site}.6509.action.@{anum}.ports}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                                            <for list="osgrenciNet nlr rciNet rcivmsite dukeNet dukevmsite renciNet rencivmsite uncNet uncvmsite ncsuNet ncsuvmsite" param="parentsite" delimiter=" " parallel="false"> 
-                                                <sequential> 
-                                                    <if> 
-                                                        <and> 
-                                                            <isset property="@{parentsite}.unit.portlist" /> 
-                                                            <equals arg1="${code}" arg2="0" /> 
-                                                        </and> 
-                                                        <then> 
-                                                            <echo message="Add ports ${@{parentsite}.unit.portlist} on ${@{parentsite}.map.router} to VLAN ${unit.vlan.tag}" /> 
-                                                            <add.trunk.ports router="${@{parentsite}.map.router}" router.type="${@{site}.router.type}" vlan.tag="${unit.vlan.tag}" ports="${@{parentsite}.unit.portlist}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                                                        </then> 
-                                                    </if> 
-                                                </sequential> 
-                                            </for> 
-                                        </sequential> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished setting up BEN vlan. code=${code}" /> 
-        <echo message="Performing map operations" /> 
-        <var name="map.counter" unset="true"></var> 
-        <property name="map.counter" value="0" /> 
-        <for list="osgrenciNet nlr rciNet rcivmsite dukeNet dukevmsite renciNet rencivmsite uncNet uncvmsite ncsuNet ncsuvmsite acisrenciNet" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <if> 
-                    <and> 
-                        <isset property="@{site}.unit.vlan.tag" /> 
-                        <isset property="@{site}.edge.interface" /> 
-                        <equals arg1="0" arg2="${code}" /> 
-                    </and> 
-                    <then> 
-                        <echo message="Mapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" /> 
-                        <map.vlans router="${@{site}.map.router}" router.type="${@{site}.router.type}" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                        <!-- count the number of map operations --> 
-                        <math result="map.counter" operand1="${map.counter}" operation="+" operand2="1" datatype="int"></math> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <!-- if only one map operation, add self mapping on dependency-reversed interface for qfx routers /ib --> 
-        <if> 
-            <and> 
-                <equals arg1="${map.counter}" arg2="1" /> 
-                <equals arg1="${reverse.dep.router.type}" arg2="qfx3500" /> 
-            </and> 
-            <then> 
-                <echo message="Mapping vlan ${unit.vlan.tag} to self on ${reverse.dep.map.router} type ${reverse.dep.router.type} interface ${reverse.dep.interface} due to reversed dependency" /> 
-                <map.vlans router="${reverse.dep.map.router}" router.type="${reverse.dep.router.type}" src.vlan.tag="${unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${reverse.dep.interface}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-            </then> 
-        </if> 
-        <echo message="Finished performing map operations" /> 
-        <atomic.sequence.stop.macro device="ALL-OF-BEN" /> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="BEN HANDLER: TEARDOWN on ${start.TIME}" /> 
-        <var name="code" value="0"></var> 
-        <if> 
-            <isset property="ben.credentials" /> 
-            <then> 
-                <property file="${ben.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="BEN credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <atomic.sequence.start.macro device="ALL-OF-BEN" /> 
-        <!-- disconnect the BEN vlan --> 
-        <for list="renci unc duke ncsu" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <echo message="performing setup at @{site}" /> 
-                <!-- check if we need to teardown Polatis --> 
-                <if> 
-                    <isset property="@{site}.polatis.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <polatis.disconnect polatis="${@{site}.polatis}" src.port="${@{site}.polatis.action.@{anum}.sport}" user="${polatis.user}" password="${polatis.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to teardown DTN --> 
-                <if> 
-                    <isset property="@{site}.dtn.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <dtn.disconnect dtn="${@{site}.dtn}" dtn.payload.type="${dtn.payloadType}" src.port="${@{site}.dtn.action.@{anum}.sport}" dst.port="${@{site}.dtn.action.@{anum}.dport}" user="${dtn.user}" password="${dtn.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to disable 6509 --> 
-                <if> 
-                    <isset property="@{site}.6509.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <for list="osgrenciNet nlr rciNet rcivmsite dukeNet dukevmsite renciNet rencivmsite uncNet uncvmsite ncsuNet ncsuvmsite" param="parentsite" delimiter=" " parallel="false"> 
-                                    <sequential> 
-                                        <if> 
-                                            <and> 
-                                                <isset property="@{parentsite}.unit.portlist" /> 
-                                                <equals arg1="${code}" arg2="0" /> 
-                                            </and> 
-                                            <then> 
-                                                <echo message="Remove ports ${@{parentsite}.unit.portlist} on ${@{parentsite}.map.router} to VLAN ${unit.vlan.tag}" /> 
-                                                <remove.trunk.ports router="${@{parentsite}.map.router}" router.type="${@{site}.router.type}" vlan.tag="${unit.vlan.tag}" ports="${@{parentsite}.unit.portlist}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                                            </then> 
-                                        </if> 
-                                    </sequential> 
-                                </for> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <sequential> 
-                                            <remove.trunk.ports router="${@{site}.router}" router.type="${@{site}.router.type}" vlan.tag="${unit.vlan.tag}" ports="${@{site}.6509.action.@{anum}.ports}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                                            <delete.vlan router="${@{site}.router}" router.type="${@{site}.router.type}" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                                        </sequential> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Performing unmap operations" /> 
-        <for list="osgrenciNet nlr rciNet rcivmsite dukeNet dukevmsite renciNet rencivmsite uncNet uncvmsite ncsuNet ncsuvmsite acisrenciNet" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <if> 
-                    <and> 
-                        <isset property="@{site}.unit.vlan.tag" /> 
-                        <isset property="@{site}.edge.interface" /> 
-                    </and> 
-                    <then> 
-                        <echo message="Unmapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" /> 
-                        <unmap.vlans router="${@{site}.map.router}" router.type="${@{site}.router.type}" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished performing unmap operations" /> 
-        <atomic.sequence.stop.macro device="ALL-OF-BEN" /> 
-        <!-- FIXME: ${code} contains the exit code of only the last operation --> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+    
+    <target name="join" depends="resolve.configuration,ben.load.tasks">
+        <tstamp prefix="start">
+                <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+        </tstamp>
+
+        <echo message="BEN HANDLER: SETUP on ${start.TIME}" />
+		<if>
+			<isset property="ben.credentials" />
+			<then>
+				<property file="${ben.credentials}" />
+			</then>
+			<else>
+				<echo message="BEN credentials properties are not set!" />
+			</else>
+		</if>
+
+        <var name="code" value="0" />
+
+		<!-- make BEN configuration atomic -->
+		<atomic.sequence.start.macro
+			device="ALL-OF-BEN" />
+        <!-- create the BEN vlan -->
+        <for list="renci unc duke ncsu"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <echo message="performing setup at @{site}" />
+                <!-- check if we need to setup Polatis -->
+                <if>
+                    <isset property="@{site}.polatis.actionslist" />
+                    <then>
+                        <for list="${@{site}.polatis.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <polatis.connect 
+                                        	polatis="${@{site}.polatis}"
+                                            src.port="${@{site}.polatis.action.@{anum}.sport}"
+                                            dst.port="${@{site}.polatis.action.@{anum}.dport}"
+                                            user="${polatis.user}"
+                                            password="${polatis.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to setup DTN -->
+                <if>
+                    <isset property="@{site}.dtn.actionslist" />
+                    <then>
+                        <for list="${@{site}.dtn.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <dtn.connect 
+                                        	dtn="${@{site}.dtn}"
+					    					dtn.payload.type="${dtn.payloadType}"
+                                            src.port="${@{site}.dtn.action.@{anum}.sport}"
+                                            dst.port="${@{site}.dtn.action.@{anum}.dport}"
+                                            user="${dtn.user}"
+                                            password="${dtn.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to setup 6509/layer2 -->
+                <if>
+                    <isset property="@{site}.6509.actionslist" />
+                    <then>
+                        <for list="${@{site}.6509.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+										<sequential>
+                                        	<create.vlan 
+                                        		router="${@{site}.router}"
+												router.type="${@{site}.router.type}"
+                                           		vlan.tag="${unit.vlan.tag}"
+												vlan.qos.rate="${unit.vlan.qos.rate}"
+												vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+                                            	router.user="${router.user}"
+                                            	router.password="${router.password}"
+												router.default.prompt="${router.default.prompt}"
+                                            	router.admin.password="${router.admin.password}" />
+											<add.trunk.ports 
+                 								router="${@{site}.router}"
+		 										router.type="${@{site}.router.type}"
+                								vlan.tag="${unit.vlan.tag}"
+                								ports="${@{site}.6509.action.@{anum}.ports}"
+                								router.user="${router.user}"
+                		    					router.password="${router.password}"
+												router.default.prompt="${router.default.prompt}"
+                								router.admin.password="${router.admin.password}" />
+
+                        					<for list="osgrenciNet nlr rciNet rcivmsite dukeNet dukevmsite renciNet rencivmsite uncNet uncvmsite ncsuNet ncsuvmsite"
+                             			     	param="parentsite"
+                             			     	delimiter=" "
+                             			    	parallel="false">
+                            					<sequential>
+                                				<if>
+                                    				<and>
+                                        			    <isset property="@{parentsite}.unit.portlist" />
+                                    				    <equals arg1="${code}" arg2="0" />
+													</and>	
+                                			    	<then>
+														<echo message = "Add ports ${@{parentsite}.unit.portlist} on ${@{parentsite}.map.router} to VLAN ${unit.vlan.tag}" /> 
+  															<add.trunk.ports 
+                 											router="${@{parentsite}.map.router}"
+				 											router.type="${@{site}.router.type}"
+                 											vlan.tag="${unit.vlan.tag}"
+                											ports="${@{parentsite}.unit.portlist}"
+                											router.user="${router.user}"
+                				    						router.password="${router.password}"
+															router.default.prompt="${router.default.prompt}"
+                											router.admin.password="${router.admin.password}" />
+                                			    	</then>
+							    				</if>	
+                            					</sequential>
+                        					</for>
+										</sequential>
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished setting up BEN vlan. code=${code}" />
+	
+        <echo message="Performing map operations" />
+		<var name="map.counter" unset="true" />
+		<property name="map.counter" value="0" />
+	
+        <for list="osgrenciNet nlr rciNet rcivmsite dukeNet dukevmsite renciNet rencivmsite uncNet uncvmsite ncsuNet ncsuvmsite acisrenciNet"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <if>
+                    <and>
+                        <isset property="@{site}.unit.vlan.tag" />
+                        <isset property="@{site}.edge.interface" />
+                        <equals arg1="0" arg2="${code}" />
+                    </and>
+                    <then>
+                        <echo message="Mapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" />
+                        <map.vlans router="${@{site}.map.router}"
+				   					router.type="${@{site}.router.type}"
+                                   	src.vlan.tag="${@{site}.unit.vlan.tag}"
+                                   	dst.vlan.tag="${unit.vlan.tag}"
+                                   	port="${@{site}.edge.interface}"
+                                   	router.user="${router.user}"
+                                   	router.password="${router.password}"
+									router.default.prompt="${router.default.prompt}"
+                                   	router.admin.password="${router.admin.password}" />
+						<!-- count the number of map operations -->
+						<math result="map.counter" operand1="${map.counter}" operation="+" operand2="1" datatype="int"/>
+                    </then>
+                </if>
+            </sequential>
+        </for>
+	
+		<!-- if only one map operation, add self mapping on dependency-reversed interface for qfx routers /ib -->
+		<if>
+			<and>
+				<equals arg1="${map.counter}" arg2="1" />
+				<equals arg1="${reverse.dep.router.type}" arg2="qfx3500" />
+			</and>
+			<then>
+				<echo message="Mapping vlan ${unit.vlan.tag} to self on ${reverse.dep.map.router} type ${reverse.dep.router.type} interface ${reverse.dep.interface} due to reversed dependency" />
+    			<map.vlans router="${reverse.dep.map.router}"
+					router.type="${reverse.dep.router.type}"
+               		src.vlan.tag="${unit.vlan.tag}"
+               		dst.vlan.tag="${unit.vlan.tag}"
+               		port="${reverse.dep.interface}"
+               		router.user="${router.user}"
+               		router.password="${router.password}"
+					router.default.prompt="${router.default.prompt}"
+               		router.admin.password="${router.admin.password}" />
+			</then>
+		</if>
+	
+        <echo message="Finished performing map operations" />
+		<atomic.sequence.stop.macro
+			device="ALL-OF-BEN" />
+
+	<property name="shirako.target.code" value="${code}" />
+        <!-- hairpin -->
+       	<var name="shirako.save.unit.vlan.url" unset="true" />
+	<if>
+		<isset property="unit.vlan.url" />
+		<then>
+        		<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+		</then>
+	</if>
+
+        <echo message="join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="leave" depends="resolve.configuration,ben.load.tasks">
+        <tstamp prefix="start">
+                <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+        </tstamp>
+
+        <echo message="BEN HANDLER: TEARDOWN on ${start.TIME}" />
+        <var name="code" value="0" />
+		<if>
+			<isset property="ben.credentials" />
+			<then>
+				<property file="${ben.credentials}" />
+			</then>
+			<else>
+				<echo message="BEN credentials properties are not set!" />
+			</else>
+		</if>
+		<atomic.sequence.start.macro
+			device="ALL-OF-BEN" />
+	
+        <!-- disconnect the BEN vlan -->
+        <for list="renci unc duke ncsu"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <echo message="performing setup at @{site}" />
+                <!-- check if we need to teardown Polatis -->
+                <if>
+                    <isset property="@{site}.polatis.actionslist" />
+                    <then>
+                        <for list="${@{site}.polatis.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <polatis.disconnect 
+                                        	polatis="${@{site}.polatis}"
+                                            src.port="${@{site}.polatis.action.@{anum}.sport}"
+                                            user="${polatis.user}"
+                                            password="${polatis.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to teardown DTN -->
+                <if>
+                    <isset property="@{site}.dtn.actionslist" />
+                    <then>
+                        <for list="${@{site}.dtn.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <dtn.disconnect
+                                        	dtn="${@{site}.dtn}"
+                                        dtn.payload.type="${dtn.payloadType}"    
+					src.port="${@{site}.dtn.action.@{anum}.sport}"
+                                            dst.port="${@{site}.dtn.action.@{anum}.dport}"
+                                            user="${dtn.user}"
+                                            password="${dtn.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to disable 6509 -->
+                <if>
+                    <isset property="@{site}.6509.actionslist" />
+                    <then>
+                        <for list="${@{site}.6509.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                             <sequential>
+								<for list="osgrenciNet nlr rciNet rcivmsite dukeNet dukevmsite renciNet rencivmsite uncNet uncvmsite ncsuNet ncsuvmsite"
+								     	param="parentsite"
+								     	delimiter=" "
+								    	parallel="false">
+									<sequential>
+									<if>
+										<and>
+						    			    <isset property="@{parentsite}.unit.portlist" />
+										    <equals arg1="${code}" arg2="0" />
+										</and>	
+								    	<then>
+											<echo message = "Remove ports ${@{parentsite}.unit.portlist} on ${@{parentsite}.map.router} to VLAN ${unit.vlan.tag}" /> 
+													<remove.trunk.ports 
+														router="${@{parentsite}.map.router}"
+														router.type="${@{site}.router.type}"
+														vlan.tag="${unit.vlan.tag}"
+														ports="${@{parentsite}.unit.portlist}"
+														router.user="${router.user}"
+														router.password="${router.password}"
+														router.default.prompt="${router.default.prompt}"
+														router.admin.password="${router.admin.password}" />
+								    	</then>
+									</if>	
+									</sequential>
+								</for>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+										<sequential>
+										<remove.trunk.ports
+   											router="${@{site}.router}"
+											router.type="${@{site}.router.type}"
+        									vlan.tag="${unit.vlan.tag}"
+        									ports="${@{site}.6509.action.@{anum}.ports}"
+        									router.user="${router.user}"
+        									router.password="${router.password}"
+											router.default.prompt="${router.default.prompt}"
+        									router.admin.password="${router.admin.password}" />
+                                        <delete.vlan 
+                                        	router="${@{site}.router}"
+											router.type="${@{site}.router.type}"
+                                            vlan.tag="${unit.vlan.tag}"
+											vlan.with.qos="${unit.vlan.with.qos}"
+                                            router.user="${router.user}"
+                                            router.password="${router.password}"
+											router.default.prompt="${router.default.prompt}"
+                                            router.admin.password="${router.admin.password}" />
+										</sequential>
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Performing unmap operations" />
+        <for list="osgrenciNet nlr rciNet rcivmsite dukeNet dukevmsite renciNet rencivmsite uncNet uncvmsite ncsuNet ncsuvmsite acisrenciNet"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <if>
+                    <and>
+                        <isset property="@{site}.unit.vlan.tag" />
+                        <isset property="@{site}.edge.interface" />
+                    </and>
+                    <then>
+                        <echo message="Unmapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" />
+                        <unmap.vlans 
+                        	router="${@{site}.map.router}"
+							router.type="${@{site}.router.type}"
+                            src.vlan.tag="${@{site}.unit.vlan.tag}"
+                            dst.vlan.tag="${unit.vlan.tag}"
+                            port="${@{site}.edge.interface}"
+                            router.user="${router.user}"
+                            router.password="${router.password}"
+							router.default.prompt="${router.default.prompt}"
+                            router.admin.password="${router.admin.password}" />
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished performing unmap operations" />
+		<atomic.sequence.stop.macro
+			device="ALL-OF-BEN" />
+        <!-- FIXME: ${code} contains the exit code of only the last operation -->
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="leave exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="modify" depends="resolve.configuration,ben.load.tasks">
+        <echo message="BEN HANDLER: MODIFY" />
+        <property name="shirako.target.code" value="0" />
+    </target>
 </project>

--- a/handlers/providers/resources/handler/providers/departuredrive/handler.xml
+++ b/handlers/providers/resources/handler/providers/departuredrive/handler.xml
@@ -1,142 +1,162 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"--> 
-<!--ENTITY ddtasks SYSTEM "dd.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+<!ENTITY ddtasks SYSTEM "dd.tasks.xml">
+]>
+
 <project name="departuredrive" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; &amp;ddtasks; 
-    <!-- <property file="test.properties" /> --> 
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+	&ddtasks;
+
+	<!-- <property file="test.properties" /> -->
+
     <property file="../ben.properties" /> 
-    <!--
+	
+	<!--
     <property file="../../../dd.test.properties" />
-    --> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Departure Drive HANDLER: JOIN on ${start.TIME}" /> 
-        <if> 
-            <isset property="dd.credentials" /> 
-            <then> 
-                <property file="${dd.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="Departure Drive credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <var name="code" value="0"></var> 
-        <atomic.sequence.start.macro device="DEPARTURE DRIVE" /> 
-        <trycatch property="returnmsg"> 
-            <try> 
-                <for list="${unit.device.num}" param="deviter" delimiter="," parallel="false"> 
-                    <sequential> 
-                        <if> 
-                            <equals arg1="${unit.device.@{deviter}}" arg2="DD" /> 
-                            <then> 
-                                <!-- plumbing vlans --> 
-                                <DDIterateJoin iter="${unit.action.num.DD}" /> 
-                            </then> 
-                            <else> 
-                                <if> 
-                                    <equals arg1="${unit.device.@{deviter}}" arg2="Exchange" /> 
-                                    <then> 
-                                        <!--  multipoint and vlan translation --> 
-                                        <ExchangeIterateJoin iter="${unit.action.num.Exchange}" /> 
-                                    </then> 
-                                    <else> 
-                                        <echo message="DD Handler: Unknown device ${unit.device.@{deviter}}, exiting" /> 
-                                        <fail message="DD Handler: Unknown device ${unit.device.@{deviter}}, exiting" /> 
-                                    </else> 
-                                </if> 
-                            </else> 
-                        </if> 
-                    </sequential> 
-                </for> 
-            </try> 
-            <catch> 
-                <fail message="${returnmsg}" /> 
-            </catch> 
-            <finally> 
-                <atomic.sequence.stop.macro device="DEPARTURE DRIVE" /> 
-            </finally> 
-        </trycatch> 
-        <property name="shirako.target.code" value="0" /> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-        <echo message="Departure Drive join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- LEAVE --> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Departure Drive HANDLER: TEARDOWN on ${start.TIME}" /> 
-        <if> 
-            <isset property="dd.credentials" /> 
-            <then> 
-                <property file="${dd.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="Departure Drive credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <var name="code" value="0"></var> 
-        <atomic.sequence.start.macro device="DEPARTURE DRIVE" /> 
-        <trycatch property="returnmsg"> 
-            <try> 
-                <for list="${unit.device.num}" param="deviter" delimiter="," parallel="false"> 
-                    <sequential> 
-                        <if> 
-                            <equals arg1="${unit.device.@{deviter}}" arg2="DD" /> 
-                            <then> 
-                                <!-- unplumbing vlans iteratively --> 
-                                <DDIterateLeave iter="${unit.action.num.DD}" /> 
-                            </then> 
-                            <else> 
-                                <if> 
-                                    <equals arg1="${unit.device.@{deviter}}" arg2="Exchange" /> 
-                                    <then> 
-                                        <!--  multipoint and vlan translation --> 
-                                        <ExchangeIterateLeave iter="${unit.action.num.Exchange}" /> 
-                                    </then> 
-                                    <else> 
-                                        <echo message="DD Handler: Unknown device ${unit.device.@{deviter}}, exiting" /> 
-                                        <fail message="DD Handler: Unknown device ${unit.device.@{deviter}}, exiting" /> 
-                                    </else> 
-                                </if> 
-                            </else> 
-                        </if> 
-                    </sequential> 
-                </for> 
-            </try> 
-            <catch> 
-                <fail message="${returnmsg}" /> 
-            </catch> 
-            <finally> 
-                <atomic.sequence.stop.macro device="DEPARTURE DRIVE" /> 
-            </finally> 
-        </trycatch> 
-        <property name="shirako.target.code" value="0" /> 
-        <echo message="Departure Drive leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- MODIFY --> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="Departure Drive HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+    -->
+	
+    <target name="join" depends="resolve.configuration,ben.load.tasks">
+        <tstamp prefix="start">
+                <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+        </tstamp>
+
+        <echo message="Departure Drive HANDLER: JOIN on ${start.TIME}" />
+		<if>
+			<isset property="dd.credentials" />
+			<then>
+				<property file="${dd.credentials}" />
+			</then>
+			<else>
+				<echo message="Departure Drive credentials properties are not set!" />
+			</else>
+		</if>
+        <var name="code" value="0" />
+		<atomic.sequence.start.macro
+			device="DEPARTURE DRIVE" />
+		<trycatch property="returnmsg">
+			<try>
+				<for list="${unit.device.num}" param="deviter" delimiter="," parallel="false" >
+					<sequential>
+						<if>
+							<equals arg1="${unit.device.@{deviter}}" arg2="DD"/>
+							<then>
+								<!-- plumbing vlans -->
+								<DDIterateJoin iter="${unit.action.num.DD}"/>
+							</then>
+							<else>
+								<if>
+									<equals arg1="${unit.device.@{deviter}}" arg2="Exchange" />
+									<then>
+										<!--  multipoint and vlan translation -->
+										<ExchangeIterateJoin iter="${unit.action.num.Exchange}"/>
+									</then>
+									<else>
+										<echo message="DD Handler: Unknown device ${unit.device.@{deviter}}, exiting" />
+										<fail message="DD Handler: Unknown device ${unit.device.@{deviter}}, exiting" />
+									</else>
+								</if>
+							</else>
+						</if>
+					</sequential>
+				</for>
+			</try>
+			<catch>
+				<fail message="${returnmsg}"/>
+			</catch>
+			<finally>
+				<atomic.sequence.stop.macro
+					device="DEPARTURE DRIVE" />
+			</finally>
+		</trycatch>
+		<property name="shirako.target.code" value="0" />
+		<!-- hairpin -->
+    	<var name="shirako.save.unit.vlan.url" unset="true" />
+    	<if>
+            <isset property="unit.vlan.url" />
+            <then>
+                    <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+            </then>
+    	</if>
+        <!-- hairpin -->
+        <var name="shirako.save.unit.vlan.url" unset="true" />
+        <if>
+                <isset property="unit.vlan.url" />
+                <then>
+                        <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+                </then>
+        </if>
+
+        <echo message="Departure Drive join exit code: ${shirako.target.code}" />
+    </target>
+
+	<!-- LEAVE -->
+    <target name="leave" depends="resolve.configuration,ben.load.tasks">
+        <tstamp prefix="start">
+                <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+        </tstamp>
+
+        <echo message="Departure Drive HANDLER: TEARDOWN on ${start.TIME}" />
+		<if>
+			<isset property="dd.credentials" />
+			<then>
+				<property file="${dd.credentials}" />
+			</then>
+			<else>
+				<echo message="Departure Drive credentials properties are not set!" />
+			</else>
+		</if>
+        <var name="code" value="0" />
+		<atomic.sequence.start.macro
+			device="DEPARTURE DRIVE" />
+		<trycatch property="returnmsg">
+			<try>
+				<for list="${unit.device.num}" param="deviter" delimiter="," parallel="false" >
+					<sequential>
+						<if>
+							<equals arg1="${unit.device.@{deviter}}" arg2="DD"/>
+							<then>
+								<!-- unplumbing vlans iteratively -->
+								<DDIterateLeave iter="${unit.action.num.DD}" />
+							</then>
+							<else>
+								<if>
+									<equals arg1="${unit.device.@{deviter}}" arg2="Exchange" />
+									<then>
+										<!--  multipoint and vlan translation -->
+										<ExchangeIterateLeave iter="${unit.action.num.Exchange}"/>
+									</then>
+									<else>
+										<echo message="DD Handler: Unknown device ${unit.device.@{deviter}}, exiting" />
+										<fail message="DD Handler: Unknown device ${unit.device.@{deviter}}, exiting" />
+									</else>
+								</if>
+							</else>
+						</if>
+					</sequential>
+				</for>
+			</try>
+			<catch>
+				<fail message="${returnmsg}"/>
+			</catch>
+			<finally>
+				<atomic.sequence.stop.macro
+					device="DEPARTURE DRIVE" />
+			</finally>
+		</trycatch>
+		<property name="shirako.target.code" value="0" />
+        <echo message="Departure Drive leave exit code: ${shirako.target.code}" />
+    </target>
+
+	<!-- MODIFY -->
+    <target name="modify" depends="resolve.configuration,ben.load.tasks">
+        <echo message="Departure Drive HANDLER: MODIFY" />
+        <property name="shirako.target.code" value="0" />
+    </target>
 </project>

--- a/handlers/providers/resources/handler/providers/dukenet/handler.xml
+++ b/handlers/providers/resources/handler/providers/dukenet/handler.xml
@@ -1,20 +1,43 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="dukenet" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: SETUP" /> 
-        <!-- enable DUKE.NET tag on all VM interfaaces --> 
-        <sequential> 
-            <create.vlan router="${router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <add.trunk.ports router="${router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${dukenet.6509.action.ports}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <!-- old way
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<property file="../ben.properties" />
+
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: SETUP" />
+		<!-- enable DUKE.NET tag on all VM interfaaces -->
+                <sequential>
+                	<create.vlan 
+                                router="${router}"
+                                router.type="Cisco6509"
+                                vlan.tag="${unit.vlan.tag}"
+                                vlan.qos.rate="${unit.vlan.qos.rate}"
+                                vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+                                router.user="${router.user}"
+                                router.password="${router.password}"
+                                router.admin.password="${router.admin.password}" />
+                        <add.trunk.ports 
+                                router="${router}"
+                                router.type="Cisco6509"
+                                vlan.tag="${unit.vlan.tag}"
+                                ports="${dukenet.6509.action.ports}"
+                                router.user="${router.user}"
+                                router.password="${router.password}"
+                                router.admin.password="${router.admin.password}" />
+		</sequential>
+<!-- old way
 		<enable.vlan 
 			service.location="${service.location}"
 			router="${router}"
@@ -24,34 +47,71 @@
 			router.password="${router.password}"
 			router.admin.password="${router.admin.password}"
 			/>
---> 
-        <!-- map the DUKE.NET tag to the NLR tag --> 
-        <if> 
-            <equals arg1="0" arg2="${code}" /> 
-            <then> 
-                <map.vlans router="${router}" router.type="Cisco6509" port="${router.ports.nlr}" src.vlan.tag="${dukenet.net.vlan}" dst.vlan.tag="${unit.net.vlan}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            </then> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: TEARDOWN" /> 
-        <unmap.vlans router="${router}" router.type="Cisco6509" src.vlan.tag="${dukenet.net.vlan}" dst.vlan.tag="${unit.net.vlan}" port="${router.ports.nlr}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <if> 
-            <equals arg1="0" arg2="${code}" /> 
-            <then> 
-                <sequential> 
-                    <remove.trunk.ports router="${router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${dukenet.6509.action.ports}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                    <delete.vlan router="${router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                </sequential> 
-            </then> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+-->
+		<!-- map the DUKE.NET tag to the NLR tag -->
+		<if>
+			<equals arg1="0" arg2="${code}" />
+			<then>	
+				<map.vlans 
+					router="${router}"
+                                        router.type="Cisco6509"
+					port="${router.ports.nlr}"
+					src.vlan.tag="${dukenet.net.vlan}"
+					dst.vlan.tag="${unit.net.vlan}"
+					router.user="${router.user}"
+					router.password="${router.password}"
+					router.admin.password="${router.admin.password}"
+					/>
+			</then>
+		</if>
+
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: TEARDOWN" />
+		<unmap.vlans 
+			router="${router}"
+			router.type="Cisco6509"
+			src.vlan.tag="${dukenet.net.vlan}"
+			dst.vlan.tag="${unit.net.vlan}"
+			port="${router.ports.nlr}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}"
+			/>
+
+		<if>
+			<equals arg1="0" arg2="${code}" />
+			<then>	
+               			<sequential>
+                        		<remove.trunk.ports
+                                		router="${router}"
+                                		router.type="Cisco6509"
+                               		 	vlan.tag="${unit.vlan.tag}"
+                               		 	ports="${dukenet.6509.action.ports}"
+                                		router.user="${router.user}"
+                                		router.password="${router.password}"
+                                		router.admin.password="${router.admin.password}" />
+                        		<delete.vlan 
+                                		router="${router}"
+                                		router.type="Cisco6509"
+                                		vlan.tag="${unit.vlan.tag}"
+                                		vlan.with.qos="${unit.vlan.with.qos}"
+                                		router.user="${router.user}"
+                                		router.password="${router.password}"
+                                		router.admin.password="${router.admin.password}" />
+              			</sequential>
+			</then>
+		</if>
+
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/handlers/providers/resources/handler/providers/euca-sites/renci.euca.net.xml
+++ b/handlers/providers/resources/handler/providers/euca-sites/renci.euca.net.xml
@@ -1,54 +1,93 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="renci.euca.net" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<property file="../ben.properties" />
+	<!-- Uncomment for handler testing
 	<property file="renci.euca.net.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="RENCI EUCA NET HANDLER: SETUP" /> 
-        <if> 
-            <isset property="eucanet.credentials" /> 
-            <then> 
-                <property file="${eucanet.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="Euca-net credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <!-- enable RENCI EUCA tag on all Euca interfaaces --> 
-        <sequential> 
-            <create.vlan router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <add.trunk.ports router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="RENCI EUCA NET HANDLER: TEARDOWN" /> 
-        <if> 
-            <isset property="eucanet.credentials" /> 
-            <then> 
-                <property file="${eucanet.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="Euca-net credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <sequential> 
-            <remove.trunk.ports router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <delete.vlan router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="RENCI EUCA NET HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="RENCI EUCA NET HANDLER: SETUP" />
+		<if>
+			<isset property="eucanet.credentials" />
+			<then>
+				<property file="${eucanet.credentials}" />
+			</then>
+			<else>
+				<echo message="Euca-net credentials properties are not set!" />
+			</else>
+		</if>
+		<!-- enable RENCI EUCA tag on all Euca interfaaces -->
+		<sequential>
+    	<create.vlan 
+    		router="${renci.euca.router}"
+			router.type="ex3200"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.qos.rate="${unit.vlan.qos.rate}"
+			vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+	    <add.trunk.ports 
+			router="${renci.euca.router}"
+			router.type="ex3200"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.ports}"
+			router.user="${router.user}"
+	    	router.password="${router.password}"
+	    	router.admin.password="${router.admin.password}" />
+		</sequential>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="RENCI EUCA NET HANDLER: TEARDOWN" />
+		<if>
+			<isset property="eucanet.credentials" />
+			<then>
+				<property file="${eucanet.credentials}" />
+			</then>
+			<else>
+				<echo message="Euca-net credentials properties are not set!" />
+			</else>
+		</if>
+		<sequential>
+		<remove.trunk.ports
+			router="${renci.euca.router}"
+			router.type="ex3200"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.ports}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}" />
+    	<delete.vlan 
+    		router="${renci.euca.router}"
+			router.type="ex3200"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.with.qos="${unit.vlan.with.qos}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+		</sequential>
+    	<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="RENCI EUCA NET HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/handlers/providers/resources/handler/providers/euca-sites/unc.euca.net.xml
+++ b/handlers/providers/resources/handler/providers/euca-sites/unc.euca.net.xml
@@ -1,54 +1,93 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="unc.euca.net" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<property file="../ben.properties" />
+	<!-- Uncomment for handler testing
 	<property file="unc.euca.net.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="UNC EUCA NET HANDLER: SETUP" /> 
-        <if> 
-            <isset property="eucanet.credentials" /> 
-            <then> 
-                <property file="${eucanet.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="Euca-net credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <!-- enable UNC EUCA tag on all Euca interfaaces --> 
-        <sequential> 
-            <create.vlan router="${unc.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <add.trunk.ports router="${unc.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="UNC EUCA NET HANDLER: TEARDOWN" /> 
-        <if> 
-            <isset property="eucanet.credentials" /> 
-            <then> 
-                <property file="${eucanet.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="Euca-net credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <sequential> 
-            <remove.trunk.ports router="${unc.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <delete.vlan router="${unc.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="UNC EUCA NET HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="UNC EUCA NET HANDLER: SETUP" />
+		<if>
+			<isset property="eucanet.credentials" />
+			<then>
+				<property file="${eucanet.credentials}" />
+			</then>
+			<else>
+				<echo message="Euca-net credentials properties are not set!" />
+			</else>
+		</if>
+		<!-- enable UNC EUCA tag on all Euca interfaaces -->
+		<sequential>
+    	<create.vlan 
+    		router="${unc.euca.router}"
+			router.type="ex3200"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.qos.rate="${unit.vlan.qos.rate}"
+			vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+	    <add.trunk.ports 
+			router="${unc.euca.router}"
+			router.type="ex3200"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.ports}"
+			router.user="${router.user}"
+	    	router.password="${router.password}"
+	    	router.admin.password="${router.admin.password}" />
+		</sequential>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="UNC EUCA NET HANDLER: TEARDOWN" />
+		<if>
+			<isset property="eucanet.credentials" />
+			<then>
+				<property file="${eucanet.credentials}" />
+			</then>
+			<else>
+				<echo message="Euca-net credentials properties are not set!" />
+			</else>
+		</if>
+		<sequential>
+		<remove.trunk.ports
+			router="${unc.euca.router}"
+			router.type="ex3200"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.ports}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}" />
+    	<delete.vlan 
+    		router="${unc.euca.router}"
+			router.type="ex3200"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.with.qos="${unit.vlan.with.qos}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+		</sequential>
+    	<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="UNC EUCA NET HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/handlers/providers/resources/handler/providers/euca-sites/unified.euca.net.xml
+++ b/handlers/providers/resources/handler/providers/euca-sites/unified.euca.net.xml
@@ -1,180 +1,230 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="unified.euca.net" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<property file="../ben.properties" />
+	<!-- Uncomment for handler testing
 	<property file="unified.euca.net.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <if> 
-            <not> 
-                <isset property="euca.site" /> 
-            </not> 
-            <then> 
-                <echo message="Property euca.site must be set for unified euca net handler" /> 
-            </then> 
-        </if> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Unified Eucalyptus Network Handler for ${euca.site}: JOIN on ${start.TIME}" /> 
-        <if> 
-            <isset property="eucanet.credentials" /> 
-            <then> 
-                <property file="${eucanet.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="Euca-net credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <!-- hairpin --> 
-                <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <!-- enable EUCA tag on all Euca interfaaces --> 
-                <sequential> 
-                    <propertycopy property="euca.router" from="${euca.site}.euca.router" /> 
-                    <propertycopy property="euca.router.type" from="${euca.site}.euca.router.type" /> 
-                    <echo message="creating VLAN ${unit.vlan.url} with tag ${unit.vlan.tag}, rate ${unit.vlan.qos.rate} on router ${euca.router}" /> 
-                    <!-- atomize this sequence --> 
-                    <atomic.sequence.start.macro device="${euca.router}" /> 
-                    <create.vlan router="${euca.router}" router.type="${euca.router.type}" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                    <add.trunk.ports router="${euca.router}" router.type="${euca.router.type}" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                    <atomic.sequence.stop.macro device="${euca.router}" /> 
-                </sequential> 
-                <echo message="use.neuca.quantum: ${use.neuca.quantum}" /> 
-                <if> 
-                    <equals arg1="${use.neuca.quantum}" arg2="true" /> 
-                    <then> 
-                        <echo message="Starting Add Quantum Network" /> 
-                        <var name="create.network.output" unset="true"></var> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <echo message="Running: ${provider.scripts}/neuca-quantum-create-net" /> 
-                        <echo message="PROVIDER_DIR = ${provider.dir}" /> 
-                        <echo message="PROVIDER_LOG_DIR ${provider.log.dir}" /> 
-                        <echo message="PROVIDER_LOG_FILE ${provider.log.file}" /> 
-                        <echo message="PROVIDER_LOG_LEVEL ${provider.log.level}" /> 
-                        <echo message="QUANTUM_TENANT_ID ${quantum.tenant.id}" /> 
-                        <echo message="QUANTUM_NET_TYPE ipv4" /> 
-                        <echo message="QUANTUM_NET_NETWORK ${unit.quantum.netname}" /> 
-                        <echo message="QUANTUM_NET_VLAN ${unit.vlan.tag}" /> 
-                        <echo message="QUANTUM_MAX_RATE ${unit.vlan.qos.rate}" /> 
-                        <echo message="QUANTUM_BURST_RATE ${unit.vlan.qos.burst.size}" /> 
-                        <exec executable="${provider.scripts}/neuca-quantum-create-net" resultproperty="code" outputproperty="create.network.output"> 
-                            <env key="PROVIDER_DIR" value="${provider.dir}" /> 
-                            <env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" /> 
-                            <env key="PROVIDER_LOG_FILE" value="${provider.log.file}" /> 
-                            <env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" /> 
-                            <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                            <env key="QUANTUM_NET_TYPE" value="ipv4" /> 
-                            <env key="QUANTUM_NET_NETWORK" value="${unit.quantum.netname}" /> 
-                            <env key="QUANTUM_NET_VLAN" value="${unit.vlan.tag}" /> 
-                            <env key="QUANTUM_MAX_RATE" value="${unit.vlan.qos.rate}" /> 
-                            <env key="QUANTUM_BURST_RATE" value="${unit.vlan.qos.burst.size}" /> 
-                        </exec> 
-                        <echo message="Finished: ${provider.scripts}/neuca-quantum-create-net" /> 
-                        <echo message="exit code ${code}, ${create.network.output}" /> 
-                        <if> 
-                            <not> 
-                                <equals arg1="${code}" arg2="0" /> 
-                            </not> 
-                            <then> 
-                                <echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" /> 
-                                <property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" /> 
-                            </then> 
-                            <else> 
-                                <var name="shirako.save.unit.quantum.net.uuid" unset="true"></var> 
-                                <property name="shirako.save.unit.quantum.net.uuid" value="${create.network.output}" /> 
-                            </else> 
-                        </if> 
-                        <echo message="shirako.save.unit.quantum.net.uuid = ${shirako.save.unit.quantum.net.uuid}, create.network.output = ${create.network.output}" /> 
-                        <echo message="Done Add Quantum Network" /> 
-                    </then> 
-                </if> 
-                <!-- hairpin the url property so the user sees it too --> 
-                <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Unified Eucalyptus Network Handler for ${euca.site}: LEAVE on ${start.TIME}" /> 
-        <if> 
-            <isset property="eucanet.credentials" /> 
-            <then> 
-                <property file="${eucanet.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="Euca-net credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <sequential> 
-                    <propertycopy property="euca.router" from="${euca.site}.euca.router" /> 
-                    <propertycopy property="euca.router.type" from="${euca.site}.euca.router.type" /> 
-                    <!-- atomize this sequence --> 
-                    <atomic.sequence.start.macro device="${euca.router}" /> 
-                    <remove.trunk.ports router="${euca.router}" router.type="${euca.router.type}" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                    <delete.vlan router="${euca.router}" router.type="${euca.router.type}" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                    <atomic.sequence.stop.macro device="${euca.router}" /> 
-                </sequential> 
-                <echo message="About to call neuca-quantum-delete-net" /> 
-                <if> 
-                    <equals arg1="${use.neuca.quantum}" arg2="true" /> 
-                    <then> 
-                        <var name="create.network.output" unset="true"></var> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <exec executable="${provider.scripts}/neuca-quantum-delete-net" resultproperty="code" outputproperty="create.network.output"> 
-                            <env key="PROVIDER_DIR" value="${provider.dir}" /> 
-                            <env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" /> 
-                            <env key="PROVIDER_LOG_FILE" value="${provider.log.file}" /> 
-                            <env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" /> 
-                            <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                            <env key="QUANTUM_NET_UUID" value="${unit.quantum.net.uuid}" /> 
-                        </exec> 
-                        <echo message="exit code ${code}, ${create.network.output}" /> 
-                        <if> 
-                            <not> 
-                                <equals arg1="${code}" arg2="0" /> 
-                            </not> 
-                            <then> 
-                                <echo message="unable to create quantum network: exit code ${code}, ${create.instance.output}" /> 
-                                <property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" /> 
-                            </then> 
-                        </if> 
-                    </then> 
-                </if> 
-            </else> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="Unified Eucalyptus Network Handler for ${euca.site}: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<if>
+			<not>
+				<isset property="euca.site" />
+			</not>
+			<then>
+				<echo message="Property euca.site must be set for unified euca net handler" />
+			</then>
+		</if>
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="Unified Eucalyptus Network Handler for ${euca.site}: JOIN on ${start.TIME}" />
+		<if>
+			<isset property="eucanet.credentials" />
+			<then>
+				<property file="${eucanet.credentials}" />
+			</then>
+			<else>
+				<echo message="Euca-net credentials properties are not set!" />
+			</else>
+		</if>
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<!-- hairpin -->
+				<var name="shirako.save.unit.vlan.url" unset="true" />
+				<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<!-- enable EUCA tag on all Euca interfaaces -->
+				<sequential>
+					<propertycopy property="euca.router" from="${euca.site}.euca.router" />
+					<propertycopy property="euca.router.type" from="${euca.site}.euca.router.type" />
+					<echo message="creating VLAN ${unit.vlan.url} with tag ${unit.vlan.tag}, rate ${unit.vlan.qos.rate} on router ${euca.router}" />
+					<!-- atomize this sequence -->
+					<atomic.sequence.start.macro
+						device="${euca.router}" />
+					<create.vlan 
+		    			router="${euca.router}"
+					router.type="${euca.router.type}"
+		       		 	vlan.tag="${unit.vlan.tag}"
+					vlan.qos.rate="${unit.vlan.qos.rate}"
+					vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+		       		 	router.user="${router.user}"
+		       		 	router.password="${router.password}"
+		       		 	router.default.prompt="${router.default.prompt}"
+		       		 	router.admin.password="${router.admin.password}" />
+					<add.trunk.ports 
+					router="${euca.router}"
+					router.type="${euca.router.type}"
+					vlan.tag="${unit.vlan.tag}"
+					ports="${config.interface.ports}"
+					router.user="${router.user}"
+			    		router.password="${router.password}"
+		       		 	router.default.prompt="${router.default.prompt}"
+			    		router.admin.password="${router.admin.password}" />
+					<atomic.sequence.stop.macro
+						device="${euca.router}" />
+				</sequential>
+ 				<echo message="use.neuca.quantum: ${use.neuca.quantum}" />
+				<if>
+					<equals arg1="${use.neuca.quantum}" arg2="true" />
+					<then>
+ 						<echo message="Starting Add Quantum Network"/> 
+						<var name="create.network.output" unset="true" />
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<echo message="Running: ${provider.scripts}/neuca-quantum-create-net" />
+						<echo message="PROVIDER_DIR = ${provider.dir}" />
+                                                <echo message="PROVIDER_LOG_DIR ${provider.log.dir}" />
+                                                <echo message="PROVIDER_LOG_FILE ${provider.log.file}" />
+                                                <echo message="PROVIDER_LOG_LEVEL ${provider.log.level}" />
+                                                <echo message="QUANTUM_TENANT_ID ${quantum.tenant.id}" />
+                                                <echo message="QUANTUM_NET_TYPE ipv4" />
+                                                <echo message="QUANTUM_NET_NETWORK ${unit.quantum.netname}" />
+                                                <echo message="QUANTUM_NET_VLAN ${unit.vlan.tag}" />
+                                                <echo message="QUANTUM_MAX_RATE ${unit.vlan.qos.rate}" />
+                                                <echo message="QUANTUM_BURST_RATE ${unit.vlan.qos.burst.size}" />
+						<exec executable="${provider.scripts}/neuca-quantum-create-net" resultproperty="code" outputproperty="create.network.output" >
+							<env key="PROVIDER_DIR" value="${provider.dir}" />
+							<env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" />
+							<env key="PROVIDER_LOG_FILE" value="${provider.log.file}" />
+							<env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" />
+							<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+							<env key="QUANTUM_NET_TYPE" value="ipv4" />
+							<env key="QUANTUM_NET_NETWORK" value="${unit.quantum.netname}" />
+							<env key="QUANTUM_NET_VLAN" value="${unit.vlan.tag}" />
+							<env key="QUANTUM_MAX_RATE" value="${unit.vlan.qos.rate}" />
+							<env key="QUANTUM_BURST_RATE" value="${unit.vlan.qos.burst.size}" />
+						</exec>
+						<echo message="Finished: ${provider.scripts}/neuca-quantum-create-net" />
+						<echo message="exit code ${code}, ${create.network.output}" />
+						<if>
+							<not>
+								<equals arg1="${code}" arg2="0" />
+							</not>
+							<then>
+								<echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" />
+								<property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" />
+							</then>
+							<else>
+								<var name="shirako.save.unit.quantum.net.uuid" unset="true" />
+								<property name="shirako.save.unit.quantum.net.uuid" value="${create.network.output}" />
+							</else>
+						</if>
+						<echo message="shirako.save.unit.quantum.net.uuid = ${shirako.save.unit.quantum.net.uuid}, create.network.output = ${create.network.output}" />
+						<echo message="Done Add Quantum Network"/>
+					</then>
+				</if>	
+				<!-- hairpin the url property so the user sees it too -->
+				<var name="shirako.save.unit.vlan.url" unset="true" />
+				<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+				<property name="shirako.target.code" value="${code}" />
+			</else>
+		</if>
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="Unified Eucalyptus Network Handler for ${euca.site}: LEAVE on ${start.TIME}" />
+		<if>
+			<isset property="eucanet.credentials" />
+			<then>
+				<property file="${eucanet.credentials}" />
+			</then>
+			<else>
+				<echo message="Euca-net credentials properties are not set!" />
+			</else>
+		</if>
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<sequential>
+					<propertycopy property="euca.router" from="${euca.site}.euca.router" />
+					<propertycopy property="euca.router.type" from="${euca.site}.euca.router.type" />
+					<!-- atomize this sequence -->
+					<atomic.sequence.start.macro
+					device="${euca.router}" />
+					<remove.trunk.ports
+					router="${euca.router}"
+					router.type="${euca.router.type}"
+					vlan.tag="${unit.vlan.tag}"
+					ports="${config.interface.ports}"
+					router.user="${router.user}"
+					router.password="${router.password}"
+		       		 	router.default.prompt="${router.default.prompt}"
+					router.admin.password="${router.admin.password}" />
+					<delete.vlan 
+		    			router="${euca.router}"
+					router.type="${euca.router.type}"
+		        		vlan.tag="${unit.vlan.tag}"
+					vlan.with.qos="${unit.vlan.with.qos}"
+		        		router.user="${router.user}"
+		        		router.password="${router.password}"
+		       		 	router.default.prompt="${router.default.prompt}"
+		        		router.admin.password="${router.admin.password}" />
+					<atomic.sequence.stop.macro
+						device="${euca.router}" />
+				</sequential>
+				<echo message="About to call neuca-quantum-delete-net" />
+				<if>
+					<equals arg1="${use.neuca.quantum}" arg2="true" />
+					<then>
+						<var name="create.network.output" unset="true" />
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<exec executable="${provider.scripts}/neuca-quantum-delete-net" resultproperty="code" outputproperty="create.network.output" >
+							<env key="PROVIDER_DIR" value="${provider.dir}" />
+							<env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" />
+							<env key="PROVIDER_LOG_FILE" value="${provider.log.file}" />
+							<env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" />
+							<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+							<env key="QUANTUM_NET_UUID" value="${unit.quantum.net.uuid}" />
+						</exec>
+						<echo message="exit code ${code}, ${create.network.output}" />
+						<if>
+							<not>
+								<equals arg1="${code}" arg2="0" />
+							</not>
+							<then>
+								<echo message="unable to create quantum network: exit code ${code}, ${create.instance.output}" />
+								<property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" />
+							</then>
+						</if>
+					</then>
+				</if>
+
+			</else>
+		</if>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="Unified Eucalyptus Network Handler for ${euca.site}: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/handlers/providers/resources/handler/providers/flowvisor/handler.xml
+++ b/handlers/providers/resources/handler/providers/flowvisor/handler.xml
@@ -1,14 +1,22 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="flowvisor" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- Uncomment for handler testing
 	<property file="flowvisor.test.properties" />
-	--> 
-    <!-- 
+	-->
+
+	<!-- 
 		Controller must supply
 			unit.openflow.slice.ctrl.url - [optional] User OF Controller URL
 			unit.openflow.slice.email - [optional] User OF slice email
@@ -38,188 +46,206 @@
 
 			#tenant that uses orca
 			quantum.tenant.id=geni-orca
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Flowvisor Handler: JOIN on ${start.TIME}" /> 
-        <if> 
-            <isset property="flowvisor.properties" /> 
-            <then> 
-                <property file="${flowvisor.properties}" /> 
-            </then> 
-            <else> 
-                <echo message="Flowvisor credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <!-- hairpin --> 
-                <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <!-- atomize this sequence (need to start early because otherwise NOX's start in parallel) --> 
-                <atomic.sequence.start.macro device="${flowvisor.url}" /> 
-                <!-- create a slice and add a vlan flowspace to it --> 
-                <var name="ctrl.url" unset="true"></var> 
-                <if> 
-                    <isset property="unit.openflow.slice.ctrl.url" /> 
-                    <!-- user provided a controller --> 
-                    <then> 
-                        <property name="ctrl.url" value="${unit.openflow.slice.ctrl.url}" /> 
-                        <if> 
-                            <not> 
-                                <isset property="unit.openflow.slice.email" /> 
-                            </not> 
-                            <then> 
-                                <echo message="Slice email not specified, setting to default exogeni-ops@renci.org" /> 
-                                <property name="unit.openflow.slice.email" value="exogeni-ops@renci.org" /> 
-                            </then> 
-                        </if> 
-                        <if> 
-                            <not> 
-                                <isset property="unit.openflow.slice.pass" /> 
-                            </not> 
-                            <then> 
-                                <echo message="Slice password not specified, setting to default 'slicepass'" /> 
-                                <property name="unit.openflow.slice.pass" value="slicepass" /> 
-                            </then> 
-                        </if> 
-                    </then> 
-                    <else> 
-                        <!-- start our own controller --> 
-                        <var name="unit.openflow.slice.email" unset="true"></var> 
-                        <var name="unit.openflow.slice.pass" unset="true"></var> 
-                        <property name="unit.openflow.slice.email" value="exogeni-ops@renci.org" /> 
-                        <exec executable="${provider.scripts}/genpasswd.sh" resultproperty="code" outputproperty="unit.openflow.slice.pass" /> 
-                        <if> 
-                            <not> 
-                                <equals arg1="${code}" arg2="0" /> 
-                            </not> 
-                            <then> 
-                                <property name="message" value="unable to generate random slice password for flowvisor, using default" /> 
-                                <var name="unit.openflow.slice.pass" unset="true"></var> 
-                                <property name="unit.openflow.slice.pass" value="defaultpass" /> 
-                            </then> 
-                        </if> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <if> 
-                            <equals arg1="${fvctrl.type}" arg2="nox" /> 
-                            <then> 
-                                <echo message="Starting NOX controller in ${nox.core.exec}" /> 
-                                <exec executable="${provider.scripts}/start_nox.sh" resultproperty="code" outputproperty="ctrl.url"> 
-                                    <env key="NOXHOST" value="${fvctrl.host}" /> 
-                                    <env key="FVVLAN" value="${unit.vlan.tag}" /> 
-                                    <env key="NOX_FIRST_PORT" value="${fvctrl.first.port}" /> 
-                                    <env key="NOX_LAST_PORT" value="${fvctrl.last.port}" /> 
-                                    <env key="NOXEXEC" value="${nox.core.exec}" /> 
-                                </exec> 
-                            </then> 
-                            <else> 
-                                <if> 
-                                    <equals arg1="${fvctrl.type}" arg2="floodlight" /> 
-                                    <then> 
-                                        <echo message="Starting Floodlight controller from ${floodlight.jar}" /> 
-                                        <exec executable="${provider.scripts}/start_floodlight.sh" resultproperty="code" outputproperty="ctrl.url"> 
-                                            <env key="FLHOST" value="${fvctrl.host}" /> 
-                                            <env key="FVVLAN" value="${unit.vlan.tag}" /> 
-                                            <env key="FL_FIRST_PORT" value="${fvctrl.first.port}" /> 
-                                            <env key="FL_LAST_PORT" value="${fvctrl.last.port}" /> 
-                                            <env key="FLEXEC" value="${floodlight.jar}" /> 
-                                        </exec> 
-                                    </then> 
-                                </if> 
-                            </else> 
-                        </if> 
-                        <if> 
-                            <not> 
-                                <equals arg1="${code}" arg2="0" /> 
-                            </not> 
-                            <then> 
-                                <echo message="Unable to start OF Controller due to: ${ctrl.url}" /> 
-                                <property name="message" value="Unable to start OF Controller due to: ${ctrl.url}" /> 
-                                <var name="ctrl.url" unset="true"></var> 
-                            </then> 
-                        </if> 
-                    </else> 
-                </if> 
-                <if> 
-                    <isset property="ctrl.url" /> 
-                    <then> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <echo message="creating VLAN ${unit.vlan.url} with tag ${unit.vlan.tag}, on FlowVisor ${flowvisor.url} with controller ${ctrl.url}" /> 
-                        <create.openflow.slice url="${flowvisor.url}" router.user="${flowvisor.user}" router.password="${flowvisor.passwd}" slice.name="orca-${unit.vlan.tag}" slice.email="${unit.openflow.slice.email}" slice.pass="${unit.openflow.slice.pass}" slice.ctrl.url="${ctrl.url}" /> 
-                        <add.openflow.vlan.flowspace url="${flowvisor.url}" router.user="${flowvisor.user}" router.password="${flowvisor.passwd}" slice.name="orca-${unit.vlan.tag}" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" /> 
-                    </then> 
-                    <else> 
-                        <echo message="controller URL property not set, flowvisor slice will not be created" /> 
-                    </else> 
-                </if> 
-                <atomic.sequence.stop.macro device="${flowvisor.url}" /> 
-                <echo message="About to create quantum network, use.neuca.quantum = ${use.neuca.quantum}" /> 
-                <if> 
-                    <equals arg1="${use.neuca.quantum}" arg2="true" /> 
-                    <then> 
-                        <echo message="Using quantum network" /> 
-                        <var name="create.network.output" unset="true"></var> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <echo message="PROVIDER_DIR =${provider.dir}" /> 
-                        <echo message="PROVIDER_LOG_DIR= ${provider.log.dir}" /> 
-                        <echo message="PROVIDER_LOG_FILE= ${provider.log.file}" /> 
-                        <echo message="PROVIDER_LOG_LEVEL= ${provider.log.level}" /> 
-                        <echo message="QUANTUM_TENANT_ID = ${quantum.tenant.id}" /> 
-                        <echo message="QUANTUM_NET_TYPE = ipv4" /> 
-                        <echo message="QUANTUM_NET_NETWORK= ${unit.quantum.netname}" /> 
-                        <echo message="QUANTUM_NET_VLAN= ${unit.vlan.tag}" /> 
-                        <echo message="QUANTUM_MAX_RATE= ${unit.vlan.qos.rate}" /> 
-                        <echo message="QUANTUM_BURST_RATE= ${unit.vlan.qos.burst.size}" /> 
-                        <exec executable="${provider.scripts}/neuca-quantum-create-net" resultproperty="code" outputproperty="create.network.output"> 
-                            <env key="PROVIDER_DIR" value="${provider.dir}" /> 
-                            <env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" /> 
-                            <env key="PROVIDER_LOG_FILE" value="${provider.log.file}" /> 
-                            <env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" /> 
-                            <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                            <env key="QUANTUM_NET_TYPE" value="ipv4" /> 
-                            <env key="QUANTUM_NET_NETWORK" value="${unit.quantum.netname}" /> 
-                            <env key="QUANTUM_NET_VLAN" value="${unit.vlan.tag}" /> 
-                            <env key="QUANTUM_MAX_RATE" value="${unit.vlan.qos.rate}" /> 
-                            <env key="QUANTUM_BURST_RATE" value="${unit.vlan.qos.burst.size}" /> 
-                        </exec> 
-                        <echo message="exit code ${code}, ${create.network.output}" /> 
-                        <if> 
-                            <not> 
-                                <equals arg1="${code}" arg2="0" /> 
-                            </not> 
-                            <then> 
-                                <echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" /> 
-                                <property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" /> 
-                            </then> 
-                            <else> 
-                                <var name="shirako.save.unit.quantum.net.uuid" unset="true"></var> 
-                                <property name="shirako.save.unit.quantum.net.uuid" value="${create.network.output}" /> 
-                            </else> 
-                        </if> 
-                        <echo message="shirako.save.unit.quantum.net.uuid = ${shirako.save.unit.quantum.net.uuid}, create.network.output = ${create.network.output}" /> 
-                    </then> 
-                </if> 
-                <!-- hairpin the url property so the user sees it too --> 
-                <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <property name="shirako.target.code.message" value="${message}" /> 
-            </else> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code} with message: ${shirako.target.code.message}" /> 
-    </target> 
-    <!-- 
+	-->
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="Flowvisor Handler: JOIN on ${start.TIME}" />
+		<if>
+			<isset property="flowvisor.properties" />
+			<then>
+				<property file="${flowvisor.properties}" />
+			</then>
+			<else>
+				<echo message="Flowvisor credentials properties are not set!" />
+			</else>
+		</if>
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<!-- hairpin -->
+				<var name="shirako.save.unit.vlan.url" unset="true" />
+				<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<!-- atomize this sequence (need to start early because otherwise NOX's start in parallel) -->
+				<atomic.sequence.start.macro
+					device="${flowvisor.url}" />
+				<!-- create a slice and add a vlan flowspace to it -->
+				<var name="ctrl.url" unset="true" />
+				<if>
+					<isset property="unit.openflow.slice.ctrl.url" />
+					<!-- user provided a controller -->
+					<then>
+						<property name="ctrl.url" value="${unit.openflow.slice.ctrl.url}" />
+						<if>
+							<not>
+								<isset property="unit.openflow.slice.email" />
+							</not>
+							<then>
+								<echo message="Slice email not specified, setting to default exogeni-ops@renci.org" />
+								<property name="unit.openflow.slice.email" value="exogeni-ops@renci.org" />
+							</then>
+						</if>
+						<if>
+							<not>
+								<isset property="unit.openflow.slice.pass" />
+							</not>
+							<then>
+								<echo message="Slice password not specified, setting to default 'slicepass'" />
+								<property name="unit.openflow.slice.pass" value="slicepass" />
+							</then>
+						</if>
+					</then>
+					<else>
+						<!-- start our own controller -->
+						<var name="unit.openflow.slice.email" unset="true" />
+						<var name="unit.openflow.slice.pass" unset="true" />
+						<property name="unit.openflow.slice.email" value="exogeni-ops@renci.org" />
+						<exec executable="${provider.scripts}/genpasswd.sh" resultproperty="code" outputproperty="unit.openflow.slice.pass" />
+						<if>
+							<not>
+								<equals arg1="${code}" arg2="0" />
+							</not>
+							<then>
+								<property name="message" value="unable to generate random slice password for flowvisor, using default" />
+								<var name="unit.openflow.slice.pass" unset="true" />
+								<property name="unit.openflow.slice.pass" value="defaultpass" />
+							</then>
+						</if>
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<if>
+							<equals arg1="${fvctrl.type}" arg2="nox" />
+							<then>
+								<echo message="Starting NOX controller in ${nox.core.exec}" />
+								<exec executable="${provider.scripts}/start_nox.sh" resultproperty="code" outputproperty="ctrl.url">
+									<env key="NOXHOST" value="${fvctrl.host}" />
+									<env key="FVVLAN" value="${unit.vlan.tag}" />
+									<env key="NOX_FIRST_PORT" value="${fvctrl.first.port}" />
+									<env key="NOX_LAST_PORT" value="${fvctrl.last.port}" />
+									<env key="NOXEXEC" value="${nox.core.exec}" />
+								</exec>
+							</then>
+							<else>
+								<if>
+									<equals arg1="${fvctrl.type}" arg2="floodlight" />
+									<then>
+										<echo message="Starting Floodlight controller from ${floodlight.jar}" />
+										<exec executable="${provider.scripts}/start_floodlight.sh" resultproperty="code" outputproperty="ctrl.url">
+											<env key="FLHOST" value="${fvctrl.host}" />
+											<env key="FVVLAN" value="${unit.vlan.tag}" />
+											<env key="FL_FIRST_PORT" value="${fvctrl.first.port}" />
+											<env key="FL_LAST_PORT" value="${fvctrl.last.port}" />
+											<env key="FLEXEC" value="${floodlight.jar}" />
+										</exec>
+									</then>
+								</if>
+							</else>
+						</if>
+
+						<if>
+							<not>
+								<equals arg1="${code}" arg2="0" />
+							</not>
+							<then>
+								<echo message="Unable to start OF Controller due to: ${ctrl.url}" />
+								<property name="message" value="Unable to start OF Controller due to: ${ctrl.url}" />
+								<var name="ctrl.url" unset="true" />
+							</then>
+						</if>
+					</else>
+				</if>
+				<if>
+					<isset property="ctrl.url" />
+					<then>
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<echo message="creating VLAN ${unit.vlan.url} with tag ${unit.vlan.tag}, on FlowVisor ${flowvisor.url} with controller ${ctrl.url}" />
+						<create.openflow.slice
+							url="${flowvisor.url}"
+							router.user="${flowvisor.user}"
+							router.password="${flowvisor.passwd}"
+							slice.name="orca-${unit.vlan.tag}"
+							slice.email="${unit.openflow.slice.email}"
+							slice.pass="${unit.openflow.slice.pass}"
+							slice.ctrl.url="${ctrl.url}" />
+						<add.openflow.vlan.flowspace
+							url="${flowvisor.url}"
+							router.user="${flowvisor.user}"
+							router.password="${flowvisor.passwd}"
+							slice.name="orca-${unit.vlan.tag}"
+							vlan.tag="${unit.vlan.tag}"
+							ports="${config.interface.ports}" />
+					</then>
+					<else>
+						<echo message="controller URL property not set, flowvisor slice will not be created" />
+					</else>
+				</if>
+				<atomic.sequence.stop.macro
+					device="${flowvisor.url}" />
+				<echo message="About to create quantum network, use.neuca.quantum = ${use.neuca.quantum}" />
+				<if>
+					<equals arg1="${use.neuca.quantum}" arg2="true" />
+					<then>
+						<echo message="Using quantum network" />
+						<var name="create.network.output" unset="true" />
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<echo message="PROVIDER_DIR =${provider.dir}" />
+						<echo message="PROVIDER_LOG_DIR= ${provider.log.dir}" />
+						<echo message="PROVIDER_LOG_FILE= ${provider.log.file}" />
+						<echo message="PROVIDER_LOG_LEVEL= ${provider.log.level}" />
+						<echo message="QUANTUM_TENANT_ID = ${quantum.tenant.id}" />
+						<echo message="QUANTUM_NET_TYPE = ipv4" />
+						<echo message="QUANTUM_NET_NETWORK= ${unit.quantum.netname}" />
+						<echo message="QUANTUM_NET_VLAN= ${unit.vlan.tag}" />
+						<echo message="QUANTUM_MAX_RATE= ${unit.vlan.qos.rate}" />
+						<echo message="QUANTUM_BURST_RATE= ${unit.vlan.qos.burst.size}" />
+						<exec executable="${provider.scripts}/neuca-quantum-create-net" resultproperty="code" outputproperty="create.network.output">
+							<env key="PROVIDER_DIR" value="${provider.dir}" />
+							<env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" />
+							<env key="PROVIDER_LOG_FILE" value="${provider.log.file}" />
+							<env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" />
+							<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+							<env key="QUANTUM_NET_TYPE" value="ipv4" />
+							<env key="QUANTUM_NET_NETWORK" value="${unit.quantum.netname}" />
+							<env key="QUANTUM_NET_VLAN" value="${unit.vlan.tag}" />
+							<env key="QUANTUM_MAX_RATE" value="${unit.vlan.qos.rate}" />
+							<env key="QUANTUM_BURST_RATE" value="${unit.vlan.qos.burst.size}" />
+						</exec>
+						<echo message="exit code ${code}, ${create.network.output}" />
+						<if>
+							<not>
+								<equals arg1="${code}" arg2="0" />
+							</not>
+							<then>
+								<echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" />
+								<property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" />
+							</then>
+							<else>
+								<var name="shirako.save.unit.quantum.net.uuid" unset="true" />
+								<property name="shirako.save.unit.quantum.net.uuid" value="${create.network.output}" />
+							</else>
+						</if>
+						<echo message="shirako.save.unit.quantum.net.uuid = ${shirako.save.unit.quantum.net.uuid}, create.network.output = ${create.network.output}" />
+					</then>
+				</if>
+				<!-- hairpin the url property so the user sees it too -->
+				<var name="shirako.save.unit.vlan.url" unset="true" />
+				<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+				<property name="shirako.target.code" value="${code}" />
+				<property name="shirako.target.code.message" value="${message}" />
+			</else>
+		</if>
+		<echo message="join exit code: ${shirako.target.code} with message: ${shirako.target.code.message}" />
+	</target>
+
+	<!-- 
 		Controller must supply
 			unit.vlan.tag [mandatory]
 			
@@ -227,68 +253,74 @@
 			flowvisor.url
 			flowvisor.user
 			flowvisor.passwd
-	--> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Flowvisor Handler: LEAVE on ${start.TIME}" /> 
-        <if> 
-            <isset property="flowvisor.properties" /> 
-            <then> 
-                <property file="${flowvisor.properties}" /> 
-            </then> 
-            <else> 
-                <echo message="Flowvisor credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <delete.openflow.slice url="${flowvisor.url}" router.user="${flowvisor.user}" router.password="${flowvisor.passwd}" slice.name="orca-${unit.vlan.tag}" /> 
-                <var name="code" unset="true"></var> 
-                <echo message="Stopping OpenFlow controller ${fvctrl.type}" /> 
-                <exec executable="${provider.scripts}/stop_${fvctrl.type}.sh" resultproperty="code"> 
-                    <env key="FVVLAN" value="${unit.vlan.tag}" /> 
-                </exec> 
-                <echo message="About to call neuca-quantum-delete-net, use.neuca.quantum = ${use.neuca.quantum}" /> 
-                <if> 
-                    <equals arg1="${use.neuca.quantum}" arg2="true" /> 
-                    <then> 
-                        <var name="create.network.output" unset="true"></var> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <exec executable="${provider.scripts}/neuca-quantum-delete-net" resultproperty="code" outputproperty="create.network.output"> 
-                            <env key="PROVIDER_DIR" value="${provider.dir}" /> 
-                            <env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" /> 
-                            <env key="PROVIDER_LOG_FILE" value="${provider.log.file}" /> 
-                            <env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" /> 
-                            <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                            <env key="QUANTUM_NET_UUID" value="${unit.quantum.net.uuid}" /> 
-                        </exec> 
-                        <echo message="exit code ${code}, ${create.network.output}" /> 
-                        <if> 
-                            <not> 
-                                <equals arg1="${code}" arg2="0" /> 
-                            </not> 
-                            <then> 
-                                <echo message="unable to create quantum network: exit code ${code}, ${create.instance.output}" /> 
-                                <property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" /> 
-                            </then> 
-                        </if> 
-                    </then> 
-                </if> 
-            </else> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="Flowvisor Handler: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="Flowvisor Handler: LEAVE on ${start.TIME}" />
+		<if>
+			<isset property="flowvisor.properties" />
+			<then>
+				<property file="${flowvisor.properties}" />
+			</then>
+			<else>
+				<echo message="Flowvisor credentials properties are not set!" />
+			</else>
+		</if>
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<delete.openflow.slice
+					url="${flowvisor.url}"
+					router.user="${flowvisor.user}"
+					router.password="${flowvisor.passwd}"
+					slice.name="orca-${unit.vlan.tag}" />
+				<var name="code" unset="true" />
+				<echo message="Stopping OpenFlow controller ${fvctrl.type}" />
+				<exec executable="${provider.scripts}/stop_${fvctrl.type}.sh" resultproperty="code">
+					<env key="FVVLAN" value="${unit.vlan.tag}" />
+				</exec>
+				<echo message="About to call neuca-quantum-delete-net, use.neuca.quantum = ${use.neuca.quantum}" />
+				<if>
+					<equals arg1="${use.neuca.quantum}" arg2="true" />
+					<then>
+						<var name="create.network.output" unset="true" />
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<exec executable="${provider.scripts}/neuca-quantum-delete-net" resultproperty="code" outputproperty="create.network.output">
+							<env key="PROVIDER_DIR" value="${provider.dir}" />
+							<env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" />
+							<env key="PROVIDER_LOG_FILE" value="${provider.log.file}" />
+							<env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" />
+							<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+							<env key="QUANTUM_NET_UUID" value="${unit.quantum.net.uuid}" />
+						</exec>
+						<echo message="exit code ${code}, ${create.network.output}" />
+						<if>
+							<not>
+								<equals arg1="${code}" arg2="0" />
+							</not>
+							<then>
+								<echo message="unable to create quantum network: exit code ${code}, ${create.instance.output}" />
+								<property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" />
+							</then>
+						</if>
+					</then>
+				</if>
+			</else>
+		</if>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="Flowvisor Handler: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/handlers/providers/resources/handler/providers/learn/handler.xml
+++ b/handlers/providers/resources/handler/providers/learn/handler.xml
@@ -1,122 +1,197 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="learn" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+
     <property file="../ben.properties" /> 
     <!-- Uncomment for handler testing
     <property file="learn.test.properties" />
-    --> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="LEARN HANDLER: JOIN on ${start.TIME}" /> 
-        <if> 
-            <isset property="learn.credentials" /> 
-            <then> 
-                <property file="${learn.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="LEARN credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <var name="code" value="0"></var> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <echo message="Enabling LEARN vlan=${unit.vlan.tag} on ${learn.router} QoS=${unit.vlan.qos.rate}/${unit.vlan.qos.burst.size}: ${config.interface.ports}" /> 
-                <atomic.sequence.start.macro device="LEARN" /> 
-                <create.vlan router="${learn.router}" router.type="Cisco3400" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                <add.trunk.ports router="${learn.router}" router.type="Cisco3400" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                <if> 
-                    <equals arg1="0" arg2="${code}" /> 
-                    <then> 
-                        <for list="learnNet" param="site" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <and> 
-                                        <isset property="@{site}.unit.vlan.tag" /> 
-                                        <isset property="@{site}.edge.interface" /> 
-                                    </and> 
-                                    <then> 
-                                        <echo message="mapping LEARN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${learn.router}: ${@{site}.edge.interface}" /> 
-                                        <map.vlans router="${learn.router}" router.type="Cisco3400" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <atomic.sequence.stop.macro device="LEARN" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-        <echo message="learn join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="LEARN HANDLER: TEARDOWN on ${start.TIME}" /> 
-        <if> 
-            <isset property="learn.credentials" /> 
-            <then> 
-                <property file="${learn.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="LEARN credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <var name="code" value="0"></var> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <atomic.sequence.start.macro device="LEARN" /> 
-                <for list="learnNet" param="site" delimiter=" " parallel="false"> 
-                    <sequential> 
-                        <if> 
-                            <and> 
-                                <isset property="@{site}.unit.vlan.tag" /> 
-                                <isset property="@{site}.edge.interface" /> 
-                            </and> 
-                            <then> 
-                                <echo message="Unmapping LEARN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${learn.router}: ${@{site}.edge.interface}" /> 
-                                <unmap.vlans router="${learn.router}" router.type="Cisco3400" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                            </then> 
-                        </if> 
-                    </sequential> 
-                </for> 
-                <echo message="Disabling LEARN vlan ${unit.vlan.tag} on ${learn.router}: ${config.interface.ports}" /> 
-                <remove.trunk.ports router="${learn.router}" router.type="Cisco3400" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                <delete.vlan router="${learn.router}" router.type="Cisco3400" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                <atomic.sequence.stop.macro device="LEARN" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <echo message="LEARN leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="LEARN HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+    -->
+
+    <target name="join" depends="resolve.configuration,ben.load.tasks">
+        <tstamp prefix="start">
+                <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+        </tstamp>
+
+        <echo message="LEARN HANDLER: JOIN on ${start.TIME}" />
+		<if>
+			<isset property="learn.credentials" />
+			<then>
+				<property file="${learn.credentials}" />
+			</then>
+			<else>
+				<echo message="LEARN credentials properties are not set!" />
+			</else>
+		</if>
+        <var name="code" value="0" />
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+		        <echo message="Enabling LEARN vlan=${unit.vlan.tag} on ${learn.router} QoS=${unit.vlan.qos.rate}/${unit.vlan.qos.burst.size}: ${config.interface.ports}" />
+				<atomic.sequence.start.macro
+					device="LEARN" />
+				<create.vlan 
+					router="${learn.router}"
+					router.type="Cisco3400"
+			   		vlan.tag="${unit.vlan.tag}"
+					vlan.qos.rate="${unit.vlan.qos.rate}"
+					vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+			    	router.user="${router.user}"
+			    	router.password="${router.password}"
+					router.default.prompt="${router.default.prompt}"
+			    	router.admin.password="${router.admin.password}" />
+		        <add.trunk.ports 
+		            router="${learn.router}"
+				    router.type="Cisco3400"
+		            vlan.tag="${unit.vlan.tag}"
+				    ports="${config.interface.ports}"
+		            router.user="${router.user}"
+		            router.password="${router.password}"
+				    router.default.prompt="${router.default.prompt}"
+		            router.admin.password="${router.admin.password}" />
+		        <if>
+		            <equals arg1="0" arg2="${code}" />
+		            <then>
+						<for list="learnNet"
+	                    	param="site"
+	                        delimiter=" "
+	                        parallel="false">
+	                    	<sequential>
+							    <if>
+							        <and>
+							            <isset property="@{site}.unit.vlan.tag" />
+							            <isset property="@{site}.edge.interface" />
+							        </and>
+									<then>
+					                	<echo message="mapping LEARN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${learn.router}: ${@{site}.edge.interface}" />
+					                	<map.vlans 
+						                     router="${learn.router}"
+								     		 router.type="Cisco3400"
+						                     src.vlan.tag="${@{site}.unit.vlan.tag}"
+						                     dst.vlan.tag="${unit.vlan.tag}"
+						                     port="${@{site}.edge.interface}"
+						                     router.user="${router.user}"
+						                     router.password="${router.password}"
+								     		 router.default.prompt="${router.default.prompt}"
+						                     router.admin.password="${router.admin.password}" />
+									</then>
+								</if>
+							</sequential>
+						</for>
+		            </then>
+		        </if>
+				<atomic.sequence.stop.macro
+					device="LEARN" />
+    			<property name="shirako.target.code" value="${code}" />
+			</else>
+		</if>
+        <!-- hairpin -->
+        <var name="shirako.save.unit.vlan.url" unset="true" />
+        <if>
+                <isset property="unit.vlan.url" />
+                <then>
+                        <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+                </then>
+        </if>
+
+        <echo message="learn join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="leave" depends="resolve.configuration,ben.load.tasks">
+        <tstamp prefix="start">
+                <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+        </tstamp>
+
+        <echo message="LEARN HANDLER: TEARDOWN on ${start.TIME}" />
+		<if>
+			<isset property="learn.credentials" />
+			<then>
+				<property file="${learn.credentials}" />
+			</then>
+			<else>
+				<echo message="LEARN credentials properties are not set!" />
+			</else>
+		</if>
+        <var name="code" value="0" />
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<atomic.sequence.start.macro
+					device="LEARN" />
+				<for list="learnNet"
+			    	param="site"
+			        delimiter=" "
+			        parallel="false">
+			    	<sequential>
+					    <if>
+					        <and>
+					            <isset property="@{site}.unit.vlan.tag" />
+					            <isset property="@{site}.edge.interface" />
+					        </and>
+							<then>
+				        		<echo message="Unmapping LEARN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${learn.router}: ${@{site}.edge.interface}" />
+						        <unmap.vlans 
+				                     router="${learn.router}"
+						     		 router.type="Cisco3400"
+				                     src.vlan.tag="${@{site}.unit.vlan.tag}"
+				                     dst.vlan.tag="${unit.vlan.tag}"
+				                     port="${@{site}.edge.interface}"
+				                     router.user="${router.user}"
+				                     router.password="${router.password}"
+						     		 router.default.prompt="${router.default.prompt}"
+				                     router.admin.password="${router.admin.password}" />
+							</then>
+						</if>
+					</sequential>
+				</for>
+		        <echo message="Disabling LEARN vlan ${unit.vlan.tag} on ${learn.router}: ${config.interface.ports}" />
+		        <remove.trunk.ports
+                      router="${learn.router}"
+		      		  router.type="Cisco3400"
+                      vlan.tag="${unit.vlan.tag}"
+                      ports="${config.interface.ports}"
+                      router.user="${router.user}"
+                      router.password="${router.password}"
+		      		  router.default.prompt="${router.default.prompt}"
+                      router.admin.password="${router.admin.password}" />
+			    <delete.vlan 
+			    	router="${learn.router}"
+					router.type="Cisco3400"
+			        vlan.tag="${unit.vlan.tag}"
+					vlan.with.qos="${unit.vlan.with.qos}"
+			        router.user="${router.user}"
+			        router.password="${router.password}"
+					router.default.prompt="${router.default.prompt}"
+			        router.admin.password="${router.admin.password}" />
+				<atomic.sequence.stop.macro
+					device="LEARN" />
+		        <property name="shirako.target.code" value="${code}" />
+			</else>
+		</if>
+        <echo message="LEARN leave exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="modify" depends="resolve.configuration,ben.load.tasks">
+        <echo message="LEARN HANDLER: MODIFY" />
+        <property name="shirako.target.code" value="0" />
+    </target>
 </project>

--- a/handlers/providers/resources/handler/providers/quantum-vlan/handler.xml
+++ b/handlers/providers/resources/handler/providers/quantum-vlan/handler.xml
@@ -1,17 +1,25 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <!-- This handler supports configuring Quantum 
 as well as flowvisor-emulated and native VLAN provisioning
-in a *hybrid* or OF only rack switch /ib --> 
+in a *hybrid* or OF only rack switch /ib -->
 <project name="quantum-vlan" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- Uncomment for handler testing
 	<property file="quantum-vlan.test.properties" />
-	--> 
-    <!-- 
+	-->
+
+	<!-- 
 		Controller must supply
 			unit.openflow.slice.ctrl.url - [optional] User OF Controller URL
 			unit.openflow.slice.email - [optional] User OF slice email
@@ -55,229 +63,264 @@ in a *hybrid* or OF only rack switch /ib -->
 
 			#tenant that uses orca
 			quantum.tenant.id=geni-orca
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Quantum VLAN Handler: JOIN on ${start.TIME}" /> 
-        <if> 
-            <isset property="quantum-vlan.properties" /> 
-            <then> 
-                <property file="${quantum-vlan.properties}" /> 
-            </then> 
-            <else> 
-                <echo message="Flowvisor or switch credentials properties are not set: quantum-vlan.properties absent!" /> 
-            </else> 
-        </if> 
-        <if> 
-            <and> 
-                <not> 
-                    <equals arg1="${router.vlan.type}" arg2="openflow" /> 
-                </not> 
-                <not> 
-                    <equals arg1="${router.vlan.type}" arg2="hybrid" /> 
-                </not> 
-            </and> 
-            <then> 
-                <fail message="Unknown router vlan type in configuration: ${router.vlan.type} (only openflow and hybrid are allowed)" /> 
-            </then> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <!-- hairpin --> 
-                <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <if> 
-                    <or> 
-                        <!-- controller is asking for openflow vlan with user controller --> 
-                        <isset property="unit.openflow.slice.ctrl.url" /> 
-                        <and> 
-                            <!-- controller is asking for native vlan, but switch only supports openflow (not hybrid) --> 
-                            <not> 
-                                <isset property="unit.openflow.slice.ctrl.url" /> 
-                            </not> 
-                            <equals arg1="${router.vlan.type}" arg2="openflow" /> 
-                        </and> 
-                    </or> 
-                    <then> 
-                        <!-- atomize this sequence (need to start early because otherwise NOX's start in parallel) --> 
-                        <atomic.sequence.start.macro device="${flowvisor.url}" /> 
-                        <!-- create a slice and add a vlan flowspace to it --> 
-                        <var name="ctrl.url" unset="true"></var> 
-                        <if> 
-                            <isset property="unit.openflow.slice.ctrl.url" /> 
-                            <!-- user provided a controller --> 
-                            <then> 
-                                <property name="ctrl.url" value="${unit.openflow.slice.ctrl.url}" /> 
-                                <if> 
-                                    <not> 
-                                        <isset property="unit.openflow.slice.email" /> 
-                                    </not> 
-                                    <then> 
-                                        <echo message="Slice email not specified, setting to default exogeni-ops@renci.org" /> 
-                                        <property name="unit.openflow.slice.email" value="exogeni-ops@renci.org" /> 
-                                    </then> 
-                                </if> 
-                                <if> 
-                                    <not> 
-                                        <isset property="unit.openflow.slice.pass" /> 
-                                    </not> 
-                                    <then> 
-                                        <echo message="Slice password not specified, setting to default 'slicepass'" /> 
-                                        <property name="unit.openflow.slice.pass" value="slicepass" /> 
-                                    </then> 
-                                </if> 
-                            </then> 
-                            <else> 
-                                <!-- start our own controller --> 
-                                <var name="unit.openflow.slice.email" unset="true"></var> 
-                                <var name="unit.openflow.slice.pass" unset="true"></var> 
-                                <property name="unit.openflow.slice.email" value="exogeni-ops@renci.org" /> 
-                                <exec executable="${provider.scripts}/genpasswd.sh" resultproperty="code" outputproperty="unit.openflow.slice.pass" /> 
-                                <if> 
-                                    <not> 
-                                        <equals arg1="${code}" arg2="0" /> 
-                                    </not> 
-                                    <then> 
-                                        <property name="message" value="unable to generate random slice password for flowvisor, using default" /> 
-                                        <var name="unit.openflow.slice.pass" unset="true"></var> 
-                                        <property name="unit.openflow.slice.pass" value="defaultpass" /> 
-                                    </then> 
-                                </if> 
-                                <var name="code" unset="true"></var> 
-                                <var name="message" unset="true"></var> 
-                                <if> 
-                                    <equals arg1="${fvctrl.type}" arg2="nox" /> 
-                                    <then> 
-                                        <echo message="Starting NOX controller in ${nox.core.exec}" /> 
-                                        <exec executable="${provider.scripts}/start_nox.sh" resultproperty="code" outputproperty="ctrl.url"> 
-                                            <env key="NOXHOST" value="${fvctrl.host}" /> 
-                                            <env key="FVVLAN" value="${unit.vlan.tag}" /> 
-                                            <env key="NOX_FIRST_PORT" value="${fvctrl.first.port}" /> 
-                                            <env key="NOX_LAST_PORT" value="${fvctrl.last.port}" /> 
-                                            <env key="NOXEXEC" value="${nox.core.exec}" /> 
-                                        </exec> 
-                                    </then> 
-                                    <else> 
-                                        <if> 
-                                            <equals arg1="${fvctrl.type}" arg2="floodlight" /> 
-                                            <then> 
-                                                <echo message="Starting Floodlight controller from ${floodlight.jar}" /> 
-                                                <exec executable="${provider.scripts}/start_floodlight.sh" resultproperty="code" outputproperty="ctrl.url"> 
-                                                    <env key="FLHOST" value="${fvctrl.host}" /> 
-                                                    <env key="FVVLAN" value="${unit.vlan.tag}" /> 
-                                                    <env key="FL_FIRST_PORT" value="${fvctrl.first.port}" /> 
-                                                    <env key="FL_LAST_PORT" value="${fvctrl.last.port}" /> 
-                                                    <env key="FLEXEC" value="${floodlight.jar}" /> 
-                                                </exec> 
-                                            </then> 
-                                        </if> 
-                                    </else> 
-                                </if> 
-                                <if> 
-                                    <not> 
-                                        <equals arg1="${code}" arg2="0" /> 
-                                    </not> 
-                                    <then> 
-                                        <echo message="Unable to start OF Controller due to: ${ctrl.url}" /> 
-                                        <property name="message" value="Unable to start OF Controller due to: ${ctrl.url}" /> 
-                                        <var name="ctrl.url" unset="true"></var> 
-                                    </then> 
-                                </if> 
-                            </else> 
-                        </if> 
-                        <if> 
-                            <isset property="ctrl.url" /> 
-                            <then> 
-                                <var name="code" unset="true"></var> 
-                                <var name="message" unset="true"></var> 
-                                <echo message="creating VLAN ${unit.vlan.url} with tag ${unit.vlan.tag}, on FlowVisor ${flowvisor.url} with controller ${ctrl.url}" /> 
-                                <create.openflow.slice url="${flowvisor.url}" router.user="${flowvisor.user}" router.password="${flowvisor.passwd}" slice.name="orca-${unit.vlan.tag}" slice.email="${unit.openflow.slice.email}" slice.pass="${unit.openflow.slice.pass}" slice.ctrl.url="${ctrl.url}" /> 
-                                <add.openflow.vlan.flowspace url="${flowvisor.url}" router.user="${flowvisor.user}" router.password="${flowvisor.passwd}" slice.name="orca-${unit.vlan.tag}" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" /> 
-                            </then> 
-                            <else> 
-                                <echo message="controller URL property not set, flowvisor slice will not be created" /> 
-                            </else> 
-                        </if> 
-                        <atomic.sequence.stop.macro device="${flowvisor.url}" /> 
-                        <var name="shirako.save.unit.vlan.type" unset="true"></var> 
-                        <property name="shirako.save.unit.vlan.type" value="openflow" /> 
-                    </then> 
-                    <else> 
-                        <!-- native vlan setup --> 
-                        <echo message="Performing native vlan provisioning on ${router.device} of type ${router.type}" /> 
-                        <atomic.sequence.start.macro device="${router.device}" /> 
-                        <create.vlan router="${router.device}" router.type="${router.type}" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="0" vlan.qos.burst.size="0" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                        <add.trunk.ports router="${router.device}" router.type="${router.type}" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                        <atomic.sequence.stop.macro device="${router.device}" /> 
-                        <var name="shirako.save.unit.vlan.type" unset="true"></var> 
-                        <property name="shirako.save.unit.vlan.type" value="native" /> 
-                    </else> 
-                </if> 
-                <!-- Quantum setup --> 
-                <echo message="About to create quantum network, use.neuca.quantum = ${use.neuca.quantum}" /> 
-                <if> 
-                    <equals arg1="${use.neuca.quantum}" arg2="true" /> 
-                    <then> 
-                        <echo message="Using quantum network" /> 
-                        <var name="create.network.output" unset="true"></var> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <echo message="PROVIDER_DIR =${provider.dir}" /> 
-                        <echo message="PROVIDER_LOG_DIR= ${provider.log.dir}" /> 
-                        <echo message="PROVIDER_LOG_FILE= ${provider.log.file}" /> 
-                        <echo message="PROVIDER_LOG_LEVEL= ${provider.log.level}" /> 
-                        <echo message="QUANTUM_TENANT_ID = ${quantum.tenant.id}" /> 
-                        <echo message="QUANTUM_NET_TYPE = ipv4" /> 
-                        <echo message="QUANTUM_NET_NETWORK= ${unit.quantum.netname}" /> 
-                        <echo message="QUANTUM_NET_VLAN= ${unit.vlan.tag}" /> 
-                        <echo message="QUANTUM_MAX_RATE= ${unit.vlan.qos.rate}" /> 
-                        <echo message="QUANTUM_BURST_RATE= ${unit.vlan.qos.burst.size}" /> 
-                        <exec executable="${provider.scripts}/neuca-quantum-create-net" resultproperty="code" outputproperty="create.network.output"> 
-                            <env key="PROVIDER_DIR" value="${provider.dir}" /> 
-                            <env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" /> 
-                            <env key="PROVIDER_LOG_FILE" value="${provider.log.file}" /> 
-                            <env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" /> 
-                            <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                            <env key="QUANTUM_NET_TYPE" value="ipv4" /> 
-                            <env key="QUANTUM_NET_NETWORK" value="${unit.quantum.netname}" /> 
-                            <env key="QUANTUM_NET_VLAN" value="${unit.vlan.tag}" /> 
-                            <env key="QUANTUM_MAX_RATE" value="${unit.vlan.qos.rate}" /> 
-                            <env key="QUANTUM_BURST_RATE" value="${unit.vlan.qos.burst.size}" /> 
-                        </exec> 
-                        <echo message="exit code ${code}, ${create.network.output}" /> 
-                        <if> 
-                            <not> 
-                                <equals arg1="${code}" arg2="0" /> 
-                            </not> 
-                            <then> 
-                                <echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" /> 
-                                <property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" /> 
-                            </then> 
-                            <else> 
-                                <var name="shirako.save.unit.quantum.net.uuid" unset="true"></var> 
-                                <property name="shirako.save.unit.quantum.net.uuid" value="${create.network.output}" /> 
-                            </else> 
-                        </if> 
-                        <echo message="shirako.save.unit.quantum.net.uuid = ${shirako.save.unit.quantum.net.uuid}, create.network.output = ${create.network.output}" /> 
-                    </then> 
-                </if> 
-                <!-- hairpin the url property so the user sees it too --> 
-                <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <property name="shirako.target.code.message" value="${message}" /> 
-            </else> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code} with message: ${shirako.target.code.message}, vlan type ${shirako.save.unit.vlan.type}" /> 
-    </target> 
-    <!-- 
+	-->
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="Quantum VLAN Handler: JOIN on ${start.TIME}" />
+		<if>
+			<isset property="quantum-vlan.properties" />
+			<then>
+				<property file="${quantum-vlan.properties}" />
+			</then>
+			<else>
+				<echo message="Flowvisor or switch credentials properties are not set: quantum-vlan.properties absent!" />
+			</else>
+		</if>
+		<if>
+			<and>
+				<not>
+					<equals arg1="${router.vlan.type}" arg2="openflow" />
+				</not>
+				<not>
+					<equals arg1="${router.vlan.type}" arg2="hybrid" />
+				</not>
+			</and>
+			<then>
+				<fail message="Unknown router vlan type in configuration: ${router.vlan.type} (only openflow and hybrid are allowed)" />
+			</then>
+		</if>
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<!-- hairpin -->
+				<var name="shirako.save.unit.vlan.url" unset="true" />
+				<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<if>
+					<or>
+						<!-- controller is asking for openflow vlan with user controller -->
+						<isset property="unit.openflow.slice.ctrl.url" />
+						<and>
+							<!-- controller is asking for native vlan, but switch only supports openflow (not hybrid) -->
+							<not>
+								<isset property="unit.openflow.slice.ctrl.url" />
+							</not>
+							<equals arg1="${router.vlan.type}" arg2="openflow" />
+						</and>
+					</or>
+					<then>
+						<!-- atomize this sequence (need to start early because otherwise NOX's start in parallel) -->
+						<atomic.sequence.start.macro
+							device="${flowvisor.url}" />
+						<!-- create a slice and add a vlan flowspace to it -->
+						<var name="ctrl.url" unset="true" />
+						<if>
+							<isset property="unit.openflow.slice.ctrl.url" />
+							<!-- user provided a controller -->
+							<then>
+								<property name="ctrl.url" value="${unit.openflow.slice.ctrl.url}" />
+								<if>
+									<not>
+										<isset property="unit.openflow.slice.email" />
+									</not>
+									<then>
+										<echo message="Slice email not specified, setting to default exogeni-ops@renci.org" />
+										<property name="unit.openflow.slice.email" value="exogeni-ops@renci.org" />
+									</then>
+								</if>
+								<if>
+									<not>
+										<isset property="unit.openflow.slice.pass" />
+									</not>
+									<then>
+										<echo message="Slice password not specified, setting to default 'slicepass'" />
+										<property name="unit.openflow.slice.pass" value="slicepass" />
+									</then>
+								</if>
+							</then>
+							<else>
+								<!-- start our own controller -->
+								<var name="unit.openflow.slice.email" unset="true" />
+								<var name="unit.openflow.slice.pass" unset="true" />
+								<property name="unit.openflow.slice.email" value="exogeni-ops@renci.org" />
+								<exec executable="${provider.scripts}/genpasswd.sh" resultproperty="code" outputproperty="unit.openflow.slice.pass" />
+								<if>
+									<not>
+										<equals arg1="${code}" arg2="0" />
+									</not>
+									<then>
+										<property name="message" value="unable to generate random slice password for flowvisor, using default" />
+										<var name="unit.openflow.slice.pass" unset="true" />
+										<property name="unit.openflow.slice.pass" value="defaultpass" />
+									</then>
+								</if>
+								<var name="code" unset="true" />
+								<var name="message" unset="true" />
+								<if>
+									<equals arg1="${fvctrl.type}" arg2="nox" />
+									<then>
+										<echo message="Starting NOX controller in ${nox.core.exec}" />
+										<exec executable="${provider.scripts}/start_nox.sh" resultproperty="code" outputproperty="ctrl.url">
+											<env key="NOXHOST" value="${fvctrl.host}" />
+											<env key="FVVLAN" value="${unit.vlan.tag}" />
+											<env key="NOX_FIRST_PORT" value="${fvctrl.first.port}" />
+											<env key="NOX_LAST_PORT" value="${fvctrl.last.port}" />
+											<env key="NOXEXEC" value="${nox.core.exec}" />
+										</exec>
+									</then>
+									<else>
+										<if>
+											<equals arg1="${fvctrl.type}" arg2="floodlight" />
+											<then>
+												<echo message="Starting Floodlight controller from ${floodlight.jar}" />
+												<exec executable="${provider.scripts}/start_floodlight.sh" resultproperty="code" outputproperty="ctrl.url">
+													<env key="FLHOST" value="${fvctrl.host}" />
+													<env key="FVVLAN" value="${unit.vlan.tag}" />
+													<env key="FL_FIRST_PORT" value="${fvctrl.first.port}" />
+													<env key="FL_LAST_PORT" value="${fvctrl.last.port}" />
+													<env key="FLEXEC" value="${floodlight.jar}" />
+												</exec>
+											</then>
+										</if>
+									</else>
+								</if>
+
+								<if>
+									<not>
+										<equals arg1="${code}" arg2="0" />
+									</not>
+									<then>
+										<echo message="Unable to start OF Controller due to: ${ctrl.url}" />
+										<property name="message" value="Unable to start OF Controller due to: ${ctrl.url}" />
+										<var name="ctrl.url" unset="true" />
+									</then>
+								</if>
+							</else>
+						</if>
+						<if>
+							<isset property="ctrl.url" />
+							<then>
+								<var name="code" unset="true" />
+								<var name="message" unset="true" />
+								<echo message="creating VLAN ${unit.vlan.url} with tag ${unit.vlan.tag}, on FlowVisor ${flowvisor.url} with controller ${ctrl.url}" />
+								<create.openflow.slice
+									url="${flowvisor.url}"
+									router.user="${flowvisor.user}"
+									router.password="${flowvisor.passwd}"
+									slice.name="orca-${unit.vlan.tag}"
+									slice.email="${unit.openflow.slice.email}"
+									slice.pass="${unit.openflow.slice.pass}"
+									slice.ctrl.url="${ctrl.url}" />
+								<add.openflow.vlan.flowspace
+									url="${flowvisor.url}"
+									router.user="${flowvisor.user}"
+									router.password="${flowvisor.passwd}"
+									slice.name="orca-${unit.vlan.tag}"
+									vlan.tag="${unit.vlan.tag}"
+									ports="${config.interface.ports}" />
+							</then>
+							<else>
+								<echo message="controller URL property not set, flowvisor slice will not be created" />
+							</else>
+						</if>
+						<atomic.sequence.stop.macro
+							device="${flowvisor.url}" />
+						<var name="shirako.save.unit.vlan.type" unset="true" />
+						<property name="shirako.save.unit.vlan.type" value="openflow" />
+					</then>
+					<else>
+						<!-- native vlan setup -->
+						<echo message="Performing native vlan provisioning on ${router.device} of type ${router.type}"/>
+						<atomic.sequence.start.macro device="${router.device}" />
+							<create.vlan 
+								router="${router.device}"
+								router.type="${router.type}"
+		 						vlan.tag="${unit.vlan.tag}"
+								vlan.qos.rate="0"
+								vlan.qos.burst.size="0"
+		 						router.user="${router.user}"
+		 						router.password="${router.password}"
+		 						router.default.prompt="${router.default.prompt}"
+		 						router.admin.password="${router.admin.password}" />
+							<add.trunk.ports 
+								router="${router.device}"
+								router.type="${router.type}"
+								vlan.tag="${unit.vlan.tag}"
+								ports="${config.interface.ports}"
+								router.user="${router.user}"
+								router.password="${router.password}"
+		 						router.default.prompt="${router.default.prompt}"
+								router.admin.password="${router.admin.password}" />
+						<atomic.sequence.stop.macro device="${router.device}" />
+						<var name="shirako.save.unit.vlan.type" unset="true" />
+						<property name="shirako.save.unit.vlan.type" value="native" />
+					</else>
+				</if>
+				<!-- Quantum setup -->
+				<echo message="About to create quantum network, use.neuca.quantum = ${use.neuca.quantum}" />
+				<if>
+					<equals arg1="${use.neuca.quantum}" arg2="true" />
+					<then>
+						<echo message="Using quantum network" />
+						<var name="create.network.output" unset="true" />
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<echo message="PROVIDER_DIR =${provider.dir}" />
+						<echo message="PROVIDER_LOG_DIR= ${provider.log.dir}" />
+						<echo message="PROVIDER_LOG_FILE= ${provider.log.file}" />
+						<echo message="PROVIDER_LOG_LEVEL= ${provider.log.level}" />
+						<echo message="QUANTUM_TENANT_ID = ${quantum.tenant.id}" />
+						<echo message="QUANTUM_NET_TYPE = ipv4" />
+						<echo message="QUANTUM_NET_NETWORK= ${unit.quantum.netname}" />
+						<echo message="QUANTUM_NET_VLAN= ${unit.vlan.tag}" />
+						<echo message="QUANTUM_MAX_RATE= ${unit.vlan.qos.rate}" />
+						<echo message="QUANTUM_BURST_RATE= ${unit.vlan.qos.burst.size}" />
+						<exec executable="${provider.scripts}/neuca-quantum-create-net" resultproperty="code" outputproperty="create.network.output">
+							<env key="PROVIDER_DIR" value="${provider.dir}" />
+							<env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" />
+							<env key="PROVIDER_LOG_FILE" value="${provider.log.file}" />
+							<env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" />
+							<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+							<env key="QUANTUM_NET_TYPE" value="ipv4" />
+							<env key="QUANTUM_NET_NETWORK" value="${unit.quantum.netname}" />
+							<env key="QUANTUM_NET_VLAN" value="${unit.vlan.tag}" />
+							<env key="QUANTUM_MAX_RATE" value="${unit.vlan.qos.rate}" />
+							<env key="QUANTUM_BURST_RATE" value="${unit.vlan.qos.burst.size}" />
+						</exec>
+						<echo message="exit code ${code}, ${create.network.output}" />
+						<if>
+							<not>
+								<equals arg1="${code}" arg2="0" />
+							</not>
+							<then>
+								<echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" />
+								<property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" />
+							</then>
+							<else>
+								<var name="shirako.save.unit.quantum.net.uuid" unset="true" />
+								<property name="shirako.save.unit.quantum.net.uuid" value="${create.network.output}" />
+							</else>
+						</if>
+						<echo message="shirako.save.unit.quantum.net.uuid = ${shirako.save.unit.quantum.net.uuid}, create.network.output = ${create.network.output}" />
+					</then>
+				</if>
+				<!-- hairpin the url property so the user sees it too -->
+				<var name="shirako.save.unit.vlan.url" unset="true" />
+				<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+				<property name="shirako.target.code" value="${code}" />
+				<property name="shirako.target.code.message" value="${message}" />
+			</else>
+		</if>
+		<echo message="join exit code: ${shirako.target.code} with message: ${shirako.target.code.message}, vlan type ${shirako.save.unit.vlan.type}" />
+	</target>
+
+	<!-- 
 		Controller must supply
 			unit.vlan.tag [mandatory]
 			unit.vlan.type [mandatory, set by join to 'native' or 'openflow']
@@ -290,81 +333,103 @@ in a *hybrid* or OF only rack switch /ib -->
 			fvctrl.type
 			
 			router.device
-	--> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Quantum VLAN Handler: LEAVE on ${start.TIME}" /> 
-        <if> 
-            <isset property="quantum-vlan.properties" /> 
-            <then> 
-                <property file="${quantum-vlan.properties}" /> 
-            </then> 
-            <else> 
-                <echo message="Flowvisor credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <if> 
-                    <equals arg1="${unit.vlan.type}" arg2="openflow" /> 
-                    <then> 
-                        <echo message="Deleting openflow vlan ${unit.vlan.tag}" /> 
-                        <delete.openflow.slice url="${flowvisor.url}" router.user="${flowvisor.user}" router.password="${flowvisor.passwd}" slice.name="orca-${unit.vlan.tag}" /> 
-                        <var name="code" unset="true"></var> 
-                        <echo message="Stopping OpenFlow controller ${fvctrl.type}" /> 
-                        <exec executable="${provider.scripts}/stop_${fvctrl.type}.sh" resultproperty="code"> 
-                            <env key="FVVLAN" value="${unit.vlan.tag}" /> 
-                        </exec> 
-                    </then> 
-                    <else> 
-                        <echo message="Deleting native vlan ${unit.vlan.tag} from ${router.device}" /> 
-                        <atomic.sequence.start.macro device="${router.device}" /> 
-                        <remove.trunk.ports router="${router.device}" router.type="${router.type}" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                        <delete.vlan router="${router.device}" router.type="${router.type}" vlan.tag="${unit.vlan.tag}" vlan.with.qos="true" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                        <atomic.sequence.stop.macro device="${router.device}" /> 
-                    </else> 
-                </if> 
-                <echo message="About to call neuca-quantum-delete-net, use.neuca.quantum = ${use.neuca.quantum}" /> 
-                <if> 
-                    <equals arg1="${use.neuca.quantum}" arg2="true" /> 
-                    <then> 
-                        <var name="create.network.output" unset="true"></var> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <exec executable="${provider.scripts}/neuca-quantum-delete-net" resultproperty="code" outputproperty="create.network.output"> 
-                            <env key="PROVIDER_DIR" value="${provider.dir}" /> 
-                            <env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" /> 
-                            <env key="PROVIDER_LOG_FILE" value="${provider.log.file}" /> 
-                            <env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" /> 
-                            <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                            <env key="QUANTUM_NET_UUID" value="${unit.quantum.net.uuid}" /> 
-                        </exec> 
-                        <echo message="exit code ${code}, ${create.network.output}" /> 
-                        <if> 
-                            <not> 
-                                <equals arg1="${code}" arg2="0" /> 
-                            </not> 
-                            <then> 
-                                <echo message="unable to create quantum network: exit code ${code}, ${create.instance.output}" /> 
-                                <property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" /> 
-                            </then> 
-                        </if> 
-                    </then> 
-                </if> 
-            </else> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="Flowvisor Handler: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="Quantum VLAN Handler: LEAVE on ${start.TIME}" />
+		<if>
+			<isset property="quantum-vlan.properties" />
+			<then>
+				<property file="${quantum-vlan.properties}" />
+			</then>
+			<else>
+				<echo message="Flowvisor credentials properties are not set!" />
+			</else>
+		</if>
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<if>
+					<equals arg1="${unit.vlan.type}" arg2="openflow"/>
+					<then>
+						<echo message="Deleting openflow vlan ${unit.vlan.tag}" />
+						<delete.openflow.slice
+							url="${flowvisor.url}"
+							router.user="${flowvisor.user}"
+							router.password="${flowvisor.passwd}"
+							slice.name="orca-${unit.vlan.tag}" />
+						<var name="code" unset="true" />
+						<echo message="Stopping OpenFlow controller ${fvctrl.type}" />
+						<exec executable="${provider.scripts}/stop_${fvctrl.type}.sh" resultproperty="code">
+							<env key="FVVLAN" value="${unit.vlan.tag}" />
+						</exec>
+					</then>
+					<else>
+						<echo message="Deleting native vlan ${unit.vlan.tag} from ${router.device}" />
+						<atomic.sequence.start.macro device="${router.device}" />
+							<remove.trunk.ports
+								router="${router.device}"
+								router.type="${router.type}"
+								vlan.tag="${unit.vlan.tag}"
+								ports="${config.interface.ports}"
+								router.user="${router.user}"
+								router.password="${router.password}"
+		 						router.default.prompt="${router.default.prompt}"
+								router.admin.password="${router.admin.password}" />
+							<delete.vlan 
+								router="${router.device}"
+								router.type="${router.type}"
+								vlan.tag="${unit.vlan.tag}"
+								vlan.with.qos="true"
+								router.user="${router.user}"
+								router.password="${router.password}"
+		 						router.default.prompt="${router.default.prompt}"
+								router.admin.password="${router.admin.password}" />
+						<atomic.sequence.stop.macro device="${router.device}" />					
+					</else>
+				</if>
+				<echo message="About to call neuca-quantum-delete-net, use.neuca.quantum = ${use.neuca.quantum}" />
+				<if>
+					<equals arg1="${use.neuca.quantum}" arg2="true" />
+					<then>
+						<var name="create.network.output" unset="true" />
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<exec executable="${provider.scripts}/neuca-quantum-delete-net" resultproperty="code" outputproperty="create.network.output">
+							<env key="PROVIDER_DIR" value="${provider.dir}" />
+							<env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" />
+							<env key="PROVIDER_LOG_FILE" value="${provider.log.file}" />
+							<env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" />
+							<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+							<env key="QUANTUM_NET_UUID" value="${unit.quantum.net.uuid}" />
+						</exec>
+						<echo message="exit code ${code}, ${create.network.output}" />
+						<if>
+							<not>
+								<equals arg1="${code}" arg2="0" />
+							</not>
+							<then>
+								<echo message="unable to create quantum network: exit code ${code}, ${create.instance.output}" />
+								<property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" />
+							</then>
+						</if>
+					</then>
+				</if>
+			</else>
+		</if>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="Flowvisor Handler: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/handlers/providers/resources/handler/providers/quantum/handler.xml
+++ b/handlers/providers/resources/handler/providers/quantum/handler.xml
@@ -1,14 +1,22 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="quantum" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- Uncomment for handler testing
 	<property file="quantum.test.properties" />
-	--> 
-    <!-- 
+	-->
+
+	<!-- 
 		Controller must supply
 			unit.openflow.slice.ctrl.url - [optional] User OF Controller URL
 			unit.openflow.slice.email - [optional] User OF slice email
@@ -26,82 +34,84 @@
                         #tenant that uses orca
                         quantum.tenant.id=geni-orca
 
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Quantum Handler: JOIN on ${start.TIME}" /> 
-        <if> 
-            <isset property="quantum.properties" /> 
-            <then> 
-                <property file="${quantum.properties}" /> 
-            </then> 
-            <else> 
-                <echo message="Quantum properties are not set!" /> 
-            </else> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <!-- hairpin --> 
-                <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <echo message="About to create quantum network, use.neuca.quantum = ${use.neuca.quantum}" /> 
-                <var name="create.network.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <echo message="PROVIDER_DIR =${provider.dir}" /> 
-                <echo message="PROVIDER_LOG_DIR= ${provider.log.dir}" /> 
-                <echo message="PROVIDER_LOG_FILE= ${provider.log.file}" /> 
-                <echo message="PROVIDER_LOG_LEVEL= ${provider.log.level}" /> 
-                <echo message="QUANTUM_TENANT_ID = ${quantum.tenant.id}" /> 
-                <echo message="QUANTUM_NET_TYPE = ipv4" /> 
-                <echo message="QUANTUM_NET_NETWORK= ${unit.quantum.netname}" /> 
-                <echo message="QUANTUM_NET_VLAN= ${unit.vlan.tag}" /> 
-                <echo message="QUANTUM_MAX_RATE= ${unit.vlan.qos.rate}" /> 
-                <echo message="QUANTUM_BURST_RATE= ${unit.vlan.qos.burst.size}" /> 
-                <exec executable="${provider.scripts}/neuca-quantum-create-net" resultproperty="code" outputproperty="create.network.output"> 
-                    <env key="PROVIDER_DIR" value="${provider.dir}" /> 
-                    <env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" /> 
-                    <env key="PROVIDER_LOG_FILE" value="${provider.log.file}" /> 
-                    <env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" /> 
-                    <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                    <env key="QUANTUM_NET_TYPE" value="ipv4" /> 
-                    <env key="QUANTUM_NET_NETWORK" value="${unit.quantum.netname}" /> 
-                    <env key="QUANTUM_NET_VLAN" value="${unit.vlan.tag}" /> 
-                    <env key="QUANTUM_MAX_RATE" value="${unit.vlan.qos.rate}" /> 
-                    <env key="QUANTUM_BURST_RATE" value="${unit.vlan.qos.burst.size}" /> 
-                </exec> 
-                <echo message="exit code ${code}, ${create.network.output}" /> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" /> 
-                        <property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" /> 
-                    </then> 
-                    <else> 
-                        <var name="shirako.save.unit.quantum.net.uuid" unset="true"></var> 
-                        <property name="shirako.save.unit.quantum.net.uuid" value="${create.network.output}" /> 
-                    </else> 
-                </if> 
-                <echo message="shirako.save.unit.quantum.net.uuid = ${shirako.save.unit.quantum.net.uuid}, create.network.output = ${create.network.output}" /> 
-                <!-- hairpin the url property so the user sees it too --> 
-                <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <property name="shirako.target.code.message" value="${message}" /> 
-            </else> 
-        </if> 
-        <echo message="join exit code: ${shirako.target.code} with message: ${shirako.target.code.message}" /> 
-    </target> 
-    <!-- 
+	-->
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="Quantum Handler: JOIN on ${start.TIME}" />
+		<if>
+			<isset property="quantum.properties" />
+			<then>
+				<property file="${quantum.properties}" />
+			</then>
+			<else>
+				<echo message="Quantum properties are not set!" />
+			</else>
+		</if>
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<!-- hairpin -->
+				<var name="shirako.save.unit.vlan.url" unset="true" />
+				<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<echo message="About to create quantum network, use.neuca.quantum = ${use.neuca.quantum}" />
+				<var name="create.network.output" unset="true" />
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+				<echo message="PROVIDER_DIR =${provider.dir}" />
+				<echo message="PROVIDER_LOG_DIR= ${provider.log.dir}" />
+				<echo message="PROVIDER_LOG_FILE= ${provider.log.file}" />
+				<echo message="PROVIDER_LOG_LEVEL= ${provider.log.level}" />
+				<echo message="QUANTUM_TENANT_ID = ${quantum.tenant.id}" />
+				<echo message="QUANTUM_NET_TYPE = ipv4" />
+				<echo message="QUANTUM_NET_NETWORK= ${unit.quantum.netname}" />
+				<echo message="QUANTUM_NET_VLAN= ${unit.vlan.tag}" />
+				<echo message="QUANTUM_MAX_RATE= ${unit.vlan.qos.rate}" />
+				<echo message="QUANTUM_BURST_RATE= ${unit.vlan.qos.burst.size}" />
+				<exec executable="${provider.scripts}/neuca-quantum-create-net" resultproperty="code" outputproperty="create.network.output">
+					<env key="PROVIDER_DIR" value="${provider.dir}" />
+					<env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" />
+					<env key="PROVIDER_LOG_FILE" value="${provider.log.file}" />
+					<env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" />
+					<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+					<env key="QUANTUM_NET_TYPE" value="ipv4" />
+					<env key="QUANTUM_NET_NETWORK" value="${unit.quantum.netname}" />
+					<env key="QUANTUM_NET_VLAN" value="${unit.vlan.tag}" />
+					<env key="QUANTUM_MAX_RATE" value="${unit.vlan.qos.rate}" />
+					<env key="QUANTUM_BURST_RATE" value="${unit.vlan.qos.burst.size}" />
+				</exec>
+				<echo message="exit code ${code}, ${create.network.output}" />
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" />
+						<property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" />
+					</then>
+					<else>
+						<var name="shirako.save.unit.quantum.net.uuid" unset="true" />
+						<property name="shirako.save.unit.quantum.net.uuid" value="${create.network.output}" />
+					</else>
+				</if>
+				<echo message="shirako.save.unit.quantum.net.uuid = ${shirako.save.unit.quantum.net.uuid}, create.network.output = ${create.network.output}" />
+				<!-- hairpin the url property so the user sees it too -->
+				<var name="shirako.save.unit.vlan.url" unset="true" />
+				<property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+				<property name="shirako.target.code" value="${code}" />
+				<property name="shirako.target.code.message" value="${message}" />
+			</else>
+		</if>
+		<echo message="join exit code: ${shirako.target.code} with message: ${shirako.target.code.message}" />
+	</target>
+
+	<!-- 
 		Controller must supply
 			unit.vlan.tag [mandatory]
 			
@@ -113,57 +123,59 @@
                         
                         #tenant that uses orca
                         quantum.tenant.id=geni-orca
-	--> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="Quantum Handler: LEAVE on ${start.TIME}" /> 
-        <if> 
-            <isset property="quantum.properties" /> 
-            <then> 
-                <property file="${quantum.properties}" /> 
-            </then> 
-            <else> 
-                <echo message="Quantum credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <echo message="About to call neuca-quantum-delete-net, use.neuca.quantum = ${use.neuca.quantum}" /> 
-                <var name="create.network.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <exec executable="${provider.scripts}/neuca-quantum-delete-net" resultproperty="code" outputproperty="create.network.output"> 
-                    <env key="PROVIDER_DIR" value="${provider.dir}" /> 
-                    <env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" /> 
-                    <env key="PROVIDER_LOG_FILE" value="${provider.log.file}" /> 
-                    <env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" /> 
-                    <env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" /> 
-                    <env key="QUANTUM_NET_UUID" value="${unit.quantum.net.uuid}" /> 
-                </exec> 
-                <echo message="exit code ${code}, ${create.network.output}" /> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="unable to create quantum network: exit code ${code}, ${create.instance.output}" /> 
-                        <property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" /> 
-                    </then> 
-                </if> 
-            </else> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="Quantum Handler: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="Quantum Handler: LEAVE on ${start.TIME}" />
+		<if>
+			<isset property="quantum.properties" />
+			<then>
+				<property file="${quantum.properties}" />
+			</then>
+			<else>
+				<echo message="Quantum credentials properties are not set!" />
+			</else>
+		</if>
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<echo message="About to call neuca-quantum-delete-net, use.neuca.quantum = ${use.neuca.quantum}" />
+				<var name="create.network.output" unset="true" />
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+				<exec executable="${provider.scripts}/neuca-quantum-delete-net" resultproperty="code" outputproperty="create.network.output">
+					<env key="PROVIDER_DIR" value="${provider.dir}" />
+					<env key="PROVIDER_LOG_DIR" value="${provider.log.dir}" />
+					<env key="PROVIDER_LOG_FILE" value="${provider.log.file}" />
+					<env key="PROVIDER_LOG_LEVEL" value="${provider.log.level}" />
+					<env key="QUANTUM_TENANT_ID" value="${quantum.tenant.id}" />
+					<env key="QUANTUM_NET_UUID" value="${unit.quantum.net.uuid}" />
+				</exec>
+				<echo message="exit code ${code}, ${create.network.output}" />
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo message="unable to create quantum network: exit code ${code}, ${create.instance.output}" />
+						<property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" />
+					</then>
+				</if>
+			</else>
+		</if>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="Quantum Handler: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/handlers/providers/resources/handler/providers/starlight/handler.xml
+++ b/handlers/providers/resources/handler/providers/starlight/handler.xml
@@ -1,122 +1,197 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../common/core.xml">
+<!ENTITY paths SYSTEM "../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="starlight" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+
     <property file="../ben.properties" /> 
     <!-- Uncomment for handler testing
     <property file="starlight.test.properties" />
-    --> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="STARLIGHT HANDLER: JOIN on ${start.TIME}" /> 
-        <if> 
-            <isset property="starlight.credentials" /> 
-            <then> 
-                <property file="${starlight.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="STARLIGHT credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <var name="code" value="0"></var> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <echo message="Enabling STARLIGHT vlan=${unit.vlan.tag} on ${starlight.router} QoS=${unit.vlan.qos.rate}/${unit.vlan.qos.burst.size}: ${config.interface.ports}" /> 
-                <atomic.sequence.start.macro device="STARLIGHT" /> 
-                <create.vlan router="${starlight.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                <add.trunk.ports router="${starlight.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                <if> 
-                    <equals arg1="0" arg2="${code}" /> 
-                    <then> 
-                        <for list="nlr esnet" param="site" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <and> 
-                                        <isset property="@{site}.unit.vlan.tag" /> 
-                                        <isset property="@{site}.edge.interface" /> 
-                                    </and> 
-                                    <then> 
-                                        <echo message="mapping STARLIGHT and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${starlight.router}: ${@{site}.edge.interface}" /> 
-                                        <map.vlans router="${starlight.router}" router.type="Cisco6509" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <atomic.sequence.stop.macro device="STARLIGHT" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <!-- hairpin --> 
-        <var name="shirako.save.unit.vlan.url" unset="true"></var> 
-        <if> 
-            <isset property="unit.vlan.url" /> 
-            <then> 
-                <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" /> 
-            </then> 
-        </if> 
-        <echo message="starlight join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="STARLIGHT HANDLER: TEARDOWN on ${start.TIME}" /> 
-        <if> 
-            <isset property="starlight.credentials" /> 
-            <then> 
-                <property file="${starlight.credentials}" /> 
-            </then> 
-            <else> 
-                <echo message="STARLIGHT credentials properties are not set!" /> 
-            </else> 
-        </if> 
-        <var name="code" value="0"></var> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <atomic.sequence.start.macro device="STARLIGHT" /> 
-                <for list="nlr esnet" param="site" delimiter=" " parallel="false"> 
-                    <sequential> 
-                        <if> 
-                            <and> 
-                                <isset property="@{site}.unit.vlan.tag" /> 
-                                <isset property="@{site}.edge.interface" /> 
-                            </and> 
-                            <then> 
-                                <echo message="Unmapping STARLIGHT and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${starlight.router}: ${@{site}.edge.interface}" /> 
-                                <unmap.vlans router="${starlight.router}" router.type="Cisco6509" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                            </then> 
-                        </if> 
-                    </sequential> 
-                </for> 
-                <echo message="Disabling STARLIGHT vlan ${unit.vlan.tag} on ${starlight.router}: ${config.interface.ports}" /> 
-                <remove.trunk.ports router="${starlight.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                <delete.vlan router="${starlight.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.default.prompt="${router.default.prompt}" router.admin.password="${router.admin.password}" /> 
-                <atomic.sequence.stop.macro device="STARLIGHT" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <echo message="STARLIGHT leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="STARLIGHT HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+    -->
+
+    <target name="join" depends="resolve.configuration,ben.load.tasks">
+        <tstamp prefix="start">
+                <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+        </tstamp>
+
+        <echo message="STARLIGHT HANDLER: JOIN on ${start.TIME}" />
+		<if>
+			<isset property="starlight.credentials" />
+			<then>
+				<property file="${starlight.credentials}" />
+			</then>
+			<else>
+				<echo message="STARLIGHT credentials properties are not set!" />
+			</else>
+		</if>
+        <var name="code" value="0" />
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+		        <echo message="Enabling STARLIGHT vlan=${unit.vlan.tag} on ${starlight.router} QoS=${unit.vlan.qos.rate}/${unit.vlan.qos.burst.size}: ${config.interface.ports}" />
+				<atomic.sequence.start.macro
+					device="STARLIGHT" />
+				<create.vlan 
+					router="${starlight.router}"
+					router.type="Cisco6509"
+			   		vlan.tag="${unit.vlan.tag}"
+					vlan.qos.rate="${unit.vlan.qos.rate}"
+					vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+			    	router.user="${router.user}"
+			    	router.password="${router.password}"
+					router.default.prompt="${router.default.prompt}"
+			    	router.admin.password="${router.admin.password}" />
+		        <add.trunk.ports 
+		            router="${starlight.router}"
+				    router.type="Cisco6509"
+		            vlan.tag="${unit.vlan.tag}"
+				    ports="${config.interface.ports}"
+		            router.user="${router.user}"
+		            router.password="${router.password}"
+				    router.default.prompt="${router.default.prompt}"
+		            router.admin.password="${router.admin.password}" />
+		        <if>
+		            <equals arg1="0" arg2="${code}" />
+		            <then>
+						<for list="nlr esnet"
+	                    	param="site"
+	                        delimiter=" "
+	                        parallel="false">
+	                    	<sequential>
+							    <if>
+							        <and>
+							            <isset property="@{site}.unit.vlan.tag" />
+							            <isset property="@{site}.edge.interface" />
+							        </and>
+									<then>
+					                	<echo message="mapping STARLIGHT and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${starlight.router}: ${@{site}.edge.interface}" />
+					                	<map.vlans 
+						                     router="${starlight.router}"
+								     		 router.type="Cisco6509"
+						                     src.vlan.tag="${@{site}.unit.vlan.tag}"
+						                     dst.vlan.tag="${unit.vlan.tag}"
+						                     port="${@{site}.edge.interface}"
+						                     router.user="${router.user}"
+						                     router.password="${router.password}"
+								     		 router.default.prompt="${router.default.prompt}"
+						                     router.admin.password="${router.admin.password}" />
+									</then>
+								</if>
+							</sequential>
+						</for>
+		            </then>
+		        </if>
+			<atomic.sequence.stop.macro
+				device="STARLIGHT" />
+    			<property name="shirako.target.code" value="${code}" />
+			</else>
+		</if>
+        <!-- hairpin -->
+        <var name="shirako.save.unit.vlan.url" unset="true" />
+        <if>
+                <isset property="unit.vlan.url" />
+                <then>
+                        <property name="shirako.save.unit.vlan.url" value="${unit.vlan.url}" />
+                </then>
+        </if>
+
+        <echo message="starlight join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="leave" depends="resolve.configuration,ben.load.tasks">
+        <tstamp prefix="start">
+                <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+        </tstamp>
+
+        <echo message="STARLIGHT HANDLER: TEARDOWN on ${start.TIME}" />
+		<if>
+			<isset property="starlight.credentials" />
+			<then>
+				<property file="${starlight.credentials}" />
+			</then>
+			<else>
+				<echo message="STARLIGHT credentials properties are not set!" />
+			</else>
+		</if>
+        <var name="code" value="0" />
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<atomic.sequence.start.macro
+					device="STARLIGHT" />
+				<for list="nlr esnet"
+			    	param="site"
+			        delimiter=" "
+			        parallel="false">
+			    	<sequential>
+					    <if>
+					        <and>
+					            <isset property="@{site}.unit.vlan.tag" />
+					            <isset property="@{site}.edge.interface" />
+					        </and>
+							<then>
+				        		<echo message="Unmapping STARLIGHT and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${starlight.router}: ${@{site}.edge.interface}" />
+						        <unmap.vlans 
+				                     router="${starlight.router}"
+						     		 router.type="Cisco6509"
+				                     src.vlan.tag="${@{site}.unit.vlan.tag}"
+				                     dst.vlan.tag="${unit.vlan.tag}"
+				                     port="${@{site}.edge.interface}"
+				                     router.user="${router.user}"
+				                     router.password="${router.password}"
+						     		 router.default.prompt="${router.default.prompt}"
+				                     router.admin.password="${router.admin.password}" />
+							</then>
+						</if>
+					</sequential>
+				</for>
+		        <echo message="Disabling STARLIGHT vlan ${unit.vlan.tag} on ${starlight.router}: ${config.interface.ports}" />
+		        <remove.trunk.ports
+                      router="${starlight.router}"
+		      		  router.type="Cisco6509"
+                      vlan.tag="${unit.vlan.tag}"
+                      ports="${config.interface.ports}"
+                      router.user="${router.user}"
+                      router.password="${router.password}"
+		      		  router.default.prompt="${router.default.prompt}"
+                      router.admin.password="${router.admin.password}" />
+			    <delete.vlan 
+			    	router="${starlight.router}"
+					router.type="Cisco6509"
+			        vlan.tag="${unit.vlan.tag}"
+					vlan.with.qos="${unit.vlan.with.qos}"
+			        router.user="${router.user}"
+			        router.password="${router.password}"
+					router.default.prompt="${router.default.prompt}"
+			        router.admin.password="${router.admin.password}" />
+				<atomic.sequence.stop.macro
+					device="STARLIGHT" />
+		        <property name="shirako.target.code" value="${code}" />
+			</else>
+		</if>
+        <echo message="STARLIGHT leave exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="modify" depends="resolve.configuration,ben.load.tasks">
+        <echo message="STARLIGHT HANDLER: MODIFY" />
+        <property name="shirako.target.code" value="0" />
+    </target>
 </project>

--- a/handlers/slurm/resources/handlers/slurm/handler.xml
+++ b/handlers/slurm/resources/handlers/slurm/handler.xml
@@ -1,146 +1,178 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+]>
 <project name="slurm" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; 
-    <!-- Join operation --> 
-    <target name="join" depends="resolve.configuration"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy HH:mm:ss z" /> 
-        </tstamp> 
-        <echo message="SLURM HANDLER: JOIN on ${start.TIME}" /> 
-        <!--<property file="test.properties" />--> 
-        <if> 
-            <isset property="slurm.site.properties" /> 
-            <then> 
-                <property file="${slurm.site.properties}" /> 
-            </then> 
-        </if> 
-        <!-- Echo statments for log and emulation mode --> 
-        <echo message="SLURM_VERSION=${slurm.version}" /> 
-        <echo message="SLURM_PACKAGE_DIR=${slurm.dir}" /> 
-        <echo message="SLURM_LOG_DIR=${slurm.log.dir}" /> 
-        <echo message="SLURM_LOG_FILE=${slurm.log.file}" /> 
-        <echo message="SLURM_LOG_LEVEL=${slurm.log.level}" /> 
-        <echo message="SLURM_MANAGE_HOME=${slurm.scripts}" /> 
-        <echo message="SLURM_TYPE=${slurm.allocation.type}" /> 
-        <echo message="SLURM_OWNER=${slurm.owner}" /> 
-        <echo message="SLURM_RESERVATION=${slurm.reservation}" /> 
-        <!-- If in emulation then exit without doing anything --> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="Emulation mode...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <if> 
-                    <!-- For now reusing unit.ec2.instance.type for setting slurm allocation type --> 
-                    <isset property="unit.ec2.instance.type" /> 
-                    <then> 
-                        <echo message="User supplied type is ${unit.ec2.instance.type}" /> 
-                        <var name="slurm.allocation.type" unset="true"></var> 
-                        <property name="slurm.allocation.type" value="${unit.ec2.instance.type}" /> 
-                    </then> 
-                    <else> 
-                        <echo message="User did not specify type, using default ${slurm.allocation.type}" /> 
-                    </else> 
-                </if> 
-                <!-- Log some properites for debuging --> 
-                <echo message="creating SLURM Allocation ...(may take some time)" /> 
-                <var name="create.allocation.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <echo message="before create allocation" /> 
-                <exec executable="${slurm.scripts}/slurm-create" resultproperty="code" outputproperty="create.allocation.output"> 
-                    <env key="SLURM_PACKAGE_DIR" value="${slurm.dir}" /> 
-                    <env key="SLURM_LOG_DIR" value="${slurm.log.dir}" /> 
-                    <env key="SLURM_LOG_FILE" value="${slurm.log.file}" /> 
-                    <env key="SLURM_LOG_LEVEL" value="${slurm.log.level}" /> 
-                    <env key="SLURM_MANAGE_HOME" value="${slurm.scripts}" /> 
-                    <env key="SLURM_TYPE" value="${slurm.allocation.type}" /> 
-                    <env key="SLURM_OWNER" value="${slurm.owner}" /> 
-                    <env key="SLURM_RESERVATION" value="${slurm.reservation}" /> 
-                </exec> 
-                <echo message="after create allocation: exit code ${code}, ${create.allocation.output}" /> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="unable to create allocation: exit code ${code}, ${create.allocation.output}" /> 
-                        <property name="message" value="unable to create allocation: exit code ${code}, ${create.allocation.output}" /> 
-                    </then> 
-                    <else> 
-                        <var name="shirako.save.unit.ec2.instance" unset="true"></var> 
-                        <property name="shirako.save.unit.ec2.instance" value="${create.allocation.output}" /> 
-                    </else> 
-                </if> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <!-- end of else for emulation --> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- Modify operation is not supported --> 
-    <target name="modify" /> 
-    <!-- Leave operation --> 
-    <target name="leave" depends="resolve.configuration"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy HH:mm:ss z" /> 
-        </tstamp> 
-        <echo message="SLURM HANDLER: LEAVE on ${start.TIME}" /> 
-        <!--<property file="test.properties" />--> 
-        <if> 
-            <isset property="slurm.site.properties" /> 
-            <then> 
-                <property file="${slurm.site.properties}" /> 
-            </then> 
-        </if> 
-        <!-- Echo statments for log and emulation mode --> 
-        <echo message="SLURM_PACKAGE_DIR=${slurm.dir}" /> 
-        <echo message="SLURM_LOG_DIR=${slurm.log.dir}" /> 
-        <echo message="SLURM_LOG_FILE=${slurm.log.file}" /> 
-        <echo message="SLURM_LOG_LEVEL=${slurm.log.level}" /> 
-        <echo message="SLURM_ALLOCATIONID=${slurm.allocationid}" /> 
-        <!-- If in emulation then exit without doing anything --> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="Emulation mode...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <if> 
-                    <!-- Reusing unit.ec2.instance for getting allocation id, which was saved in shirako.save.unit.ec2.instance property in join --> 
-                    <isset property="unit.ec2.instance" /> 
-                    <then> 
-                        <echo message="Allocation id to delete is ${unit.ec2.instance}" /> 
-                        <var name="slurm.allocationid" unset="true"></var> 
-                        <property name="slurm.allocationid" value="${unit.ec2.instance}" /> 
-                    </then> 
-                    <else> 
-                        <echo message="User did not specify type, using default ${slurm.allocation.type}" /> 
-                    </else> 
-                </if> 
-                <echo message="deleting SLURM Allocation ...(may take some time)" /> 
-                <var name="delete.allocation.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <echo message="before delete allocation" /> 
-                <exec executable="${slurm.scripts}/slurm-delete" resultproperty="code" outputproperty="delete.allocation.output"> 
-                    <env key="SLURM_PACKAGE_DIR" value="${slurm.dir}" /> 
-                    <env key="SLURM_LOG_DIR" value="${slurm.log.dir}" /> 
-                    <env key="SLURM_LOG_FILE" value="${slurm.log.file}" /> 
-                    <env key="SLURM_LOG_LEVEL" value="${slurm.log.level}" /> 
-                    <env key="SLURM_ALLOCATIONID" value="${slurm.allocationid}" /> 
-                </exec> 
-                <echo message="after delete allocation: exit code ${code}, ${delete.allocation.output}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-            </else> 
-        </if> 
-        <!-- end of else for emulation --> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
+
+  &paths;
+  &core;
+  &drivertasks;	
+
+
+
+  <!-- Join operation -->
+  <target name="join" depends="resolve.configuration">
+    <tstamp prefix="start">
+      <format property="TIME" pattern="MM/dd/yyyy HH:mm:ss z" />
+    </tstamp>
+    <echo message="SLURM HANDLER: JOIN on ${start.TIME}" />
+
+     <!--<property file="test.properties" />-->
+     <if>
+      <isset property="slurm.site.properties" />
+       <then>
+        <property file="${slurm.site.properties}" />
+      </then>
+    </if>
+
+
+    <!-- Echo statments for log and emulation mode -->
+    <echo message="SLURM_VERSION=${slurm.version}" />
+    <echo message="SLURM_PACKAGE_DIR=${slurm.dir}" />
+    <echo message="SLURM_LOG_DIR=${slurm.log.dir}" />
+    <echo message="SLURM_LOG_FILE=${slurm.log.file}" />
+    <echo message="SLURM_LOG_LEVEL=${slurm.log.level}" />
+    <echo message="SLURM_MANAGE_HOME=${slurm.scripts}" />
+    <echo message="SLURM_TYPE=${slurm.allocation.type}" />
+    <echo message="SLURM_OWNER=${slurm.owner}" />
+    <echo message="SLURM_RESERVATION=${slurm.reservation}" />
+    
+
+    <!-- If in emulation then exit without doing anything -->
+    <if>
+      <equals arg1="${emulation}" arg2="true" />
+      <then>
+        <echo message="Emulation mode...exiting" />
+        <property name="shirako.target.code" value="0" />
+      </then>
+    <else>
+
+	<if>
+	  <!-- For now reusing unit.ec2.instance.type for setting slurm allocation type -->
+	  <isset property="unit.ec2.instance.type" />
+	  <then>
+	  	<echo message="User supplied type is ${unit.ec2.instance.type}"/>
+	        <var name="slurm.allocation.type" unset="true" />
+	        <property name="slurm.allocation.type" value="${unit.ec2.instance.type}" />
+	  </then>
+	  <else>
+	        <echo message="User did not specify type, using default ${slurm.allocation.type}"/>
+          </else>
+        </if>
+
+    	<!-- Log some properites for debuging -->
+    	<echo message="creating SLURM Allocation ...(may take some time)" />
+    	<var name="create.allocation.output" unset="true" />
+    	<var name="code" unset="true" />
+    	<var name="message" unset="true" />
+    
+    	<echo message="before create allocation" />
+
+    	<exec executable="${slurm.scripts}/slurm-create" resultproperty="code" outputproperty="create.allocation.output">
+      	  <env key="SLURM_PACKAGE_DIR" value="${slurm.dir}" />
+      	  <env key="SLURM_LOG_DIR" value="${slurm.log.dir}" />
+      	  <env key="SLURM_LOG_FILE" value="${slurm.log.file}" />
+      	  <env key="SLURM_LOG_LEVEL" value="${slurm.log.level}" />
+      	  <env key="SLURM_MANAGE_HOME" value="${slurm.scripts}" />
+      	  <env key="SLURM_TYPE" value="${slurm.allocation.type}" />
+      	  <env key="SLURM_OWNER" value="${slurm.owner}" />
+      	  <env key="SLURM_RESERVATION" value="${slurm.reservation}" />
+    	</exec>
+
+    	<echo message="after create allocation: exit code ${code}, ${create.allocation.output}" />
+    
+	<if>
+	  <not>
+	    <equals arg1="${code}" arg2="0" />
+	  </not>
+	  <then>
+	    <echo message="unable to create allocation: exit code ${code}, ${create.allocation.output}" />
+	    <property name="message" value="unable to create allocation: exit code ${code}, ${create.allocation.output}" />
+	  </then>
+	  <else>
+	    <var name="shirako.save.unit.ec2.instance" unset="true" />
+	    <property name="shirako.save.unit.ec2.instance" value="${create.allocation.output}" />
+	  </else>
+	</if>    
+
+    	<property name="shirako.target.code" value="${code}" />
+
+    
+    </else>
+    </if> <!-- end of else for emulation -->  
+    <echo message="join exit code: ${shirako.target.code}" />
+  </target>
+  
+  <!-- Modify operation is not supported -->
+  <target name="modify" />
+
+  
+  <!-- Leave operation -->
+  <target name="leave" depends="resolve.configuration">
+    <tstamp prefix="start">
+      <format property="TIME" pattern="MM/dd/yyyy HH:mm:ss z" />
+    </tstamp>
+    <echo message="SLURM HANDLER: LEAVE on ${start.TIME}" />
+
+     <!--<property file="test.properties" />-->
+     <if>
+      <isset property="slurm.site.properties" />
+       <then>
+        <property file="${slurm.site.properties}" />
+      </then>
+    </if>
+
+
+    <!-- Echo statments for log and emulation mode -->
+    <echo message="SLURM_PACKAGE_DIR=${slurm.dir}" />
+    <echo message="SLURM_LOG_DIR=${slurm.log.dir}" />
+    <echo message="SLURM_LOG_FILE=${slurm.log.file}" />
+    <echo message="SLURM_LOG_LEVEL=${slurm.log.level}" />
+    <echo message="SLURM_ALLOCATIONID=${slurm.allocationid}" />
+    
+
+    <!-- If in emulation then exit without doing anything -->
+    <if>
+      <equals arg1="${emulation}" arg2="true" />
+      <then>
+        <echo message="Emulation mode...exiting" />
+        <property name="shirako.target.code" value="0" />
+      </then>
+    <else>
+
+	<if>
+	  <!-- Reusing unit.ec2.instance for getting allocation id, which was saved in shirako.save.unit.ec2.instance property in join -->
+	  <isset property="unit.ec2.instance" />
+	  <then>
+	  	<echo message="Allocation id to delete is ${unit.ec2.instance}"/>
+	        <var name="slurm.allocationid" unset="true" />
+	        <property name="slurm.allocationid" value="${unit.ec2.instance}" />
+	  </then>
+	  <else>
+	        <echo message="User did not specify type, using default ${slurm.allocation.type}"/>
+          </else>
+        </if>
+
+	<echo message="deleting SLURM Allocation ...(may take some time)" />
+        <var name="delete.allocation.output" unset="true" />
+        <var name="code" unset="true" />
+        <var name="message" unset="true" />
+	
+        <echo message="before delete allocation" />
+        <exec executable="${slurm.scripts}/slurm-delete" resultproperty="code" outputproperty="delete.allocation.output">
+      	  <env key="SLURM_PACKAGE_DIR" value="${slurm.dir}" />
+      	  <env key="SLURM_LOG_DIR" value="${slurm.log.dir}" />
+      	  <env key="SLURM_LOG_FILE" value="${slurm.log.file}" />
+      	  <env key="SLURM_LOG_LEVEL" value="${slurm.log.level}" />
+      	  <env key="SLURM_ALLOCATIONID" value="${slurm.allocationid}" />
+        </exec>
+        <echo message="after delete allocation: exit code ${code}, ${delete.allocation.output}" />
+	
+	<property name="shirako.target.code" value="${code}" />
+
+    </else> </if> <!-- end of else for emulation -->
+    <echo message="leave exit code: ${shirako.target.code}" />
+  </target>
 </project>
+

--- a/handlers/storage_service/resources/handlers/storage_service/handler.xml
+++ b/handlers/storage_service/resources/handlers/storage_service/handler.xml
@@ -1,138 +1,175 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+]>
 <project name="storage_service" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; 
-    <!-- Join operation --> 
-    <target name="join" depends="resolve.configuration"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy HH:mm:ss z" /> 
-        </tstamp> 
-        <echo message="STORAGE SERVICE HANDLER: JOIN on ${start.TIME}" /> 
-        <!--<property file="test.properties" />--> 
-        <if> 
-            <isset property="storage_service.site.properties" /> 
-            <then> 
-                <property file="${storage_service.site.properties}" /> 
-            </then> 
-        </if> 
-        <!-- Echo statments for log and emulation mode --> 
-        <echo message="STORAGE_SERVICE_DIR=${storage_service.dir}" /> 
-        <echo message="STORAGE_SERVICE_LOG_DIR=${storage_service.log.dir}" /> 
-        <echo message="STORAGE_SERVICE_LOG_FILE=${storage_service.log.file}" /> 
-        <echo message="STORAGE_SERVICE_LOG_LEVEL=${storage_service.log.level}" /> 
-        <echo message="STORAGE_SERVICE_CONNECTION_TIMEOUT=${storage_service.connection.timeout}" /> 
-        <echo message="STORAGE_SERVICE_REQUEST_TIMEOUT=${storage_service.request.timeout}" /> 
-        <echo message="STORAGE_SERVICE_IP=${storage_service.ip}" /> 
-        <echo message="STORAGE_SERVICE_PORT=${storage_service.port}" /> 
-        <echo message="STORAGE_SERVICE_USERNAME=${storage_service.username}" /> 
-        <echo message="STORAGE_SERVICE_PASSWORD=${storage_service.password}" /> 
-        <echo message="UNIT_INITIATOR_IQN_PREFIX=${unit.initiator.iqn_prefix}" /> 
-        <echo message="UNIT_TARGET_CHAP_USER=${unit.target.chap_user}" /> 
-        <echo message="UNIT_TARGET_CHAP_PASSWORD=${unit.target.chap_password}" /> 
-        <echo message="UNIT_TARGET_CAPACITY=${unit.target.capacity}" /> 
-        <echo message="UNIT_TARGET_LUN=${unit.target.lun}" /> 
-        <echo message="UNIT_VM_GUID=${unit.vm.guid}" /> 
-        <echo message="UNIT_LUN_GUID=${unit.lun.guid}" /> 
-        <!-- If in emulation then exit without doing anything --> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="Emulation mode...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <!-- Log some properites for debuging --> 
-                <echo message="creating LUN ...(may take some time)" /> 
-                <var name="create.lun.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <exec executable="${storage_service.scripts}/storage_service-create-lun" resultproperty="code" outputproperty="create.lun.output"> 
-                    <env key="STORAGE_SERVICE_DIR" value="${storage_service.dir}" /> 
-                    <env key="STORAGE_SERVICE_LOG_DIR" value="${storage_service.log.dir}" /> 
-                    <env key="STORAGE_SERVICE_LOG_FILE" value="${storage_service.log.file}" /> 
-                    <env key="STORAGE_SERVICE_LOG_LEVEL" value="${storage_service.log.level}" /> 
-                    <env key="STORAGE_SERVICE_CONNECTION_TIMEOUT" value="${storage_service.connection.timeout}" /> 
-                    <env key="STORAGE_SERVICE_REQUEST_TIMEOUT" value="${storage_service.request.timeout}" /> 
-                    <env key="STORAGE_SERVICE_IP" value="${storage_service.ip}" /> 
-                    <env key="STORAGE_SERVICE_PORT" value="${storage_service.port}" /> 
-                    <env key="STORAGE_SERVICE_USERNAME" value="${storage_service.username}" /> 
-                    <env key="STORAGE_SERVICE_PASSWORD" value="${storage_service.password}" /> 
-                    <env key="UNIT_INITIATOR_IQN_PREFIX" value="${unit.initiator.iqn_prefix}" /> 
-                    <env key="UNIT_TARGET_CHAP_USER" value="${unit.target.chap_user}" /> 
-                    <env key="UNIT_TARGET_CHAP_PASSWORD" value="${unit.target.chap_password}" /> 
-                    <env key="UNIT_TARGET_CAPACITY" value="${unit.target.capacity}" /> 
-                    <env key="UNIT_TARGET_LUN" value="${unit.target.lun}" /> 
-                    <env key="UNIT_VM_GUID" value="${unit.vm.guid}" /> 
-                    <env key="UNIT_LUN_GUID" value="${unit.lun.guid}" /> 
-                </exec> 
-                <echo message="after create lun: exit code ${code}, ${create.lun.output}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <property name="shirako.target.code.message" value="${create.lun.output}" /> 
-            </else> 
-        </if> 
-        <!-- end of else for emulation --> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- Modify operation is not supported --> 
-    <target name="modify" /> 
-    <!-- Leave operation --> 
-    <target name="leave" depends="resolve.configuration"> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="STORAGE SERVICE HANDLER: LEAVE on ${start.TIME}" /> 
-        <!--<property file="test.properties" />--> 
-        <if> 
-            <isset property="storage_service.site.properties" /> 
-            <then> 
-                <property file="${storage_service.site.properties}" /> 
-            </then> 
-        </if> 
-        <!-- Echo statments for log and emulation mode --> 
-        <echo message="STORAGE_SERVICE_DIR=${storage_service.dir}" /> 
-        <echo message="STORAGE_SERVICE_LOG_DIR=${storage_service.log.dir}" /> 
-        <echo message="STORAGE_SERVICE_LOG_FILE=${storage_service.log.file}" /> 
-        <echo message="STORAGE_SERVICE_LOG_LEVEL=${storage_service.log.level}" /> 
-        <echo message="STORAGE_SERVICE_CONNECTION_TIMEOUT=${storage_service.connection.timeout}" /> 
-        <echo message="STORAGE_SERVICE_REQUEST_TIMEOUT=${storage_service.request.timeout}" /> 
-        <echo message="STORAGE_SERVICE_IP=${storage_service.ip}" /> 
-        <echo message="STORAGE_SERVICE_PORT=${storage_service.port}" /> 
-        <echo message="STORAGE_SERVICE_USERNAME=${storage_service.username}" /> 
-        <echo message="STORAGE_SERVICE_PASSWORD=${storage_service.password}" /> 
-        <echo message="UNIT_LUN_GUID=${unit.lun.guid}" /> 
-        <!-- If in emulation then exit without doing anything --> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="Emulation mode...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <echo message="deleting LUN ...(may take some time)" /> 
-                <var name="delete.lun.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <echo message="before delete lun" /> 
-                <exec executable="${storage_service.scripts}/storage_service-delete-lun" resultproperty="code" outputproperty="delete.lun.output"> 
-                    <env key="STORAGE_SERVICE_DIR" value="${storage_service.dir}" /> 
-                    <env key="STORAGE_SERVICE_LOG_DIR" value="${storage_service.log.dir}" /> 
-                    <env key="STORAGE_SERVICE_LOG_FILE" value="${storage_service.log.file}" /> 
-                    <env key="STORAGE_SERVICE_LOG_LEVEL" value="${storage_service.log.level}" /> 
-                    <env key="STORAGE_SERVICE_CONNECTION_TIMEOUT" value="${storage_service.connection.timeout}" /> 
-                    <env key="STORAGE_SERVICE_REQUEST_TIMEOUT" value="${storage_service.request.timeout}" /> 
-                    <env key="STORAGE_SERVICE_IP" value="${storage_service.ip}" /> 
-                    <env key="STORAGE_SERVICE_PORT" value="${storage_service.port}" /> 
-                    <env key="STORAGE_SERVICE_USERNAME" value="${storage_service.username}" /> 
-                    <env key="STORAGE_SERVICE_PASSWORD" value="${storage_service.password}" /> 
-                    <env key="UNIT_LUN_GUID" value="${unit.lun.guid}" /> 
-                </exec> 
-                <echo message="after delete lun: exit code ${code}, ${delete.lun.output}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <property name="shirako.target.code.message" value="${delete.lun.output}" /> 
-            </else> 
-        </if> 
-        <!-- end of else for emulation --> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
+
+  &paths;
+  &core;
+  &drivertasks;	
+
+
+
+  <!-- Join operation -->
+  <target name="join" depends="resolve.configuration">
+    <tstamp prefix="start">
+      <format property="TIME" pattern="MM/dd/yyyy HH:mm:ss z" />
+    </tstamp>
+    <echo message="STORAGE SERVICE HANDLER: JOIN on ${start.TIME}" />
+
+    <!--<property file="test.properties" />-->
+    <if>
+      <isset property="storage_service.site.properties" />
+      <then>
+        <property file="${storage_service.site.properties}" />
+      </then>
+    </if>
+
+
+    <!-- Echo statments for log and emulation mode -->
+    <echo message="STORAGE_SERVICE_DIR=${storage_service.dir}" />
+    <echo message="STORAGE_SERVICE_LOG_DIR=${storage_service.log.dir}" />
+    <echo message="STORAGE_SERVICE_LOG_FILE=${storage_service.log.file}" />
+    <echo message="STORAGE_SERVICE_LOG_LEVEL=${storage_service.log.level}" />
+    <echo message="STORAGE_SERVICE_CONNECTION_TIMEOUT=${storage_service.connection.timeout}" />
+    <echo message="STORAGE_SERVICE_REQUEST_TIMEOUT=${storage_service.request.timeout}" />
+
+    <echo message="STORAGE_SERVICE_IP=${storage_service.ip}" />
+    <echo message="STORAGE_SERVICE_PORT=${storage_service.port}" />
+    <echo message="STORAGE_SERVICE_USERNAME=${storage_service.username}" />
+    <echo message="STORAGE_SERVICE_PASSWORD=${storage_service.password}" />
+  
+    <echo message="UNIT_INITIATOR_IQN_PREFIX=${unit.initiator.iqn_prefix}" />
+    <echo message="UNIT_TARGET_CHAP_USER=${unit.target.chap_user}" />
+    <echo message="UNIT_TARGET_CHAP_PASSWORD=${unit.target.chap_password}" />
+    <echo message="UNIT_TARGET_CAPACITY=${unit.target.capacity}" />
+    <echo message="UNIT_TARGET_LUN=${unit.target.lun}" />
+
+    <echo message="UNIT_VM_GUID=${unit.vm.guid}" />
+    <echo message="UNIT_LUN_GUID=${unit.lun.guid}" />
+
+
+    <!-- If in emulation then exit without doing anything -->
+    <if>
+      <equals arg1="${emulation}" arg2="true" />
+      <then>
+        <echo message="Emulation mode...exiting" />
+        <property name="shirako.target.code" value="0" />
+      </then>
+    <else>
+
+
+    <!-- Log some properites for debuging -->
+    <echo message="creating LUN ...(may take some time)" />
+    <var name="create.lun.output" unset="true" />
+    <var name="code" unset="true" />
+    
+    <exec executable="${storage_service.scripts}/storage_service-create-lun"
+          resultproperty="code" outputproperty="create.lun.output">
+      <env key="STORAGE_SERVICE_DIR" value="${storage_service.dir}" />
+      <env key="STORAGE_SERVICE_LOG_DIR" value="${storage_service.log.dir}" />
+      <env key="STORAGE_SERVICE_LOG_FILE" value="${storage_service.log.file}" />
+      <env key="STORAGE_SERVICE_LOG_LEVEL" value="${storage_service.log.level}" />
+      <env key="STORAGE_SERVICE_CONNECTION_TIMEOUT" value="${storage_service.connection.timeout}" />
+      <env key="STORAGE_SERVICE_REQUEST_TIMEOUT" value="${storage_service.request.timeout}" />
+
+      <env key="STORAGE_SERVICE_IP" value="${storage_service.ip}" />
+      <env key="STORAGE_SERVICE_PORT" value="${storage_service.port}" />
+      <env key="STORAGE_SERVICE_USERNAME" value="${storage_service.username}" />
+      <env key="STORAGE_SERVICE_PASSWORD" value="${storage_service.password}" />
+
+      <env key="UNIT_INITIATOR_IQN_PREFIX" value="${unit.initiator.iqn_prefix}" />
+      <env key="UNIT_TARGET_CHAP_USER" value="${unit.target.chap_user}" />
+      <env key="UNIT_TARGET_CHAP_PASSWORD" value="${unit.target.chap_password}" />
+      <env key="UNIT_TARGET_CAPACITY" value="${unit.target.capacity}" />
+      <env key="UNIT_TARGET_LUN" value="${unit.target.lun}" />
+
+      <env key="UNIT_VM_GUID" value="${unit.vm.guid}" />
+      <env key="UNIT_LUN_GUID" value="${unit.lun.guid}" />
+    </exec>
+    <echo message="after create lun: exit code ${code}, ${create.lun.output}" />
+
+    <property name="shirako.target.code" value="${code}" />
+    <property name="shirako.target.code.message" value="${create.lun.output}" />
+  </else></if> <!-- end of else for emulation -->
+  <echo message="join exit code: ${shirako.target.code}" />
+  </target>
+  
+  <!-- Modify operation is not supported -->
+  <target name="modify" />
+
+
+  <!-- Leave operation -->
+  <target name="leave" depends="resolve.configuration">
+    <tstamp prefix="start">
+      <format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+    </tstamp>
+    
+    <echo message="STORAGE SERVICE HANDLER: LEAVE on ${start.TIME}" />
+
+    <!--<property file="test.properties" />-->
+    <if>
+      <isset property="storage_service.site.properties" />
+      <then>
+        <property file="${storage_service.site.properties}" />
+      </then>
+    </if>
+
+
+    <!-- Echo statments for log and emulation mode -->
+    <echo message="STORAGE_SERVICE_DIR=${storage_service.dir}" />
+    <echo message="STORAGE_SERVICE_LOG_DIR=${storage_service.log.dir}" />
+    <echo message="STORAGE_SERVICE_LOG_FILE=${storage_service.log.file}" />
+    <echo message="STORAGE_SERVICE_LOG_LEVEL=${storage_service.log.level}" />
+    <echo message="STORAGE_SERVICE_CONNECTION_TIMEOUT=${storage_service.connection.timeout}" />
+    <echo message="STORAGE_SERVICE_REQUEST_TIMEOUT=${storage_service.request.timeout}" />
+
+    <echo message="STORAGE_SERVICE_IP=${storage_service.ip}" />
+    <echo message="STORAGE_SERVICE_PORT=${storage_service.port}" />
+    <echo message="STORAGE_SERVICE_USERNAME=${storage_service.username}" />
+    <echo message="STORAGE_SERVICE_PASSWORD=${storage_service.password}" />
+  
+    <echo message="UNIT_LUN_GUID=${unit.lun.guid}" />
+
+
+    <!-- If in emulation then exit without doing anything -->
+    <if>
+      <equals arg1="${emulation}" arg2="true" />
+      <then>
+        <echo message="Emulation mode...exiting" />
+        <property name="shirako.target.code" value="0" />
+      </then>
+      <else>
+
+
+	<echo message="deleting LUN ...(may take some time)" />
+        <var name="delete.lun.output" unset="true" />
+        <var name="code" unset="true" />
+        <var name="message" unset="true" />
+	
+        <echo message="before delete lun" />
+        <exec executable="${storage_service.scripts}/storage_service-delete-lun"
+              resultproperty="code" outputproperty="delete.lun.output">
+          <env key="STORAGE_SERVICE_DIR" value="${storage_service.dir}" />
+          <env key="STORAGE_SERVICE_LOG_DIR" value="${storage_service.log.dir}" />
+          <env key="STORAGE_SERVICE_LOG_FILE" value="${storage_service.log.file}" />
+          <env key="STORAGE_SERVICE_LOG_LEVEL" value="${storage_service.log.level}" />
+          <env key="STORAGE_SERVICE_CONNECTION_TIMEOUT" value="${storage_service.connection.timeout}" />
+          <env key="STORAGE_SERVICE_REQUEST_TIMEOUT" value="${storage_service.request.timeout}" />
+          
+          <env key="STORAGE_SERVICE_IP" value="${storage_service.ip}" />
+          <env key="STORAGE_SERVICE_PORT" value="${storage_service.port}" />
+          <env key="STORAGE_SERVICE_USERNAME" value="${storage_service.username}" />
+          <env key="STORAGE_SERVICE_PASSWORD" value="${storage_service.password}" />
+          
+          <env key="UNIT_LUN_GUID" value="${unit.lun.guid}" />
+        </exec>
+        <echo message="after delete lun: exit code ${code}, ${delete.lun.output}" />
+
+        <property name="shirako.target.code" value="${code}" />
+        <property name="shirako.target.code.message" value="${delete.lun.output}" />
+      </else> </if> <!-- end of else for emulation -->
+    <echo message="leave exit code: ${shirako.target.code}" />
+  </target>
 </project>

--- a/handlers/xcat/resources/handlers/xcat/handler.xml
+++ b/handlers/xcat/resources/handlers/xcat/handler.xml
@@ -1,446 +1,585 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../common/core.xml">
+<!ENTITY paths SYSTEM "../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../providers/ben.no-na.tasks.xml">
+]>
+
 <project name="xcat" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <target name="join" depends="resolve.configuration, ben.load.tasks"> 
-        <taskdef resource="orca/handlers/xcat/xcat.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="XCAT HANDLER: JOIN on ${start.TIME}" /> 
-        <!-- see xcat.site.sample.properties and wiki for description of static 
-			properties that can be specified in xcat.site.properties --> 
-        <if> 
-            <isset property="xcat.site.properties" /> 
-            <then> 
-                <property file="${xcat.site.properties}" /> 
-            </then> 
-        </if> 
-        <echo message="user ssh key: ${config.ssh.key}" /> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <echo message="initiatorid=${unit.iscsi.initiator.iqn}" /> 
-                <tempfile property="xcat.bash.file" destdir="${java.io.tmpdir}" prefix="xcat.bash" suffix=".bash" deleteonexit="true" /> 
-                <xcat.generate.bash.file file="${xcat.bash.file}" interfaceMap="${xcat.interface.map}" /> 
-                <loadfile property="xcat.bash" srcFile="${xcat.bash.file}" /> 
-                <echo message="BASH file: ${xcat.bash}" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <!-- <tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" 
-					prefix="neuca" suffix=".ini" deleteonexit="true" /> --> 
-                <!-- create the below as a template for installing dataplane interfaces --> 
-                <!-- FIXME: Determine a way to expose what images a site has available --> 
-                <echo message="Using statically specified image: ${xcat.image.name} " /> 
-                <echo message="Provisioning bare metal node ${unit.hostname.url} using image ${xcat.image.name} ... (this will take some time)" /> 
-                <var name="create.instance.output" unset="true"></var> 
-                <var name="code" unset="true"></var> 
-                <var name="message" unset="true"></var> 
-                <echo message="Running: ${xcat.scripts}/findfreenode.sh " /> 
-                <echo message="SLICE_ID=${unit.sliceid}" /> 
-                <echo message="XCAT_BAREMETAL_GROUP=${xcat.baremetal.group}" /> 
-                <atomic.sequence.start.macro device="${xcat.baremetal.group}" /> 
-                <exec executable="${xcat.scripts}/findfreenode.sh" resultproperty="code" outputproperty="create.instance.output"> 
-                    <env key="SLICE_ID" value="${unit.sliceid}" /> 
-                    <env key="XCAT_BAREMETAL_GROUP" value="${xcat.baremetal.group}" /> 
-                </exec> 
-                <atomic.sequence.stop.macro device="${xcat.baremetal.group}" /> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="Unable to allocate a free bare metal node: exit code ${code}, ${create.instance.output}" /> 
-                        <property name="message" value="Unable to allocate a bare metal node: exit code ${code}, ${create.instance.output}" /> 
-                        <property name="shirako.target.code" value="${code}" /> 
-                    </then> 
-                    <else> 
-                        <var name="shirako.save.unit.xcat.nodename" unset="true"></var> 
-                        <property name="shirako.save.unit.xcat.nodename" value="${create.instance.output}" /> 
-                        <echo message="Running: ${xcat.scripts}/start.sh ${shirako.save.unit.xcat.nodename}" /> 
-                        <echo message="XCAT_IMAGE_NAME=${xcat.image.name}" /> 
-                        <echo message="XCAT_CONF_DIR=${xcat.conf.dir}" /> 
-                        <echo message="XCAT_SSH_KEY=${xcat.ssh.key}" /> 
-                        <echo message="XCAT_PROVISION_MAXWAIT=${xcat.provision.maxwait}" /> 
-                        <echo message="XCAT_PING_RETRIES=${xcat.ping.retries}" /> 
-                        <echo message="XCAT_SSH_RETRIES=${xcat.ssh.retries}" /> 
-                        <var name="create.instance.output" unset="true"></var> 
-                        <var name="code" unset="true"></var> 
-                        <var name="message" unset="true"></var> 
-                        <exec executable="${xcat.scripts}/start.sh" resultproperty="code" outputproperty="create.instance.output"> 
-                            <!-- <env key="NEUCA_INI" value="${neuca.ini.file}" /> --> 
-                            <env key="XCAT_IMAGE_NAME" value="${xcat.image.name}" /> 
-                            <env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" /> 
-                            <env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" /> 
-                            <env key="XCAT_PROVISION_MAXWAIT" value="${xcat.provision.maxwait}" /> 
-                            <env key="XCAT_PING_RETRIES" value="${xcat.ping.retries}" /> 
-                            <env key="XCAT_SSH_RETRIES" value="${xcat.ssh.retries}" /> 
-                            <arg value="${shirako.save.unit.xcat.nodename}" /> 
-                        </exec> 
-                        <if> 
-                            <not> 
-                                <equals arg1="${code}" arg2="0" /> 
-                            </not> 
-                            <then> 
-                                <echo message="Unable to provision bare metal node: exit code ${code}, ${create.instance.output}" /> 
-                                <property name="message" value="Unable to provision bare metal node: exit code ${code}, ${create.instance.output}" /> 
-                                <property name="shirako.target.code" value="${code}" /> 
-                                <var name="create.instance.output" unset="true"></var> 
-                                <var name="code" unset="true"></var> 
-                                <atomic.sequence.start.macro device="${xcat.baremetal.group}" /> 
-                                <exec executable="${xcat.scripts}/returnnode.sh" resultproperty="code" outputproperty="create.instance.output"> 
-                                    <arg value="${shirako.save.unit.xcat.nodename}" /> 
-                                </exec> 
-                                <atomic.sequence.stop.macro device="${xcat.baremetal.group}" /> 
-                                <if> 
-                                    <not> 
-                                        <equals arg1="${code}" arg2="0" /> 
-                                    </not> 
-                                    <then> 
-                                        <echo message="Error encountered while returning bare metal node to free node pool: exit code ${code}, ${create.instance.output}" /> 
-                                    </then> 
-                                </if> 
-                            </then> 
-                            <else> 
-                                <!-- hairpin the hostname property so the user sees it too --> 
-                                <var name="shirako.save.unit.hostname.url" unset="true"></var> 
-                                <property name="shirako.save.unit.hostname.url" value="${unit.hostname.url}" /> 
-                                <echo message="provision-node exit code: ${code} nodename=${shirako.save.unit.xcat.nodename}" /> 
-                                <echo message="Obtaining management IP address for bare metal node ${shirako.save.unit.xcat.nodename}" /> 
-                                <var name="code" unset="true"></var> 
-                                <exec executable="${xcat.scripts}/get-ip.sh" resultproperty="code" outputproperty="shirako.save.unit.manage.ip"> 
-                                    <arg value="${shirako.save.unit.xcat.nodename}" /> 
-                                </exec> 
-                                <echo message="get-ip exit code: ${code} ip=${shirako.save.unit.manage.ip}" /> 
-                                <property name="shirako.target.code" value="${code}" /> 
-                                <!-- set the user's private key, if needed --> 
-                                <if> 
-                                    <isset property="shirako.save.unit.manage.ip" /> 
-                                    <then> 
-                                        <echo message="Installing ${config.ssh.numlogins} user keys and accounts in the bare-metal node ${shirako.save.unit.xcat.nodename}" /> 
-                                        <var name="code" unset="true"></var> 
-                                        <for list="${config.ssh.numlogins}" param="iter" delimiter="," parallel="false"> 
-                                            <sequential> 
-                                                <var name="icode" unset="true"></var> 
-                                                <var name="loginProperty" unset="true"></var> 
-                                                <var name="keysProperty" unset="true"></var> 
-                                                <property name="loginProperty" value="${config.ssh.user@{iter}.login}" /> 
-                                                <property name="keysProperty" value="${config.ssh.user@{iter}.keys}" /> 
-                                                <echo message="Creating account for user ${loginProperty}" /> 
-                                                <exec executable="${xcat.scripts}/prepare-key.sh" resultproperty="icode"> 
-                                                    <env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" /> 
-                                                    <env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" /> 
-                                                    <arg value="${shirako.save.unit.xcat.nodename}" /> 
-                                                    <arg value="'${loginProperty}'" /> 
-                                                    <arg value="'${keysProperty}'" /> 
-                                                </exec> 
-                                                <echo message="Exit code ${icode}" /> 
-                                            </sequential> 
-                                        </for> 
-                                        <echo message="Generating BASH script for the node" /> 
-                                        <tempfile property="xcat.bash.file" destdir="${java.io.tmpdir}" prefix="xcat.bash" suffix=".bash" deleteonexit="true" /> 
-                                        <!-- create the BASH file --> 
-                                        <xcat.generate.bash.file file="${xcat.bash.file}" interfaceMap="${xcat.interface.map}" /> 
-                                        <loadfile property="xcat.bash" srcFile="${xcat.bash.file}" /> 
-                                        <echo message="BASH file: ${xcat.bash}" /> 
-                                        <echo message="Copying and executing the script on node ${shirako.save.unit.xcat.nodename}" /> 
-                                        <var name="code" unset="true"></var> 
-                                        <exec executable="${xcat.scripts}/post-boot.sh" resultproperty="code"> 
-                                            <env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" /> 
-                                            <env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" /> 
-                                            <env key="XCAT_NODE_SCRIPT" value="${xcat.bash.file}" /> 
-                                            <arg value="${shirako.save.unit.xcat.nodename}" /> 
-                                        </exec> 
-                                        <delete file="${xcat.bash.file}" /> 
-                                        <!-- default port is SSH --> 
-                                        <property name="shirako.save.unit.manage.port" value="22" /> 
-                                        <property name="shirako.target.code" value="${code}" /> 
-                                    </then> 
-                                </if> 
-                            </else> 
-                        </if> 
-                    </else> 
-                </if> 
-                <if> 
-                    <isset property="message" /> 
-                    <then> 
-                        <property name="shirako.target.code.message" value="${message}" /> 
-                    </then> 
-                    <else> 
-                        <property name="shirako.target.code.message" value="none" /> 
-                    </else> 
-                </if> 
-                <echo message="join exit code: ${shirako.target.code} with message: ${shirako.target.code.message}" /> 
-            </else> 
-        </if> 
-    </target> 
-    <!-- add iface macro --> 
-    <macrodef name="modify.addiface" description="add a new network iface via modify"> 
-        <attribute name="seqnum" description="sequence number" /> 
-        <sequential> 
-            <if> 
-                <equals arg1="${emulation}" arg2="true" /> 
-                <then> 
-                    <echo message="Running under emulation...exiting" /> 
-                    <echoproperties /> 
-                    <property name="shirako.target.code" value="0" /> 
-                </then> 
-                <else> 
-                    <!-- Actually do it... no emulation --> 
-                    <echo message="adding interfaces to instance" /> 
-                    <var name="message" unset="true"></var> 
-                    <echo message="vlan.tag = ${modify.@{seqnum}.vlan.tag}" /> 
-                    <echo message="ip = ${modify.@{seqnum}.ip}" /> 
-                    <echo message="mode = ${modify.@{seqnum}.mode}" /> 
-                    <echo message="state = ${modify.@{seqnum}.state}" /> 
-                    <echo message="ipversion = ${modify.@{seqnum}.ipversion}" /> 
-                    <!-- CONSTRUCT NEW SCRIPT TO EXECUTE INTERFACE UPDATE ON BARE-METAL NODE --> 
-                    <echo message="Generating BASH modify-addiface script for the node" /> 
-                    <var name="xcat.bash.file" unset="true"></var> 
-                    <tempfile property="xcat.bash.file" destdir="${java.io.tmpdir}" prefix="xcat.bash.mod@{seqnum}." suffix=".bash" deleteonexit="true" /> 
-                    <!-- create the BASH file --> 
-                    <xcat.generate.bash.mod.addiface.file file="${xcat.bash.file}" modifyIndex="@{seqnum}" interfaceMap="${xcat.interface.map}" /> 
-                    <var name="xcat.bash" unset="true"></var> 
-                    <loadfile property="xcat.bash" srcFile="${xcat.bash.file}" /> 
-                    <echo message="BASH file: ${xcat.bash}" /> 
-                    <echo message="Copying and executing the modify-addiface script on node ${unit.xcat.nodename} ip ${unit.manage.ip}" /> 
-                    <var name="code" unset="true"></var> 
-                    <exec executable="${xcat.scripts}/post-boot.sh" resultproperty="code"> 
-                        <env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" /> 
-                        <env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" /> 
-                        <env key="XCAT_NODE_SCRIPT" value="${xcat.bash.file}" /> 
-                        <arg value="${unit.manage.ip}" /> 
-                    </exec> 
-                    <delete file="${xcat.bash.file}" /> 
-                    <echo>
-                         result code: ${code} 
-                    </echo> 
-                </else> 
-            </if> 
-        </sequential> 
-    </macrodef> 
-    <!-- add network interface --> 
-    <target name="modify.addiface" depends="resolve.configuration"> 
-        <taskdef resource="orca/handlers/xcat/xcat.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <if> 
-            <isset property="xcat.site.properties" /> 
-            <then> 
-                <echo message="Setting xcat.site.properties from ${xcat.site.properties}" /> 
-                <property file="${xcat.site.properties}" /> 
-            </then> 
-        </if> 
-        <var name="code" unset="true"></var> 
-        <var name="message" unset="true"></var> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="XCAT HANDLER: MODIFY.ADDIFACE on ${start.TIME}" /> 
-        <echo message="modify.addiface: xcat node=${unit.xcat.nodename}, ip=${unit.manage.ip}, modify sequence number ${shirako.save.unit.modify.sequencenum}" /> 
-        <modify.addiface seqnum="${shirako.save.unit.modify.sequencenum}" /> 
-        <property name="shirako.target.code" value="0" /> 
-        <echo message="modify.addiface exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- remove iface macro --> 
-    <macrodef name="modify.removeiface" description="remove a new network iface via modify"> 
-        <attribute name="seqnum" description="sequence number" /> 
-        <sequential> 
-            <if> 
-                <equals arg1="${emulation}" arg2="true" /> 
-                <then> 
-                    <echo message="Running under emulation...exiting" /> 
-                    <echoproperties /> 
-                    <property name="shirako.target.code" value="0" /> 
-                </then> 
-                <else> 
-                    <!-- Actually do it... no emulation --> 
-                    <echo message="removing interfaces to instance" /> 
-                    <var name="message" unset="true"></var> 
-                    <!-- CONSTRUCT NEW SCRIPT TO EXECUTE INTERFACE UPDATE ON BARE-METAL NODE --> 
-                    <echo message="Generating BASH modify-removeiface script for the node" /> 
-                    <var name="xcat.bash.file" unset="true"></var> 
-                    <tempfile property="xcat.bash.file" destdir="${java.io.tmpdir}" prefix="xcat.bash.mod@{seqnum}." suffix=".bash" deleteonexit="true" /> 
-                    <!-- create the BASH file --> 
-                    <xcat.generate.bash.mod.remiface.file file="${xcat.bash.file}" modifyIndex="@{seqnum}" interfaceMap="${xcat.interface.map}" /> 
-                    <var name="xcat.bash" unset="true"></var> 
-                    <loadfile property="xcat.bash" srcFile="${xcat.bash.file}" /> 
-                    <echo message="BASH file: ${xcat.bash}" /> 
-                    <echo message="Copying and executing the modify-removeiface script on node ${unit.xcat.nodename} ip ${unit.manage.ip}" /> 
-                    <var name="code" unset="true"></var> 
-                    <exec executable="${xcat.scripts}/post-boot.sh" resultproperty="code"> 
-                        <env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" /> 
-                        <env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" /> 
-                        <env key="XCAT_NODE_SCRIPT" value="${xcat.bash.file}" /> 
-                        <arg value="${unit.manage.ip}" /> 
-                    </exec> 
-                    <delete file="${xcat.bash.file}" /> 
-                    <echo>
-                         result code: ${code} 
-                    </echo> 
-                </else> 
-            </if> 
-        </sequential> 
-    </macrodef> 
-    <!-- remove network interface --> 
-    <target name="modify.removeiface" depends="resolve.configuration"> 
-        <taskdef resource="orca/handlers/xcat/xcat.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <if> 
-            <isset property="xcat.site.properties" /> 
-            <then> 
-                <echo message="Setting xcat.site.properties from ${xcat.site.properties}" /> 
-                <property file="${xcat.site.properties}" /> 
-            </then> 
-        </if> 
-        <var name="code" unset="true"></var> 
-        <var name="message" unset="true"></var> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="XCAT HANDLER: MODIFY.REMOVEIFACE on ${start.TIME}" /> 
-        <echo message="modify.removeiface: xcat node=${unit.xcat.nodename}, ip=${unit.manage.ip}, modify sequence number ${shirako.save.unit.modify.sequencenum}" /> 
-        <modify.removeiface seqnum="${shirako.save.unit.modify.sequencenum}" /> 
-        <property name="shirako.target.code" value="0" /> 
-        <echo message="modify.removeiface exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- Useful macros --> 
-    <macrodef name="modify.ssh" description="install new SSH keys via modify"> 
-        <attribute name="seqnum" description="sequence number" /> 
-        <sequential> 
-            <if> 
-                <equals arg1="${emulation}" arg2="true" /> 
-                <then> 
-                    <for list="${modify.@{seqnum}.config.ssh.numlogins}" param="iter" delimiter="," parallel="false"> 
-                        <sequential> 
-                            <var name="loginProperty" unset="true"></var> 
-                            <var name="keysProperty" unset="true"></var> 
-                            <var name="sudoProperty" unset="true"></var> 
-                            <property name="loginProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.login}" /> 
-                            <property name="keysProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.keys}" /> 
-                            <property name="sudoProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.sudo}" /> 
-                            <echo message="About to create account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" /> 
-                        </sequential> 
-                    </for> 
-                    <echo message="Running under emulation...exiting" /> 
-                    <property name="shirako.target.code" value="0" /> 
-                </then> 
-                <else> 
-                    <echo message="installing ${modify.@{seqnum}.config.ssh.numlogins} user keys and accounts in the instance" /> 
-                    <var name="message" unset="true"></var> 
-                    <!-- add keys --> 
-                    <echo message="Modify.ssh, numlogins : ${modify.@{seqnum}.config.ssh.numlogins} " /> 
-                    <for list="${modify.@{seqnum}.config.ssh.numlogins}" param="iter" delimiter="," parallel="false"> 
-                        <sequential> 
-                            <var name="icode" unset="true"></var> 
-                            <var name="loginProperty" unset="true"></var> 
-                            <var name="keysProperty" unset="true"></var> 
-                            <var name="sudoProperty" unset="true"></var> 
-                            <property name="loginProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.login}" /> 
-                            <property name="keysProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.keys}" /> 
-                            <property name="sudoProperty" value="${modify.@{seqnum}.config.ssh.user@{iter}.sudo}" /> 
-                            <echo message="Creating account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" /> 
-                            <echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" /> 
-                            <echo message="LoginProperty : ${loginProperty}" /> 
-                            <echo message="KeysProperty : ${keysProperty}" /> 
-                            <echo message="SudoProperty : ${sudoProperty}" /> 
-                            <!-- add key to VM --> 
-                            <exec executable="${xcat.scripts}/prepare-key.sh" resultproperty="icode"> 
-                                <env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" /> 
-                                <env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" /> 
-                                <arg value="${unit.manage.ip}" /> 
-                                <arg value="'${loginProperty}'" /> 
-                                <arg value="'${keysProperty}'" /> 
-                            </exec> 
-                            <echo message="Exit code for login ${loginProperty} is ${icode}" /> 
-                            <if> 
-                                <not> 
-                                    <equals arg1="${icode}" arg2="0" /> 
-                                </not> 
-                                <then> 
-                                    <fail message="Unable to create account ${loginProperty}, failing" /> 
-                                </then> 
-                            </if> 
-                        </sequential> 
-                    </for> 
-                    <echo message="after update userdata: exit code ${code}, ${update.userdata.output}" /> 
-                    <delete file="${neuca.ini.file}" /> 
-                </else> 
-            </if> 
-        </sequential> 
-    </macrodef> 
-    <!-- add logins --> 
-    <target name="modify.ssh" depends="resolve.configuration"> 
-        <taskdef resource="orca/handlers/xcat/xcat.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <if> 
-            <isset property="xcat.site.properties" /> 
-            <then> 
-                <echo message="Setting xcat.site.properites from ${xcat.site.properties}" /> 
-                <property file="${xcat.site.properties}" /> 
-            </then> 
-        </if> 
-        <var name="code" unset="true"></var> 
-        <var name="message" unset="true"></var> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="XCAT HANDLER: MODIFY.SSH on ${start.TIME}" /> 
-        <echo message="modify.ssh: xcat node=${unit.xcat.nodename}, ip=${unit.manage.ip}, modify sequence number ${shirako.save.unit.modify.sequencenum}" /> 
-        <modify.ssh seqnum="${shirako.save.unit.modify.sequencenum}" /> 
-        <property name="shirako.target.code" value="0" /> 
-        <echo message="modify.ssh exit code: ${shirako.target.code}" /> 
-    </target> 
-    <!-- leave --> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <taskdef resource="orca/handlers/xcat/xcat.xml" classpathref="run.classpath" loaderref="run.classpath.loader" /> 
-        <tstamp prefix="start"> 
-            <format property="TIME" pattern="MM/dd/yyyy hh:mm" /> 
-        </tstamp> 
-        <echo message="XCAT HANDLER: LEAVE on ${start.TIME}" /> 
-        <echo message="leave: bare metal node=${unit.xcat.nodename}" /> 
-        <!-- set site-specific properties like the VLAN or PHYS mode and the interface 
-			to operate on --> 
-        <if> 
-            <isset property="xcat.site.properties" /> 
-            <then> 
-                <property file="${xcat.site.properties}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <equals arg1="${emulation}" arg2="true" /> 
-            <then> 
-                <echo message="running under emulation...exiting" /> 
-                <property name="shirako.target.code" value="0" /> 
-            </then> 
-            <else> 
-                <var name="code" unset="true"></var> 
-                <var name="terminate.instance.output" unset="true"></var> 
-                <echo message="De-provisioning bare metal node: ${unit.xcat.nodename}" /> 
-                <exec executable="${xcat.scripts}/stop.sh" resultproperty="code" outputproperty="terminate.instance.output"> 
-                    <arg value="${unit.xcat.nodename}" /> 
-                </exec> 
-                <echo message="deprovision-node exit code: ${code}; ${terminate.instance.output}" /> 
-                <property name="shirako.target.code" value="${code}" /> 
-                <var name="code" unset="true"></var> 
-                <var name="terminate.instance.output" unset="true"></var> 
-                <atomic.sequence.start.macro device="${xcat.baremetal.group}" /> 
-                <exec executable="${xcat.scripts}/returnnode.sh" resultproperty="code" outputproperty="terminate.instance.output"> 
-                    <arg value="${unit.xcat.nodename}" /> 
-                </exec> 
-                <atomic.sequence.stop.macro device="${xcat.baremetal.group}" /> 
-                <if> 
-                    <not> 
-                        <equals arg1="${code}" arg2="0" /> 
-                    </not> 
-                    <then> 
-                        <echo message="Error encountered while returning bare metal node to free node pool: exit code ${code}, ${terminate.instance.output}" /> 
-                        <property name="shirako.target.code" value="${code}" /> 
-                    </then> 
-                </if> 
-            </else> 
-        </if> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
+
+  &paths;
+  &core;
+  &drivertasks;	
+  &bentasks;
+
+	<target name="join" depends="resolve.configuration, ben.load.tasks">
+		<taskdef resource="orca/handlers/xcat/xcat.xml" classpathref="run.classpath"
+			loaderref="run.classpath.loader" />
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+		<echo message="XCAT HANDLER: JOIN on ${start.TIME}" />
+		<!-- see xcat.site.sample.properties and wiki for description of static 
+			properties that can be specified in xcat.site.properties -->
+		<if>
+			<isset property="xcat.site.properties" />
+			<then>
+				<property file="${xcat.site.properties}" />
+			</then>
+		</if>
+
+		<echo message="user ssh key: ${config.ssh.key}" />
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<echo message="initiatorid=${unit.iscsi.initiator.iqn}" />
+				<tempfile property="xcat.bash.file" destdir="${java.io.tmpdir}"
+					prefix="xcat.bash" suffix=".bash" deleteonexit="true" />
+				<xcat.generate.bash.file file="${xcat.bash.file}"
+					interfaceMap="${xcat.interface.map}" />
+				<loadfile property="xcat.bash" srcFile="${xcat.bash.file}" />
+				<echo message="BASH file: ${xcat.bash}" />
+
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<!-- <tempfile property="neuca.ini.file" destdir="${java.io.tmpdir}" 
+					prefix="neuca" suffix=".ini" deleteonexit="true" /> -->
+				<!-- create the below as a template for installing dataplane interfaces -->
+
+				<!-- FIXME: Determine a way to expose what images a site has available -->
+				<echo message="Using statically specified image: ${xcat.image.name} " />
+
+				<echo
+					message="Provisioning bare metal node ${unit.hostname.url} using image ${xcat.image.name} ... (this will take some time)" />
+				<var name="create.instance.output" unset="true" />
+				<var name="code" unset="true" />
+				<var name="message" unset="true" />
+
+				<echo message="Running: ${xcat.scripts}/findfreenode.sh " />
+				<echo message="SLICE_ID=${unit.sliceid}" />
+				<echo message="XCAT_BAREMETAL_GROUP=${xcat.baremetal.group}" />
+
+				<atomic.sequence.start.macro device="${xcat.baremetal.group}" />
+				<exec executable="${xcat.scripts}/findfreenode.sh"
+					resultproperty="code" outputproperty="create.instance.output">
+					<env key="SLICE_ID" value="${unit.sliceid}" />
+					<env key="XCAT_BAREMETAL_GROUP" value="${xcat.baremetal.group}" />
+				</exec>
+				<atomic.sequence.stop.macro device="${xcat.baremetal.group}" />
+
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo
+							message="Unable to allocate a free bare metal node: exit code ${code}, ${create.instance.output}" />
+						<property name="message"
+							value="Unable to allocate a bare metal node: exit code ${code}, ${create.instance.output}" />
+						<property name="shirako.target.code" value="${code}" />
+					</then>
+					<else>
+						<var name="shirako.save.unit.xcat.nodename" unset="true" />
+						<property name="shirako.save.unit.xcat.nodename" value="${create.instance.output}" />
+
+						<echo
+							message="Running: ${xcat.scripts}/start.sh ${shirako.save.unit.xcat.nodename}" />
+						<echo message="XCAT_IMAGE_NAME=${xcat.image.name}" />
+						<echo message="XCAT_CONF_DIR=${xcat.conf.dir}" />
+						<echo message="XCAT_SSH_KEY=${xcat.ssh.key}" />
+						<echo message="XCAT_PROVISION_MAXWAIT=${xcat.provision.maxwait}" />
+						<echo message="XCAT_PING_RETRIES=${xcat.ping.retries}" />
+						<echo message="XCAT_SSH_RETRIES=${xcat.ssh.retries}" />
+
+						<var name="create.instance.output" unset="true" />
+						<var name="code" unset="true" />
+						<var name="message" unset="true" />
+						<exec executable="${xcat.scripts}/start.sh" resultproperty="code"
+							outputproperty="create.instance.output">
+							<!-- <env key="NEUCA_INI" value="${neuca.ini.file}" /> -->
+							<env key="XCAT_IMAGE_NAME" value="${xcat.image.name}" />
+							<env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" />
+							<env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" />
+							<env key="XCAT_PROVISION_MAXWAIT" value="${xcat.provision.maxwait}" />
+							<env key="XCAT_PING_RETRIES" value="${xcat.ping.retries}" />
+							<env key="XCAT_SSH_RETRIES" value="${xcat.ssh.retries}" />
+							<arg value="${shirako.save.unit.xcat.nodename}" />
+						</exec>
+
+						<if>
+							<not>
+								<equals arg1="${code}" arg2="0" />
+							</not>
+							<then>
+								<echo
+									message="Unable to provision bare metal node: exit code ${code}, ${create.instance.output}" />
+								<property name="message"
+									value="Unable to provision bare metal node: exit code ${code}, ${create.instance.output}" />
+								<property name="shirako.target.code" value="${code}" />
+
+								<var name="create.instance.output" unset="true" />
+								<var name="code" unset="true" />
+								<atomic.sequence.start.macro device="${xcat.baremetal.group}" />
+								<exec executable="${xcat.scripts}/returnnode.sh"
+									resultproperty="code" outputproperty="create.instance.output">
+									<arg value="${shirako.save.unit.xcat.nodename}" />
+								</exec>
+								<atomic.sequence.stop.macro device="${xcat.baremetal.group}" />
+								<if>
+									<not>
+										<equals arg1="${code}" arg2="0" />
+									</not>
+									<then>
+										<echo
+											message="Error encountered while returning bare metal node to free node pool: exit code ${code}, ${create.instance.output}" />
+									</then>
+								</if>
+							</then>
+							<else>
+								<!-- hairpin the hostname property so the user sees it too -->
+								<var name="shirako.save.unit.hostname.url" unset="true" />
+								<property name="shirako.save.unit.hostname.url" value="${unit.hostname.url}" />
+
+								<echo
+									message="provision-node exit code: ${code} nodename=${shirako.save.unit.xcat.nodename}" />
+								<echo
+									message="Obtaining management IP address for bare metal node ${shirako.save.unit.xcat.nodename}" />
+
+								<var name="code" unset="true" />
+								<exec executable="${xcat.scripts}/get-ip.sh"
+									resultproperty="code" outputproperty="shirako.save.unit.manage.ip">
+									<arg value="${shirako.save.unit.xcat.nodename}" />
+								</exec>
+								<echo
+									message="get-ip exit code: ${code} ip=${shirako.save.unit.manage.ip}" />
+								<property name="shirako.target.code" value="${code}" />
+
+								<!-- set the user's private key, if needed -->
+								<if>
+									<isset property="shirako.save.unit.manage.ip" />
+									<then>
+										<echo
+											message="Installing ${config.ssh.numlogins} user keys and accounts in the bare-metal node ${shirako.save.unit.xcat.nodename}" />
+
+										<var name="code" unset="true" />
+
+										<for list="${config.ssh.numlogins}" param="iter"
+											delimiter="," parallel="false">
+											<sequential>
+												<var name="icode" unset="true" />
+
+												<var name="loginProperty" unset="true" />
+												<var name="keysProperty" unset="true" />
+
+												<property name="loginProperty" value="${config.ssh.user@{iter}.login}" />
+												<property name="keysProperty" value="${config.ssh.user@{iter}.keys}" />
+
+												<echo message="Creating account for user ${loginProperty}" />
+
+												<exec executable="${xcat.scripts}/prepare-key.sh"
+													resultproperty="icode">
+													<env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" />
+													<env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" />
+													<arg value="${shirako.save.unit.xcat.nodename}" />
+													<arg value="'${loginProperty}'" />
+													<arg value="'${keysProperty}'" />
+												</exec>
+												<echo message="Exit code ${icode}" />
+											</sequential>
+										</for>
+
+										<echo message="Generating BASH script for the node" />
+										<tempfile property="xcat.bash.file" destdir="${java.io.tmpdir}"
+											prefix="xcat.bash" suffix=".bash" deleteonexit="true" />
+										<!-- create the BASH file -->
+										<xcat.generate.bash.file file="${xcat.bash.file}"
+											interfaceMap="${xcat.interface.map}" />
+										<loadfile property="xcat.bash" srcFile="${xcat.bash.file}" />
+										<echo message="BASH file: ${xcat.bash}" />
+
+										<echo
+											message="Copying and executing the script on node ${shirako.save.unit.xcat.nodename}" />
+										<var name="code" unset="true" />
+										<exec executable="${xcat.scripts}/post-boot.sh"
+											resultproperty="code">
+											<env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" />
+											<env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" />
+											<env key="XCAT_NODE_SCRIPT" value="${xcat.bash.file}" />
+											<arg value="${shirako.save.unit.xcat.nodename}" />
+										</exec>
+
+										<delete file="${xcat.bash.file}" />
+
+										<!-- default port is SSH -->
+										<property name="shirako.save.unit.manage.port" value="22" />
+										<property name="shirako.target.code" value="${code}" />
+									</then>
+								</if>
+							</else>
+						</if>
+					</else>
+				</if>
+				<if>
+					<isset property="message" />
+					<then>
+						<property name="shirako.target.code.message" value="${message}" />
+					</then>
+					<else>
+						<property name="shirako.target.code.message" value="none" />
+					</else>
+				</if>
+				<echo
+					message="join exit code: ${shirako.target.code} with message: ${shirako.target.code.message}" />
+			</else>
+		</if>
+	</target>
+
+	<!-- add iface macro -->
+	<macrodef name="modify.addiface" description="add a new network iface via modify">
+		<attribute name="seqnum" description="sequence number" />
+
+		<sequential>
+			<if>
+				<equals arg1="${emulation}" arg2="true" />
+				<then>
+					<echo message="Running under emulation...exiting" />
+					<echoproperties/>
+					<property name="shirako.target.code" value="0" />
+				</then>
+				<else>
+					<!-- Actually do it... no emulation -->
+					<echo message="adding interfaces to instance" />
+					<var name="message" unset="true" />
+
+					<echo message="vlan.tag = ${modify.@{seqnum}.vlan.tag}" />
+					<echo message="ip = ${modify.@{seqnum}.ip}" />
+					<echo message="mode = ${modify.@{seqnum}.mode}" />
+					<echo message="state = ${modify.@{seqnum}.state}" />
+					<echo message="ipversion = ${modify.@{seqnum}.ipversion}" />
+
+					<!-- CONSTRUCT NEW SCRIPT TO EXECUTE INTERFACE UPDATE ON BARE-METAL NODE -->
+				
+					<echo message="Generating BASH modify-addiface script for the node" />
+					<var name="xcat.bash.file" unset="true" />
+					<tempfile property="xcat.bash.file" destdir="${java.io.tmpdir}"
+						prefix="xcat.bash.mod@{seqnum}." suffix=".bash" deleteonexit="true" />
+						
+					<!-- create the BASH file -->
+					<xcat.generate.bash.mod.addiface.file file="${xcat.bash.file}" modifyIndex="@{seqnum}"
+						interfaceMap="${xcat.interface.map}" />
+					<var name="xcat.bash" unset="true" />
+					
+					<loadfile property="xcat.bash" srcFile="${xcat.bash.file}" />
+					<echo message="BASH file: ${xcat.bash}" />
+				
+					<echo
+						message="Copying and executing the modify-addiface script on node ${unit.xcat.nodename} ip ${unit.manage.ip}" />
+					<var name="code" unset="true" />
+					<exec executable="${xcat.scripts}/post-boot.sh" resultproperty="code">
+						<env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" />
+						<env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" />
+						<env key="XCAT_NODE_SCRIPT" value="${xcat.bash.file}" />
+						<arg value="${unit.manage.ip}" />
+					</exec>
+				
+					<delete file="${xcat.bash.file}" />
+					
+					<echo>result code: ${code}</echo>
+				</else>
+			</if>
+		</sequential>
+	</macrodef>
+
+	<!-- add network interface -->
+	<target name="modify.addiface" depends="resolve.configuration">
+		<taskdef resource="orca/handlers/xcat/xcat.xml" classpathref="run.classpath"
+			loaderref="run.classpath.loader" />
+
+		<if>
+			<isset property="xcat.site.properties" />
+			<then>
+				<echo message="Setting xcat.site.properties from ${xcat.site.properties}" />
+				<property file="${xcat.site.properties}" />
+			</then>
+		</if>
+
+		<var name="code" unset="true" />
+		<var name="message" unset="true" />
+
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="XCAT HANDLER: MODIFY.ADDIFACE on ${start.TIME}" />
+		<echo
+			message="modify.addiface: xcat node=${unit.xcat.nodename}, ip=${unit.manage.ip}, modify sequence number ${shirako.save.unit.modify.sequencenum}" />
+
+		<modify.addiface seqnum="${shirako.save.unit.modify.sequencenum}" />
+
+		<property name="shirako.target.code" value="0" />
+		<echo message="modify.addiface exit code: ${shirako.target.code}" />
+	</target>
+
+
+	<!-- remove iface macro -->
+	<macrodef name="modify.removeiface" description="remove a new network iface via modify">
+		<attribute name="seqnum" description="sequence number" />
+
+		<sequential>
+			<if>
+				<equals arg1="${emulation}" arg2="true" />
+				<then>
+					<echo message="Running under emulation...exiting" />
+					<echoproperties/>
+					<property name="shirako.target.code" value="0" />
+				</then>
+				<else>
+					<!-- Actually do it... no emulation -->
+					<echo message="removing interfaces to instance" />
+					<var name="message" unset="true" />
+
+					<!-- CONSTRUCT NEW SCRIPT TO EXECUTE INTERFACE UPDATE ON BARE-METAL NODE -->
+				
+					<echo message="Generating BASH modify-removeiface script for the node" />
+					<var name="xcat.bash.file" unset="true" />
+					<tempfile property="xcat.bash.file" destdir="${java.io.tmpdir}"
+						prefix="xcat.bash.mod@{seqnum}." suffix=".bash" deleteonexit="true" />
+						
+					<!-- create the BASH file -->
+					<xcat.generate.bash.mod.remiface.file file="${xcat.bash.file}" modifyIndex="@{seqnum}"
+						interfaceMap="${xcat.interface.map}" />
+					<var name="xcat.bash" unset="true" />
+					
+					<loadfile property="xcat.bash" srcFile="${xcat.bash.file}" />
+					<echo message="BASH file: ${xcat.bash}" />
+				
+					<echo
+						message="Copying and executing the modify-removeiface script on node ${unit.xcat.nodename} ip ${unit.manage.ip}" />
+					<var name="code" unset="true" />
+					<exec executable="${xcat.scripts}/post-boot.sh" resultproperty="code">
+						<env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" />
+						<env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" />
+						<env key="XCAT_NODE_SCRIPT" value="${xcat.bash.file}" />
+						<arg value="${unit.manage.ip}" />
+					</exec>
+				
+					<delete file="${xcat.bash.file}" />
+					
+					<echo>result code: ${code}</echo>
+				</else>
+			</if>
+		</sequential>
+	</macrodef>
+
+	<!-- remove network interface -->
+	<target name="modify.removeiface" depends="resolve.configuration">
+		<taskdef resource="orca/handlers/xcat/xcat.xml" classpathref="run.classpath"
+			loaderref="run.classpath.loader" />
+			
+		<if>
+			<isset property="xcat.site.properties" />
+			<then>
+				<echo message="Setting xcat.site.properties from ${xcat.site.properties}" />
+				<property file="${xcat.site.properties}" />
+			</then>
+		</if>
+
+		<var name="code" unset="true" />
+		<var name="message" unset="true" />
+
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="XCAT HANDLER: MODIFY.REMOVEIFACE on ${start.TIME}" />
+		<echo
+			message="modify.removeiface: xcat node=${unit.xcat.nodename}, ip=${unit.manage.ip}, modify sequence number ${shirako.save.unit.modify.sequencenum}" />
+
+		<modify.removeiface seqnum="${shirako.save.unit.modify.sequencenum}" />
+
+		<property name="shirako.target.code" value="0" />
+		<echo message="modify.removeiface exit code: ${shirako.target.code}" />
+	</target>
+
+	<!-- Useful macros -->
+	<macrodef name="modify.ssh" description="install new SSH keys via modify">
+		<attribute name="seqnum" description="sequence number" />
+		<sequential>
+			<if>
+				<equals arg1="${emulation}" arg2="true" />
+				<then>
+					<for list="${modify.@{seqnum}.config.ssh.numlogins}" param="iter"
+						delimiter="," parallel="false">
+						<sequential>
+							<var name="loginProperty" unset="true" />
+							<var name="keysProperty" unset="true" />
+							<var name="sudoProperty" unset="true" />
+
+							<property name="loginProperty"
+								value="${modify.@{seqnum}.config.ssh.user@{iter}.login}" />
+							<property name="keysProperty"
+								value="${modify.@{seqnum}.config.ssh.user@{iter}.keys}" />
+							<property name="sudoProperty"
+								value="${modify.@{seqnum}.config.ssh.user@{iter}.sudo}" />
+
+							<echo
+								message="About to create account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" />
+						</sequential>
+					</for>
+					<echo message="Running under emulation...exiting" />
+					<property name="shirako.target.code" value="0" />
+				</then>
+				<else>
+					<echo message="installing ${modify.@{seqnum}.config.ssh.numlogins} user keys and accounts in the instance" />
+					<var name="message" unset="true" />
+
+					<!-- add keys -->
+					<echo
+						message="Modify.ssh, numlogins : ${modify.@{seqnum}.config.ssh.numlogins} " />
+					<for list="${modify.@{seqnum}.config.ssh.numlogins}" param="iter"
+						delimiter="," parallel="false">
+
+						<sequential>
+							<var name="icode" unset="true" />
+							<var name="loginProperty" unset="true" />
+							<var name="keysProperty" unset="true" />
+							<var name="sudoProperty" unset="true" />
+
+							<property name="loginProperty"
+								value="${modify.@{seqnum}.config.ssh.user@{iter}.login}" />
+							<property name="keysProperty"
+								value="${modify.@{seqnum}.config.ssh.user@{iter}.keys}" />
+							<property name="sudoProperty"
+								value="${modify.@{seqnum}.config.ssh.user@{iter}.sudo}" />
+
+							<echo
+								message="Creating account on ${unit.manage.ip} for user ${loginProperty} with sudo=${sudoProperty}" />
+							<echo message="UNIT_MANAGE_IP: ${unit.manage.ip}" />
+							<echo message="LoginProperty : ${loginProperty}" />
+							<echo message="KeysProperty : ${keysProperty}" />
+							<echo message="SudoProperty : ${sudoProperty}" />
+
+							<!-- add key to VM -->
+							<exec executable="${xcat.scripts}/prepare-key.sh"
+								resultproperty="icode">
+								<env key="XCAT_CONF_DIR" value="${xcat.conf.dir}" />
+								<env key="XCAT_SSH_KEY" value="${xcat.ssh.key}" />
+								<arg value="${unit.manage.ip}" />
+								<arg value="'${loginProperty}'" />
+								<arg value="'${keysProperty}'" />
+							</exec>
+
+							<echo message="Exit code for login ${loginProperty} is ${icode}" />
+							<if>
+								<not>
+									<equals arg1="${icode}" arg2="0" />
+								</not>
+								<then>
+									<fail message="Unable to create account ${loginProperty}, failing" />
+								</then>
+							</if>
+						</sequential>
+					</for>
+
+					<echo
+						message="after update userdata: exit code ${code}, ${update.userdata.output}" />
+
+					<delete file="${neuca.ini.file}" />
+
+				</else>
+			</if>
+		</sequential>
+	</macrodef>
+
+	<!-- add logins -->
+	<target name="modify.ssh" depends="resolve.configuration">
+		<taskdef resource="orca/handlers/xcat/xcat.xml" classpathref="run.classpath"
+			loaderref="run.classpath.loader" />
+
+		<if>
+			<isset property="xcat.site.properties" />
+			<then>
+				<echo message="Setting xcat.site.properites from ${xcat.site.properties}" />
+				<property file="${xcat.site.properties}" />
+			</then>
+		</if>
+
+		<var name="code" unset="true" />
+		<var name="message" unset="true" />
+
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="XCAT HANDLER: MODIFY.SSH on ${start.TIME}" />
+		<echo message="modify.ssh: xcat node=${unit.xcat.nodename}, ip=${unit.manage.ip}, modify sequence number ${shirako.save.unit.modify.sequencenum}" />
+
+		<modify.ssh seqnum="${shirako.save.unit.modify.sequencenum}" />
+
+		<property name="shirako.target.code" value="0" />
+		<echo message="modify.ssh exit code: ${shirako.target.code}" />
+	</target>
+
+	<!-- leave -->
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<taskdef resource="orca/handlers/xcat/xcat.xml" classpathref="run.classpath"
+			loaderref="run.classpath.loader" />
+		<tstamp prefix="start">
+			<format property="TIME" pattern="MM/dd/yyyy hh:mm" />
+		</tstamp>
+
+		<echo message="XCAT HANDLER: LEAVE on ${start.TIME}" />
+		<echo message="leave: bare metal node=${unit.xcat.nodename}" />
+		<!-- set site-specific properties like the VLAN or PHYS mode and the interface 
+			to operate on -->
+		<if>
+			<isset property="xcat.site.properties" />
+			<then>
+				<property file="${xcat.site.properties}" />
+			</then>
+		</if>
+
+		<if>
+			<equals arg1="${emulation}" arg2="true" />
+			<then>
+				<echo message="running under emulation...exiting" />
+				<property name="shirako.target.code" value="0" />
+			</then>
+			<else>
+				<var name="code" unset="true" />
+				<var name="terminate.instance.output" unset="true" />
+				<echo message="De-provisioning bare metal node: ${unit.xcat.nodename}" />
+				<exec executable="${xcat.scripts}/stop.sh" resultproperty="code"
+					outputproperty="terminate.instance.output">
+					<arg value="${unit.xcat.nodename}" />
+				</exec>
+				<echo
+					message="deprovision-node exit code: ${code}; ${terminate.instance.output}" />
+				<property name="shirako.target.code" value="${code}" />
+
+				<var name="code" unset="true" />
+				<var name="terminate.instance.output" unset="true" />
+				<atomic.sequence.start.macro device="${xcat.baremetal.group}" />
+				<exec executable="${xcat.scripts}/returnnode.sh"
+					resultproperty="code" outputproperty="terminate.instance.output">
+					<arg value="${unit.xcat.nodename}" />
+				</exec>
+				<atomic.sequence.stop.macro device="${xcat.baremetal.group}" />
+
+				<if>
+					<not>
+						<equals arg1="${code}" arg2="0" />
+					</not>
+					<then>
+						<echo
+							message="Error encountered while returning bare metal node to free node pool: exit code ${code}, ${terminate.instance.output}" />
+						<property name="shirako.target.code" value="${code}" />
+					</then>
+				</if>
+			</else>
+		</if>
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
 </project>

--- a/nodeagent/ant/build.xml
+++ b/nodeagent/ant/build.xml
@@ -1,102 +1,120 @@
-<!DOCTYPE project> 
-<!--ENTITY drivers SYSTEM "drivers.xml"--> 
-<!--ENTITY tests SYSTEM "tests.xml"--> 
-<!--ENTITY util SYSTEM "util.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+	<!ENTITY deps SYSTEM "deps.xml">
+	<!ENTITY drivers SYSTEM "drivers.xml">
+	<!ENTITY tests SYSTEM "tests.xml">
+	<!ENTITY util SYSTEM "util.xml">
+]>
 <project name="orca.nodeagent" default="help" basedir="." xmlns:artifact="urn:maven-artifact-ant">
-     &amp;deps; &amp;drivers; &amp;tests; &amp;util; 
-    <target name="help"> 
-        <echo>
-             copy.local - copies template configuration files locally service - creates orca-nodeagent service aar 
-        </echo> 
-    </target> 
-    <target name="copy.local" description="copies configuration templates into the local configuration directory"> 
-        <mkdir dir="${local.dir}" /> 
-        <copy todir="${local.dir}"> 
-            <fileset dir="${config.dir}"> 
-                <include name="**/*" /> 
-            </fileset> 
-        </copy> 
-    </target> 
-    <!-- Generates the web service archive--> 
-    <target name="service"> 
-        <!--
+
+	&deps;
+	&drivers;
+	&tests;
+	&util;
+
+	<target name="help">
+		<echo>
+			copy.local - copies template configuration files locally
+			service - creates orca-nodeagent service aar
+		</echo>
+	</target>
+
+	<target name="copy.local" description="copies configuration templates into the local configuration directory">
+		<mkdir dir="${local.dir}" />
+		<copy todir="${local.dir}">
+			<fileset dir="${config.dir}">
+				<include name="**/*" />
+			</fileset>
+		</copy>
+	</target>
+
+
+	<!-- Generates the web service archive-->
+	<target name="service">
+		<!--
 		  <echo message="${maven.project.version}" />
 			  <echo message="${maven.project.build.sourceDirectory}" />
 				  <echo message="${maven.project.build.directory}" />
 					  <echo message="${maven.project.build.outputDirectory}" />
-					  --> 
-        <!-- WS-Security related files --> 
-        <copy todir="${maven.project.build.outputDirectory}" file="src/resources/service.properties" /> 
-        <if> 
-            <equals arg1="true" arg2="${aar.include.testfile}" /> 
-            <then> 
-                <copy todir="${maven.project.build.outputDirectory}" file="src/resources/testcmdline" /> 
-            </then> 
-            <else> 
-                <delete file="${maven.project.build.outputDirectory}/testcmdline" /> 
-            </else> 
-        </if> 
-        <delete dir="${maven.project.build.outputDirectory}/META-INF" /> 
-        <mkdir dir="${maven.project.build.outputDirectory}/META-INF" /> 
-        <copy todir="${maven.project.build.outputDirectory}/META-INF"> 
-            <fileset dir="src/resources"> 
-                <!-- axis2 web services definitions file --> 
-                <include name="services.xml" /> 
-                <include name="*.wsdl" /> 
-            </fileset> 
-        </copy> 
-        <delete dir="${maven.project.build.outputDirectory}/lib" /> 
-        <mkdir dir="${maven.project.build.outputDirectory}/lib" /> 
-        <mkdir dir="${maven.project.build.outputDirectory}/local" /> 
-        <copy todir="${maven.project.build.outputDirectory}/lib/local"> 
-            <fileset dir="${local.dir}"> 
-                <include name="*.properties" /> 
-            </fileset> 
-        </copy> 
-        <mkdir dir="${maven.project.build.outputDirectory}/local" /> 
-        <copy todir="${maven.project.build.outputDirectory}/local"> 
-            <fileset dir="${local.dir}"> 
-                <include name="*.properties" /> 
-            </fileset> 
-        </copy> 
-        <copy todir="${maven.project.build.outputDirectory}/lib"> 
-            <fileset dir="${local.dir}"> 
-                <include name="*.properties" /> 
-            </fileset> 
-            <!--
+					  -->
+
+		<!-- WS-Security related files -->
+		<copy todir="${maven.project.build.outputDirectory}" file="src/resources/service.properties" />
+		<if>
+			<equals arg1="true" arg2="${aar.include.testfile}" />
+			<then>
+				<copy todir="${maven.project.build.outputDirectory}" file="src/resources/testcmdline" />
+			</then>      
+			<else>
+				<delete file="${maven.project.build.outputDirectory}/testcmdline" />        
+			</else>
+		</if> 
+		<delete dir="${maven.project.build.outputDirectory}/META-INF" />
+		<mkdir dir="${maven.project.build.outputDirectory}/META-INF" />
+		<copy todir="${maven.project.build.outputDirectory}/META-INF">
+			<fileset dir="src/resources">
+				<!-- axis2 web services definitions file -->
+				<include name="services.xml" />
+				<include name="*.wsdl" />
+			</fileset>
+		</copy>
+
+		<delete dir="${maven.project.build.outputDirectory}/lib" />
+		<mkdir dir="${maven.project.build.outputDirectory}/lib" />
+		<mkdir dir="${maven.project.build.outputDirectory}/local" />
+		<copy todir="${maven.project.build.outputDirectory}/lib/local">
+			<fileset dir="${local.dir}">
+				<include name="*.properties" />
+			</fileset>        
+		</copy>
+		<mkdir dir="${maven.project.build.outputDirectory}/local" />
+		<copy todir="${maven.project.build.outputDirectory}/local">
+			<fileset dir="${local.dir}">
+				<include name="*.properties" />
+			</fileset>        
+		</copy>
+		<copy todir="${maven.project.build.outputDirectory}/lib">
+			<fileset dir="${local.dir}">
+				<include name="*.properties" />
+			</fileset>        
+			<!--
 			  <fileset dir="${maven.project.build.directory}">
 				  <include name="*.jar" />
 					  <exclude name="orca.nodeagent.tests-${maven.project.verion}.jar" />
 						  <exclude name="orca.nodeagent.client-${maven.project.verion}.jar" />
 						  </fileset>
-					  --> 
-        </copy> 
-        <!--
+					  -->
+		</copy>
+		<!--
 		  We expand out dependencies instead of including the jars.  We
 		  do this because the nodeagenthost (unlike Tomcat) has problems
 		  resolving paths.
-	  --> 
-        <!-- An ugly hack for now --> 
-        <delete dir="${tmp.dir}" /> 
-        <mkdir dir="${tmp.dir}" /> 
-        <copy todir="${tmp.dir}"> 
-            <fileset refid="compile.fileset" /> 
-        </copy> 
-        <unjar dest="${maven.project.build.outputDirectory}"> 
-            <fileset dir="${tmp.dir}"> 
-                <include name="orca/drivers/core/**/*.jar" /> 
-            </fileset> 
-        </unjar> 
-        <!--    <delete dir="${tmp.dir}" /> --> 
-        <jar jarfile="${maven.project.build.directory}/orca.nodeagent-${maven.project.version}.aar"> 
-            <fileset dir="${maven.project.build.outputDirectory}"> 
-                <exclude name="orca/axis2/tools/**/*" /> 
-                <exclude name="orca/nodeagent/Server.class" /> 
-                <exclude name="orca/nodeagent/tests/**/*.class" /> 
-                <exclude name="orca/nodeagent/AllTests.class" /> 
-                <exclude name="orca/nodeagent/client/*" /> 
-            </fileset> 
-        </jar> 
-    </target> 
+	  -->
+
+		<!-- An ugly hack for now -->
+		<delete dir="${tmp.dir}" />
+		<mkdir dir="${tmp.dir}" />
+		<copy todir="${tmp.dir}">
+			<fileset refid="compile.fileset" />
+		</copy>
+
+		<unjar dest="${maven.project.build.outputDirectory}">
+			<fileset dir="${tmp.dir}">
+				<include name="orca/drivers/core/**/*.jar" />
+			</fileset>
+		</unjar>
+		<!--    <delete dir="${tmp.dir}" /> -->
+
+		<jar jarfile="${maven.project.build.directory}/orca.nodeagent-${maven.project.version}.aar">
+			<fileset dir="${maven.project.build.outputDirectory}">
+				<exclude name="orca/axis2/tools/**/*" />
+				<exclude name="orca/nodeagent/Server.class" />
+				<exclude name="orca/nodeagent/tests/**/*.class" />
+				<exclude name="orca/nodeagent/AllTests.class" />
+				<exclude name="orca/nodeagent/client/*" />
+			</fileset>
+		</jar>
+
+	</target>
+
+
 </project>

--- a/plugins/ben/build.xml
+++ b/plugins/ben/build.xml
@@ -1,31 +1,39 @@
-<!DOCTYPE project>
- ]&gt; 
-<project name="orca.controllers.ben" default="help" basedir="." xmlns:artifact="urn:maven-artifact-ant">
-     &amp;deps; 
-    <target name="help"> 
-        <echo>
-             Build file options: bentest: invokes the ben test 
-        </echo> 
-    </target> 
-    <target name="sgetest"> 
-        <if> 
-            <isset property="config" /> 
-            <then> 
-                <delete dir="${cmdline.home}/logs" /> 
-                <delete dir="${cmdline.home}/log" /> 
-                <echo message="running ben unit test (real mode)..." /> 
-                <echo message="configuration file: ${config}" /> 
-                <java classname="orca.controllers.ben.BenTest" Fork="Yes" failonerror="true" dir="../../run"> 
-                    <classpath refid="run.classpath" /> 
-                    <arg value="${config}" /> 
-                    <arg value="do.not.recover=true" /> 
-                    <arg value="manual=false" /> 
-                    <arg value="clean.machines=true" /> 
-                </java> 
-            </then> 
-            <else> 
-                <echo message="usage: -Dhandler=&lt;path to handler> -Dtarget=&lt;target name>" /> 
-            </else> 
-        </if> 
-    </target> 
+<!DOCTYPE project [
+	<!ENTITY deps SYSTEM "ant/deps.xml">
+]>
+<project name="orca.controllers.ben"
+		default="help"
+		basedir="."
+		xmlns:artifact="urn:maven-artifact-ant">
+
+	&deps;
+
+	<target name="help">
+		<echo>
+			Build file options:
+			bentest: invokes the ben test            
+		</echo>
+	</target>
+
+	<target name="sgetest">
+		<if>
+			<isset property="config" />
+			<then>
+				<delete dir="${cmdline.home}/logs" />
+				<delete dir="${cmdline.home}/log" />
+				<echo message="running ben unit test (real mode)..." />
+				<echo message="configuration file: ${config}" />
+				<java classname="orca.controllers.ben.BenTest" Fork="Yes" failonerror="true" dir="../../run">
+					<classpath refid="run.classpath" />
+					<arg value="${config}" />
+					<arg value="do.not.recover=true" />
+					<arg value="manual=false" />
+					<arg value="clean.machines=true" />
+				</java>
+			</then>
+			<else>
+				<echo message="usage: -Dhandler=&lt;path to handler&gt; -Dtarget=&lt;target name&gt;" />
+			</else>
+		</if>
+	</target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/bencomplex/handler.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/bencomplex/handler.xml
@@ -1,152 +1,244 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../ben.tasks.xml">
+]>
+
 <project name="bencomplex" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: SETUP" /> 
-        <var name="code" value="0"></var> 
-        <!-- create the BEN vlan --> 
-        <for list="renci unc duke ncsu" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <echo message="performing settup at @{site}" /> 
-                <!-- check if we need to setup Polatis --> 
-                <if> 
-                    <isset property="@{site}.polatis.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <polatis.connect service.location="${@{site}.polatis.service.location}" polatis="${@{site}.polatis}" src.port="${@{site}.polatis.action.@{anum}.sport}" dst.port="${@{site}.polatis.action.@{anum}.dport}" user="${polatis.user}" password="${polatis.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to setup DTN --> 
-                <if> 
-                    <isset property="@{site}.dtn.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <dtn.connect service.location="${@{site}.dtn.service.location}" dtn="${@{site}.dtn}" src.port="${@{site}.dtn.action.@{anum}.sport}" dst.port="${@{site}.dtn.action.@{anum}.dport}" user="${dtn.user}" password="${dtn.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to setup 6509 --> 
-                <if> 
-                    <isset property="@{site}.6509.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <enable.vlan service.location="${@{site}.router.service.location}" router="${@{site}.router}" vlan.tag="${unit.net.vlan}" ports="${@{site}.6509.action.@{anum}.sport};${@{site}.6509.action.@{anum}.dport}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished setting up BEN vlan. code=${code}" /> 
-        <echo message="Stitching NLR and BEN vlans" /> 
-        <if> 
-            <equals arg1="0" arg2="${code}" /> 
-            <then> 
-                <enable.vlan service.location="${renci.router.service.location}" router="${renci.router}" vlan.tag="${unit.net.vlan}" ports="${renci.ports.nlr}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            </then> 
-        </if> 
-        <if> 
-            <equals arg1="0" arg2="${code}" /> 
-            <then> 
-                <map.vlans service.location="${renci.router.service.location}" router="${renci.router}" src.vlan.tag="${nlr.vlan.renci}" dst.vlan.tag="${unit.net.vlan}" port="${renci.ports.nlr}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            </then> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: TEARDOWN" /> 
-        <var name="code" value="0"></var> 
-        <!-- disconnect the BEN vlan --> 
-        <for list="renci unc" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <echo message="performing settup at @{site}" /> 
-                <!-- check if we need to teardown Polatis --> 
-                <if> 
-                    <isset property="@{site}.polatis.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <polatis.disconnect service.location="${@{site}.polatis.service.location}" polatis="${@{site}.polatis}" port="${@{site}.polatis.action.@{anum}.sport}" user="${polatis.user}" password="${polatis.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to teardown DTN --> 
-                <if> 
-                    <isset property="@{site}.dtn.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <dtn.disconnect service.location="${@{site}.dtn.service.location}" dtn="${@{site}.dtn}" src.port="${@{site}.dtn.action.@{anum}.sport}" dst.port="${@{site}.dtn.action.@{anum}.dport}" user="${dtn.user}" password="${dtn.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to disable 6509 --> 
-                <if> 
-                    <isset property="@{site}.6509.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <disable.vlan service.location="${@{site}.router.service.location}" router="${@{site}.router}" vlan.tag="${unit.net.vlan}" ports="${@{site}.6509.action.@{anum}.sport};${@{site}.6509.action.@{anum}.dport}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <!-- disable NLR(RENCI) tag on RENCI:10G interface --> 
-        <unmap.vlans service.location="${renci.router.service.location}" router="${renci.router}" src.vlan.tag="${nlr.vlan.renci}" dst.vlan.tag="${unit.net.vlan}" port="${renci.ports.nlr}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <disable.vlan service.location="${renci.router.service.location}" router="${renci.router}" vlan.tag="${unit.net.vlan}" ports="${renci.ports.nlr}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <!-- FIXME: ${code} contains the exit code of only the last operation --> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<property file="../ben.properties" />
+
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="BEN HANDLER: SETUP" />
+
+		<var name="code" value="0" />
+
+		<!-- create the BEN vlan -->
+		<for list="renci unc duke ncsu" param="site" delimiter=" " parallel="false">
+			<sequential>
+				<echo message="performing settup at @{site}" />
+    			<!-- check if we need to setup Polatis -->
+    			<if>
+            		<isset property="@{site}.polatis.actionslist" />
+            		<then>
+						<for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false">
+							<sequential>
+								<if>
+									<equals arg1="${code}" arg2="0" />
+									<then>
+										<polatis.connect
+											service.location="${@{site}.polatis.service.location}"
+											polatis="${@{site}.polatis}"
+											src.port="${@{site}.polatis.action.@{anum}.sport}"
+											dst.port="${@{site}.polatis.action.@{anum}.dport}"
+											user="${polatis.user}"
+											password="${polatis.password}"
+											/>
+									</then>
+								</if>
+							</sequential>
+						</for>
+    				</then>
+    			</if>
+				<!-- check if we need to setup DTN -->
+				<if>
+					<isset property="@{site}.dtn.actionslist" />
+					<then>
+						<for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false">
+							<sequential>
+								<if>
+									<equals arg1="${code}" arg2="0" />
+									<then>
+										<dtn.connect
+											service.location="${@{site}.dtn.service.location}"
+											dtn="${@{site}.dtn}"
+											src.port="${@{site}.dtn.action.@{anum}.sport}"
+											dst.port="${@{site}.dtn.action.@{anum}.dport}"
+											user="${dtn.user}"
+											password="${dtn.password}"
+											/>
+									</then>
+								</if>
+							</sequential>
+						</for>
+    				</then>
+    			</if>
+				<!-- check if we need to setup 6509 -->
+    			<if>
+					<isset property="@{site}.6509.actionslist" />
+					<then>
+					    <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false">
+							<sequential>
+								<if>
+									<equals arg1="${code}" arg2="0" />
+									<then>
+										<enable.vlan 
+											service.location="${@{site}.router.service.location}"
+											router="${@{site}.router}"
+											vlan.tag="${unit.net.vlan}"
+											ports="${@{site}.6509.action.@{anum}.sport};${@{site}.6509.action.@{anum}.dport}"
+											router.user="${router.user}"
+											router.password="${router.password}"
+											router.admin.password="${router.admin.password}"
+											/>
+									</then>
+								</if>
+							</sequential>
+						</for>
+    				</then>
+    			</if>
+			</sequential>
+		</for>
+		<echo message="Finished setting up BEN vlan. code=${code}" />
+		<echo message="Stitching NLR and BEN vlans" />
+		<if>
+			<equals arg1="0" arg2="${code}" />
+			<then>		
+				<enable.vlan 
+					service.location="${renci.router.service.location}"
+					router="${renci.router}"
+					vlan.tag="${unit.net.vlan}"
+					ports="${renci.ports.nlr}"
+					router.user="${router.user}"
+					router.password="${router.password}"
+					router.admin.password="${router.admin.password}"
+					/>
+			</then>
+		</if>
+		<if>
+			<equals arg1="0" arg2="${code}" />
+			<then>	
+				<map.vlans 
+					service.location="${renci.router.service.location}"
+					router="${renci.router}"
+					src.vlan.tag="${nlr.vlan.renci}"
+					dst.vlan.tag="${unit.net.vlan}"
+					port="${renci.ports.nlr}"
+					router.user="${router.user}"
+					router.password="${router.password}"
+					router.admin.password="${router.admin.password}"
+					/>
+			</then>
+		</if>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="BEN HANDLER: TEARDOWN" />
+		<var name="code" value="0" />
+
+		<!-- disconnect the BEN vlan -->
+		<for list="renci unc" param="site" delimiter=" " parallel="false">
+			<sequential>
+				<echo message="performing settup at @{site}" />
+				<!-- check if we need to teardown Polatis -->
+    			<if>
+            		<isset property="@{site}.polatis.actionslist" />
+            		<then>
+   			 			<for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false">
+							<sequential>
+								<if>
+									<equals arg1="${code}" arg2="0" />
+									<then>
+										<polatis.disconnect
+											service.location="${@{site}.polatis.service.location}"
+											polatis="${@{site}.polatis}"
+											port="${@{site}.polatis.action.@{anum}.sport}"
+											user="${polatis.user}"
+											password="${polatis.password}"
+											/>
+									</then>
+								</if>
+							</sequential>
+						</for>
+    				</then>
+    			</if>
+				<!-- check if we need to teardown DTN -->
+				<if>
+					<isset property="@{site}.dtn.actionslist" />
+					<then>				
+						<for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false">
+							<sequential>
+								<if>
+									<equals arg1="${code}" arg2="0" />
+									<then>
+										<dtn.disconnect
+											service.location="${@{site}.dtn.service.location}"
+											dtn="${@{site}.dtn}"
+											src.port="${@{site}.dtn.action.@{anum}.sport}"
+											dst.port="${@{site}.dtn.action.@{anum}.dport}"
+											user="${dtn.user}"
+											password="${dtn.password}"
+											/>
+									</then>
+								</if>
+							</sequential>
+						</for>
+					</then>
+				</if>
+    			<!-- check if we need to disable 6509 -->
+				<if>
+					<isset property="@{site}.6509.actionslist" />
+					<then>		
+					    <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false">
+							<sequential>
+								<if>
+									<equals arg1="${code}" arg2="0" />
+									<then>
+										<disable.vlan 
+											service.location="${@{site}.router.service.location}"
+											router="${@{site}.router}"
+											vlan.tag="${unit.net.vlan}"
+											ports="${@{site}.6509.action.@{anum}.sport};${@{site}.6509.action.@{anum}.dport}"
+											router.user="${router.user}"
+											router.password="${router.password}"
+											router.admin.password="${router.admin.password}"
+											/>
+									</then>
+								</if>
+							</sequential>
+						</for>
+    				</then>
+    			</if>
+			</sequential>
+		</for>
+
+		<!-- disable NLR(RENCI) tag on RENCI:10G interface -->
+		<unmap.vlans 
+			service.location="${renci.router.service.location}"
+			router="${renci.router}"
+			src.vlan.tag="${nlr.vlan.renci}"
+			dst.vlan.tag="${unit.net.vlan}"
+			port="${renci.ports.nlr}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}"
+			/>
+
+		<disable.vlan 
+			service.location="${renci.router.service.location}"
+			router="${renci.router}"
+			vlan.tag="${unit.net.vlan}"
+			ports="${renci.ports.nlr}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}"
+			/>
+		<!-- FIXME: ${code} contains the exit code of only the last operation -->
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="BEN HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/bensimple/handler.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/bensimple/handler.xml
@@ -1,107 +1,138 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../ben.tasks.xml">
+]>
 <project name="vlan-handler" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <if> 
-            <isset property="unit.net.vlan" /> 
-            <then> 
-                <var name="code" value="0"></var> 
-                <for list="${routers}" param="router" delimiter=" " parallel="false"> 
-                    <sequential> 
-                        <if> 
-                            <equals arg1="${code}" arg2="0" /> 
-                            <then> 
-                                <echo message="enabling vlan ${unit.net.vlan} on router @{router}" /> 
-                                <var name="service.location" value="${na.protocol}://${@{router}.service.ip}:${na.port}/${na.uri}"></var> 
-                                <echo message="service.location=${service.location}" /> 
-                                <if> 
-                                    <equals arg1="${emulation}" arg2="true" /> 
-                                    <then> 
-                                        <echo message="running under emulation...nothing to do" /> 
-                                        <var name="code" value="0"></var> 
-                                    </then> 
-                                    <else> 
-                                        <limit maxwait="${operation.timeout}" failonerror="true"> 
-                                            <var name="code" unset="true"></var> 
-                                            <network.Cisco6509.CreateVLAN location="${service.location}" repository="${axis2.repository}" config="${axis2.config}" driverId="${vlan.6509.driver.id}" exitCodeProperty="code" deviceAddress="@{router}" UID="${router.user}" PWD="${router.password}" adminPWD="${router.admin.password}" tagNm="${unit.net.vlan}" vlanNm="orca vlan ${unit.net.vlan}" /> 
-                                            <if> 
-                                                <equals arg1="0" arg2="${code}" /> 
-                                                <then> 
-                                                    <echo message="vlan ${unit.net.vlan} created successfully on router @{router}" /> 
-                                                </then> 
-                                                <else> 
-                                                    <echo message="vlan ${unit.net.vlan} creation on @{router} failed. code=${code}" /> 
-                                                </else> 
-                                            </if> 
-                                        </limit> 
-                                    </else> 
-                                </if> 
-                            </then> 
-                        </if> 
-                    </sequential> 
-                </for> 
-            </then> 
-            <else> 
-                <echo message="missing vlan tag" /> 
-                <var name="code" value="1"></var> 
-            </else> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <if> 
-            <isset property="unit.net.vlan" /> 
-            <then> 
-                <var name="code" value="0"></var> 
-                <for list="${routers}" param="router" delimiter=" " parallel="false"> 
-                    <sequential> 
-                        <if> 
-                            <equals arg1="${code}" arg2="0" /> 
-                            <then> 
-                                <echo message="deleting vlan ${unit.net.vlan} on router @{router}" /> 
-                                <var name="service.location" value="${na.protocol}://${@{router}.service.ip}:${na.port}/${na.uri}"></var> 
-                                <echo message="service.location=${service.location}" /> 
-                                <if> 
-                                    <equals arg1="${emulation}" arg2="true" /> 
-                                    <then> 
-                                        <echo message="running under emulation...nothing to do" /> 
-                                        <var name="code" value="0"></var> 
-                                    </then> 
-                                    <else> 
-                                        <limit maxwait="${operation.timeout}" failonerror="true"> 
-                                            <var name="code" unset="true"></var> 
-                                            <network.Cisco6509.DeleteVLAN location="${service.location}" repository="${axis2.repository}" config="${axis2.config}" driverId="${vlan.6509.driver.id}" exitCodeProperty="code" deviceAddress="@{router}" UID="${router.user}" PWD="${router.password}" adminPWD="${router.admin.password}" tagNm="${unit.net.vlan}" /> 
-                                            <if> 
-                                                <equals arg1="0" arg2="${code}" /> 
-                                                <then> 
-                                                    <echo message="vlan ${unit.net.vlan} deleted successfully on router @{router}" /> 
-                                                </then> 
-                                                <else> 
-                                                    <echo message="vlan ${unit.net.vlan} deletion on @{router} failed. code=${code}" /> 
-                                                </else> 
-                                            </if> 
-                                        </limit> 
-                                    </else> 
-                                </if> 
-                            </then> 
-                        </if> 
-                    </sequential> 
-                </for> 
-            </then> 
-            <else> 
-                <echo message="missing vlan tag" /> 
-                <var name="code" value="1"></var> 
-            </else> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration"> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+
+	&paths;
+	&core;    
+	&drivertasks;
+	&bentasks;
+
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<if>
+			<isset property="unit.net.vlan" />
+			<then>
+				<var name="code" value="0" />
+				<for list="${routers}" param="router" delimiter=" " parallel="false">
+					<sequential>
+						<if>
+							<equals arg1="${code}" arg2="0" />
+							<then>
+								<echo message="enabling vlan ${unit.net.vlan} on router @{router}" />
+								<var name="service.location" value="${na.protocol}://${@{router}.service.ip}:${na.port}/${na.uri}" />
+								<echo message="service.location=${service.location}" />
+								<if>
+									<equals arg1="${emulation}" arg2="true" />
+									<then>
+										<echo message="running under emulation...nothing to do" />
+										<var name="code" value="0" />
+									</then>
+									<else>
+										<limit maxwait="${operation.timeout}" failonerror="true">
+											<var name="code" unset="true" />
+											<network.Cisco6509.CreateVLAN 
+												location="${service.location}"
+												repository="${axis2.repository}"
+												config="${axis2.config}"
+												driverId="${vlan.6509.driver.id}"
+												exitCodeProperty="code" 
+												deviceAddress="@{router}"
+												UID="${router.user}"
+												PWD="${router.password}"
+												adminPWD="${router.admin.password}"
+												tagNm="${unit.net.vlan}"
+												vlanNm="orca vlan ${unit.net.vlan}"
+												/>
+											<if>
+												<equals arg1="0" arg2="${code}" />
+												<then>
+													<echo message="vlan ${unit.net.vlan} created successfully on router @{router}" />
+												</then>
+												<else>
+													<echo message="vlan ${unit.net.vlan} creation on @{router} failed. code=${code}" />
+												</else>
+											</if>
+										</limit>
+									</else>
+								</if>
+							</then>
+						</if>
+					</sequential>
+				</for>
+			</then>
+			<else>
+				<echo message="missing vlan tag" />
+				<var name="code" value="1" />
+			</else>
+		</if>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<if>
+			<isset property="unit.net.vlan" />
+			<then>
+				<var name="code" value="0" />
+				<for list="${routers}" param="router" delimiter=" " parallel="false">
+					<sequential>
+						<if>
+							<equals arg1="${code}" arg2="0" />
+							<then>
+								<echo message="deleting vlan ${unit.net.vlan} on router @{router}" />
+								<var name="service.location" value="${na.protocol}://${@{router}.service.ip}:${na.port}/${na.uri}" />
+								<echo message="service.location=${service.location}" />
+								<if>
+									<equals arg1="${emulation}" arg2="true" />
+									<then>
+										<echo message="running under emulation...nothing to do" />
+										<var name="code" value="0" />
+									</then>
+									<else>
+										<limit maxwait="${operation.timeout}" failonerror="true">
+											<var name="code" unset="true" />
+											<network.Cisco6509.DeleteVLAN 
+												location="${service.location}"
+												repository="${axis2.repository}"
+												config="${axis2.config}"
+												driverId="${vlan.6509.driver.id}"
+												exitCodeProperty="code" 
+												deviceAddress="@{router}"
+												UID="${router.user}"
+												PWD="${router.password}"
+												adminPWD="${router.admin.password}"
+												tagNm="${unit.net.vlan}"
+												/>
+											<if>
+												<equals arg1="0" arg2="${code}" />
+												<then>
+													<echo message="vlan ${unit.net.vlan} deleted successfully on router @{router}" />
+												</then>
+												<else>
+													<echo message="vlan ${unit.net.vlan} deletion on @{router} failed. code=${code}" />
+												</else>
+											</if>
+										</limit>
+									</else>
+								</if>
+							</then>
+						</if>
+					</sequential>
+				</for>
+			</then>
+			<else>
+				<echo message="missing vlan tag" />
+				<var name="code" value="1" />
+			</else>
+		</if>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration">
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/dukenet/handler.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/dukenet/handler.xml
@@ -1,40 +1,86 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../ben.tasks.xml">
+]>
+
 <project name="dukenet" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: SETUP" /> 
-        <!-- enable DUKE.NET tag on all VM interfaaces --> 
-        <enable.vlan service.location="${service.location}" router="${router}" vlan.tag="${unit.net.vlan}" ports="${router.ports.vms};${router.ports.nlr}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <!-- map the DUKE.NET tag to the NLR tag --> 
-        <if> 
-            <equals arg1="0" arg2="${code}" /> 
-            <then> 
-                <map.vlans service.location="${service.location}" router="${router}" port="${router.ports.nlr}" src.vlan.tag="${nlr.vlan.duke}" dst.vlan.tag="${unit.net.vlan}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            </then> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: TEARDOWN" /> 
-        <unmap.vlans service.location="${service.location}" router="${router}" src.vlan.tag="${nlr.vlan.duke}" dst.vlan.tag="${unit.net.vlan}" port="${router.ports.nlr}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <if> 
-            <equals arg1="0" arg2="${code}" /> 
-            <then> 
-                <disable.vlan service.location="${service.location}" router="${router}" vlan.tag="${unit.net.vlan}" ports="${router.ports.vms};${router.ports.nlr}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            </then> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<property file="../ben.properties" />
+
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: SETUP" />
+		<!-- enable DUKE.NET tag on all VM interfaaces -->
+		<enable.vlan 
+			service.location="${service.location}"
+			router="${router}"
+			vlan.tag="${unit.net.vlan}"
+			ports="${router.ports.vms};${router.ports.nlr}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}"
+			/>
+		<!-- map the DUKE.NET tag to the NLR tag -->
+		<if>
+			<equals arg1="0" arg2="${code}" />
+			<then>	
+				<map.vlans 
+					service.location="${service.location}"
+					router="${router}"
+					port="${router.ports.nlr}"
+					src.vlan.tag="${nlr.vlan.duke}"
+					dst.vlan.tag="${unit.net.vlan}"
+					router.user="${router.user}"
+					router.password="${router.password}"
+					router.admin.password="${router.admin.password}"
+					/>
+			</then>
+		</if>
+
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: TEARDOWN" />
+		<unmap.vlans 
+			service.location="${service.location}"
+			router="${router}"
+			src.vlan.tag="${nlr.vlan.duke}"
+			dst.vlan.tag="${unit.net.vlan}"
+			port="${router.ports.nlr}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}"
+			/>
+		<if>
+			<equals arg1="0" arg2="${code}" />
+			<then>	
+				<disable.vlan 
+					service.location="${service.location}"
+					router="${router}"
+					vlan.tag="${unit.net.vlan}"
+					ports="${router.ports.vms};${router.ports.nlr}"
+					router.user="${router.user}"
+					router.password="${router.password}"
+					router.admin.password="${router.admin.password}"
+					/>
+			</then>
+		</if>
+
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec7/ben.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec7/ben.xml
@@ -1,172 +1,261 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../ben.tasks.xml">
+]>
+
 <project name="bencomplex" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+    <property file="../ben.properties" />
     <!--
 	<property file="ben.test.properties" />
-   	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: SETUP" /> 
-        <var name="code" value="0"></var> 
-        <!-- create the BEN vlan --> 
-        <for list="renci unc duke ncsu" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <echo message="performing settup at @{site}" /> 
-                <!-- check if we need to setup Polatis --> 
-                <if> 
-                    <isset property="@{site}.polatis.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <polatis.connect service.location="${@{site}.polatis.service.location}" polatis="${@{site}.polatis}" src.port="${@{site}.polatis.action.@{anum}.sport}" dst.port="${@{site}.polatis.action.@{anum}.dport}" user="${polatis.user}" password="${polatis.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to setup DTN --> 
-                <if> 
-                    <isset property="@{site}.dtn.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <dtn.connect service.location="${@{site}.dtn.service.location}" dtn="${@{site}.dtn}" src.port="${@{site}.dtn.action.@{anum}.sport}" dst.port="${@{site}.dtn.action.@{anum}.dport}" user="${dtn.user}" password="${dtn.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to setup 6509 --> 
-                <if> 
-                    <isset property="@{site}.6509.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <enable.vlan service.location="${@{site}.router.service.location}" router="${@{site}.router}" vlan.tag="${unit.vlan.tag}" ports="${@{site}.6509.action.@{anum}.sport};${@{site}.6509.action.@{anum}.dport}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished setting up BEN vlan. code=${code}" /> 
-        <echo message="Performing map operations" /> 
-        <for list="nlr dukenet dukevm rencinet rencivm" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <if> 
-                    <and> 
-                        <isset property="@{site}.unit.vlan.tag" /> 
-                        <isset property="@{site}.edge.interface" /> 
-                        <equals arg1="0" arg2="${code}" /> 
-                    </and> 
-                    <then> 
-                        <echo message="Mapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface} (url=${@{site}.map.router.service.location})" /> 
-                        <map.vlans service.location="${@{site}.map.router.service.location}" router="${@{site}.map.router}" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished performing map operations" /> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: TEARDOWN" /> 
-        <var name="code" value="0"></var> 
-        <!-- disconnect the BEN vlan --> 
-        <for list="renci unc duke ncsu" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <echo message="performing settup at @{site}" /> 
-                <!-- check if we need to teardown Polatis --> 
-                <if> 
-                    <isset property="@{site}.polatis.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <polatis.disconnect service.location="${@{site}.polatis.service.location}" polatis="${@{site}.polatis}" port="${@{site}.polatis.action.@{anum}.sport}" user="${polatis.user}" password="${polatis.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to teardown DTN --> 
-                <if> 
-                    <isset property="@{site}.dtn.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <dtn.disconnect service.location="${@{site}.dtn.service.location}" dtn="${@{site}.dtn}" src.port="${@{site}.dtn.action.@{anum}.sport}" dst.port="${@{site}.dtn.action.@{anum}.dport}" user="${dtn.user}" password="${dtn.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to disable 6509 --> 
-                <if> 
-                    <isset property="@{site}.6509.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <disable.vlan service.location="${@{site}.router.service.location}" router="${@{site}.router}" vlan.tag="${unit.vlan.tag}" ports="${@{site}.6509.action.@{anum}.sport};${@{site}.6509.action.@{anum}.dport}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Performing unmap operations" /> 
-        <for list="nlr dukenet dukevm rencinet rencivm" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <if> 
-                    <and> 
-                        <isset property="@{site}.unit.vlan.tag" /> 
-                        <isset property="@{site}.edge.interface" /> 
-                    </and> 
-                    <then> 
-                        <echo message="Unmapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface} (url=${@{site}.map.router.service.location})" /> 
-                        <unmap.vlans service.location="${@{site}.map.router.service.location}" router="${@{site}.map.router}" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished performing unmap operations" /> 
-        <!-- FIXME: ${code} contains the exit code of only the last operation --> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+   	-->
+    
+    <target name="join" depends="resolve.configuration,ben.load.tasks">
+        <echo message="BEN HANDLER: SETUP" />
+
+        <var name="code" value="0" />
+
+        <!-- create the BEN vlan -->
+        <for list="renci unc duke ncsu"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <echo message="performing settup at @{site}" />
+                <!-- check if we need to setup Polatis -->
+                <if>
+                    <isset property="@{site}.polatis.actionslist" />
+                    <then>
+                        <for list="${@{site}.polatis.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <polatis.connect service.location="${@{site}.polatis.service.location}"
+                                                         polatis="${@{site}.polatis}"
+                                                         src.port="${@{site}.polatis.action.@{anum}.sport}"
+                                                         dst.port="${@{site}.polatis.action.@{anum}.dport}"
+                                                         user="${polatis.user}"
+                                                         password="${polatis.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to setup DTN -->
+                <if>
+                    <isset property="@{site}.dtn.actionslist" />
+                    <then>
+                        <for list="${@{site}.dtn.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <dtn.connect service.location="${@{site}.dtn.service.location}"
+                                                     dtn="${@{site}.dtn}"
+                                                     src.port="${@{site}.dtn.action.@{anum}.sport}"
+                                                     dst.port="${@{site}.dtn.action.@{anum}.dport}"
+                                                     user="${dtn.user}"
+                                                     password="${dtn.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to setup 6509 -->
+                <if>
+                    <isset property="@{site}.6509.actionslist" />
+                    <then>
+                        <for list="${@{site}.6509.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <enable.vlan service.location="${@{site}.router.service.location}"
+                                                     router="${@{site}.router}"
+                                                     vlan.tag="${unit.vlan.tag}"
+                                                     ports="${@{site}.6509.action.@{anum}.sport};${@{site}.6509.action.@{anum}.dport}"
+                                                     router.user="${router.user}"
+                                                     router.password="${router.password}"
+                                                     router.admin.password="${router.admin.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished setting up BEN vlan. code=${code}" />
+    
+        <echo message="Performing map operations" />
+        <for list="nlr dukenet dukevm rencinet rencivm"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <if>
+                    <and>
+                        <isset property="@{site}.unit.vlan.tag" />
+                        <isset property="@{site}.edge.interface" />
+                        <equals arg1="0" arg2="${code}" />
+                    </and>
+                    <then>
+                        <echo message="Mapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface} (url=${@{site}.map.router.service.location})" />
+                        <map.vlans service.location="${@{site}.map.router.service.location}"
+                                   router="${@{site}.map.router}"
+                                   src.vlan.tag="${@{site}.unit.vlan.tag}"
+                                   dst.vlan.tag="${unit.vlan.tag}"
+                                   port="${@{site}.edge.interface}"
+                                   router.user="${router.user}"
+                                   router.password="${router.password}"
+                                   router.admin.password="${router.admin.password}" />
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished performing map operations" />
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="leave" depends="resolve.configuration,ben.load.tasks">
+        <echo message="BEN HANDLER: TEARDOWN" />
+        <var name="code" value="0" />
+
+        <!-- disconnect the BEN vlan -->
+        <for list="renci unc duke ncsu"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <echo message="performing settup at @{site}" />
+                <!-- check if we need to teardown Polatis -->
+                <if>
+                    <isset property="@{site}.polatis.actionslist" />
+                    <then>
+                        <for list="${@{site}.polatis.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <polatis.disconnect service.location="${@{site}.polatis.service.location}"
+                                                            polatis="${@{site}.polatis}"
+                                                            port="${@{site}.polatis.action.@{anum}.sport}"
+                                                            user="${polatis.user}"
+                                                            password="${polatis.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to teardown DTN -->
+                <if>
+                    <isset property="@{site}.dtn.actionslist" />
+                    <then>
+                        <for list="${@{site}.dtn.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <dtn.disconnect service.location="${@{site}.dtn.service.location}"
+                                                        dtn="${@{site}.dtn}"
+                                                        src.port="${@{site}.dtn.action.@{anum}.sport}"
+                                                        dst.port="${@{site}.dtn.action.@{anum}.dport}"
+                                                        user="${dtn.user}"
+                                                        password="${dtn.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to disable 6509 -->
+                <if>
+                    <isset property="@{site}.6509.actionslist" />
+                    <then>
+                        <for list="${@{site}.6509.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <disable.vlan service.location="${@{site}.router.service.location}"
+                                                      router="${@{site}.router}"
+                                                      vlan.tag="${unit.vlan.tag}"
+                                                      ports="${@{site}.6509.action.@{anum}.sport};${@{site}.6509.action.@{anum}.dport}"
+                                                      router.user="${router.user}"
+                                                      router.password="${router.password}"
+                                                      router.admin.password="${router.admin.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Performing unmap operations" />
+        <for list="nlr dukenet dukevm rencinet rencivm"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <if>
+                    <and>
+                        <isset property="@{site}.unit.vlan.tag" />
+                        <isset property="@{site}.edge.interface" />
+                    </and>
+                    <then>
+                        <echo message="Unmapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface} (url=${@{site}.map.router.service.location})" />
+                        <unmap.vlans service.location="${@{site}.map.router.service.location}"
+                                     router="${@{site}.map.router}"
+                                     src.vlan.tag="${@{site}.unit.vlan.tag}"
+                                     dst.vlan.tag="${unit.vlan.tag}"
+                                     port="${@{site}.edge.interface}"
+                                     router.user="${router.user}"
+                                     router.password="${router.password}"
+                                     router.admin.password="${router.admin.password}" />
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished performing unmap operations" />
+        <!-- FIXME: ${code} contains the exit code of only the last operation -->
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="modify" depends="resolve.configuration,ben.load.tasks">
+        <echo message="BEN HANDLER: MODIFY" />
+        <property name="shirako.target.code" value="0" />
+    </target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec7/dukenet.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec7/dukenet.xml
@@ -1,30 +1,55 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../ben.tasks.xml">
+]>
+
 <project name="dukenet" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <!--
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<property file="../ben.properties" />
+	<!--
 	<property file="dukenet.test.properties" />
-    	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: SETUP" /> 
-        <!-- enable DUKE.NET tag on all VM interfaaces --> 
-        <enable.vlan service.location="${duke.router.service.location}" router="${duke.router}" vlan.tag="${unit.vlan.tag}" ports="${config.interface.1};${config.interface.2}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: TEARDOWN" /> 
-        <disable.vlan service.location="${duke.router.service.location}" router="${duke.router}" vlan.tag="${unit.vlan.tag}" ports="${config.interface.1};${config.interface.2}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+    	-->
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: SETUP" />
+		<!-- enable DUKE.NET tag on all VM interfaaces -->
+		<enable.vlan 
+			service.location="${duke.router.service.location}"
+			router="${duke.router}"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.1};${config.interface.2}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}"
+			/>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: TEARDOWN" />
+		<disable.vlan 
+			service.location="${duke.router.service.location}"
+			router="${duke.router}"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.1};${config.interface.2}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}"
+			/>
+    	<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec7/starlight.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec7/starlight.xml
@@ -1,21 +1,31 @@
-<!DOCTYPE project> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY bentasks SYSTEM "../ben.tasks.xml">
+]>
+
 <project name="bencomplex" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+    <property file="../ben.properties" />
+
     <!--
     <property file="starlight.test.properties" />
-    --> 
-    <property name="unit.vlan.tag" value="533" /> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="STARLIGHT HANDLER: SETUP" /> 
-        <var name="code" value="0"></var> 
-        <echo message="Stitching NLR and STARLIGHT vlans" /> 
-        <!--
+    -->
+
+    <property name="unit.vlan.tag" value="533" />
+    
+    <target name="join" depends="resolve.configuration,ben.load.tasks">
+        <echo message="STARLIGHT HANDLER: SETUP" />
+        <var name="code" value="0" />
+        <echo message="Stitching NLR and STARLIGHT vlans" />
+<!--
 	CISCO DRIVER IS NOT MODULAR ENOUGH TO DO THIS FOR NOW - THIS WILL BE DONE MANUALLY 
         <echo message="enabling STARLIGHT vlan ${unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
         <enable.vlan service.location="${starlight.router.service.location}"
@@ -25,23 +35,38 @@
                      router.user="${router.user}"
                      router.password="${router.password}"
                      router.admin.password="${router.admin.password}" />
---> 
-        <if> 
-            <equals arg1="0" arg2="${code}" /> 
-            <then> 
-                <echo message="mapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" /> 
-                <map.vlans service.location="${starlight.router.service.location}" router="${starlight.router}" src.vlan.tag="${nlr.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${nlr.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            </then> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="starlight join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="STARLIGHT HANDLER: TEARDOWN" /> 
-        <var name="code" value="0"></var> 
-        <echo message="unmapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" /> 
-        <unmap.vlans service.location="${starlight.router.service.location}" router="${starlight.router}" src.vlan.tag="${nlr.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${nlr.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <!--
+-->
+        <if>
+            <equals arg1="0" arg2="${code}" />
+            <then>
+                <echo message="mapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
+                <map.vlans service.location="${starlight.router.service.location}"
+                           router="${starlight.router}"
+                           src.vlan.tag="${nlr.unit.vlan.tag}"
+                           dst.vlan.tag="${unit.vlan.tag}"
+                           port="${nlr.edge.interface}"
+                           router.user="${router.user}"
+                           router.password="${router.password}"
+                           router.admin.password="${router.admin.password}" />
+            </then>
+        </if>   
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="starlight join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="leave" depends="resolve.configuration,ben.load.tasks">
+        <echo message="STARLIGHT HANDLER: TEARDOWN" />
+        <var name="code" value="0" />
+        <echo message="unmapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
+        <unmap.vlans service.location="${starlight.router.service.location}"
+                     router="${starlight.router}"
+                     src.vlan.tag="${nlr.unit.vlan.tag}"
+                     dst.vlan.tag="${unit.vlan.tag}"
+                     port="${nlr.edge.interface}"
+                     router.user="${router.user}"
+                     router.password="${router.password}"
+                     router.admin.password="${router.admin.password}" />
+<!--
 	CISCO DRIVER DOES NOT SUPPORT THIS DUE TO MULARITY ISSUES
         <echo message="disabling BEN vlan ${unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
         <disable.vlan service.location="${starlight.router.service.location}"
@@ -51,12 +76,13 @@
                       router.user="${router.user}"
                       router.password="${router.password}"
                       router.admin.password="${router.admin.password}" />
---> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="startlight leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="STARLIGHT HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+-->
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="startlight leave exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="modify" depends="resolve.configuration,ben.load.tasks">
+        <echo message="STARLIGHT HANDLER: MODIFY" />
+        <property name="shirako.target.code" value="0" />
+    </target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec8/ben.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec8/ben.xml
@@ -1,178 +1,287 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="bencomplex" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+    <property file="../ben.properties" />
+	<!-- Uncomment for handler testing
 	<property file="ben.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: SETUP" /> 
-        <var name="code" value="0"></var> 
-        <!-- create the BEN vlan --> 
-        <for list="renci unc duke ncsu" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <echo message="performing settup at @{site}" /> 
-                <!-- check if we need to setup Polatis --> 
-                <if> 
-                    <isset property="@{site}.polatis.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <polatis.connect polatis="${@{site}.polatis}" src.port="${@{site}.polatis.action.@{anum}.sport}" dst.port="${@{site}.polatis.action.@{anum}.dport}" user="${polatis.user}" password="${polatis.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to setup DTN --> 
-                <if> 
-                    <isset property="@{site}.dtn.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <dtn.connect dtn="${@{site}.dtn}" dtn.payload.type="${dtn.payloadType}" src.port="${@{site}.dtn.action.@{anum}.sport}" dst.port="${@{site}.dtn.action.@{anum}.dport}" user="${dtn.user}" password="${dtn.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to setup 6509 --> 
-                <if> 
-                    <isset property="@{site}.6509.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <sequential> 
-                                            <create.vlan router="${@{site}.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                            <add.trunk.ports router="${@{site}.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${@{site}.6509.action.@{anum}.sport},${@{site}.6509.action.@{anum}.dport}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                        </sequential> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished setting up BEN vlan. code=${code}" /> 
-        <echo message="Performing map operations" /> 
-        <for list="nlr dukenet dukevm rencinet rencivm" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <if> 
-                    <and> 
-                        <isset property="@{site}.unit.vlan.tag" /> 
-                        <isset property="@{site}.edge.interface" /> 
-                        <equals arg1="0" arg2="${code}" /> 
-                    </and> 
-                    <then> 
-                        <echo message="Mapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" /> 
-                        <map.vlans router="${@{site}.map.router}" router.type="Cisco6509" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished performing map operations" /> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: TEARDOWN" /> 
-        <var name="code" value="0"></var> 
-        <!-- disconnect the BEN vlan --> 
-        <for list="renci unc duke ncsu" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <echo message="performing settup at @{site}" /> 
-                <!-- check if we need to teardown Polatis --> 
-                <if> 
-                    <isset property="@{site}.polatis.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <polatis.disconnect polatis="${@{site}.polatis}" src.port="${@{site}.polatis.action.@{anum}.sport}" user="${polatis.user}" password="${polatis.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to teardown DTN --> 
-                <if> 
-                    <isset property="@{site}.dtn.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <dtn.disconnect dtn="${@{site}.dtn}" dtn.payload.type="${dtn.payloadType}" src.port="${@{site}.dtn.action.@{anum}.sport}" dst.port="${@{site}.dtn.action.@{anum}.dport}" user="${dtn.user}" password="${dtn.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to disable 6509 --> 
-                <if> 
-                    <isset property="@{site}.6509.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <sequential> 
-                                            <remove.trunk.ports router="${@{site}.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${@{site}.6509.action.@{anum}.sport},${@{site}.6509.action.@{anum}.dport}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                            <delete.vlan router="${@{site}.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                        </sequential> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Performing unmap operations" /> 
-        <for list="nlr dukenet dukevm rencinet rencivm" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <if> 
-                    <and> 
-                        <isset property="@{site}.unit.vlan.tag" /> 
-                        <isset property="@{site}.edge.interface" /> 
-                    </and> 
-                    <then> 
-                        <echo message="Unmapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" /> 
-                        <unmap.vlans router="${@{site}.map.router}" router.type="Cisco6509" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished performing unmap operations" /> 
-        <!-- FIXME: ${code} contains the exit code of only the last operation --> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+    
+    <target name="join" depends="resolve.configuration,ben.load.tasks">
+        <echo message="BEN HANDLER: SETUP" />
+
+        <var name="code" value="0" />
+
+        <!-- create the BEN vlan -->
+        <for list="renci unc duke ncsu"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <echo message="performing settup at @{site}" />
+                <!-- check if we need to setup Polatis -->
+                <if>
+                    <isset property="@{site}.polatis.actionslist" />
+                    <then>
+                        <for list="${@{site}.polatis.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <polatis.connect 
+                                        	polatis="${@{site}.polatis}"
+                                            src.port="${@{site}.polatis.action.@{anum}.sport}"
+                                            dst.port="${@{site}.polatis.action.@{anum}.dport}"
+                                            user="${polatis.user}"
+                                            password="${polatis.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to setup DTN -->
+                <if>
+                    <isset property="@{site}.dtn.actionslist" />
+                    <then>
+                        <for list="${@{site}.dtn.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <dtn.connect 
+                                        	dtn="${@{site}.dtn}"
+					    dtn.payload.type="${dtn.payloadType}"
+                                            src.port="${@{site}.dtn.action.@{anum}.sport}"
+                                            dst.port="${@{site}.dtn.action.@{anum}.dport}"
+                                            user="${dtn.user}"
+                                            password="${dtn.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to setup 6509 -->
+                <if>
+                    <isset property="@{site}.6509.actionslist" />
+                    <then>
+                        <for list="${@{site}.6509.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+										<sequential>
+                                        <create.vlan 
+                                        	router="${@{site}.router}"
+											router.type="Cisco6509"
+                                            vlan.tag="${unit.vlan.tag}"
+											vlan.qos.rate="${unit.vlan.qos.rate}"
+											vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+                                            router.user="${router.user}"
+                                            router.password="${router.password}"
+                                            router.admin.password="${router.admin.password}" />
+  									   <add.trunk.ports 
+                 							router="${@{site}.router}"
+				 							router.type="Cisco6509"
+                 							vlan.tag="${unit.vlan.tag}"
+                							ports="${@{site}.6509.action.@{anum}.sport},${@{site}.6509.action.@{anum}.dport}"
+                							router.user="${router.user}"
+                						    router.password="${router.password}"
+                						    router.admin.password="${router.admin.password}" />
+										</sequential>
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished setting up BEN vlan. code=${code}" />
+    
+        <echo message="Performing map operations" />
+        <for list="nlr dukenet dukevm rencinet rencivm"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <if>
+                    <and>
+                        <isset property="@{site}.unit.vlan.tag" />
+                        <isset property="@{site}.edge.interface" />
+                        <equals arg1="0" arg2="${code}" />
+                    </and>
+                    <then>
+                        <echo message="Mapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" />
+                        <map.vlans router="${@{site}.map.router}"
+				   router.type="Cisco6509"
+                                   src.vlan.tag="${@{site}.unit.vlan.tag}"
+                                   dst.vlan.tag="${unit.vlan.tag}"
+                                   port="${@{site}.edge.interface}"
+                                   router.user="${router.user}"
+                                   router.password="${router.password}"
+                                   router.admin.password="${router.admin.password}" />
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished performing map operations" />
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="leave" depends="resolve.configuration,ben.load.tasks">
+        <echo message="BEN HANDLER: TEARDOWN" />
+        <var name="code" value="0" />
+
+        <!-- disconnect the BEN vlan -->
+        <for list="renci unc duke ncsu"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <echo message="performing settup at @{site}" />
+                <!-- check if we need to teardown Polatis -->
+                <if>
+                    <isset property="@{site}.polatis.actionslist" />
+                    <then>
+                        <for list="${@{site}.polatis.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <polatis.disconnect 
+                                        	polatis="${@{site}.polatis}"
+                                            src.port="${@{site}.polatis.action.@{anum}.sport}"
+                                            user="${polatis.user}"
+                                            password="${polatis.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to teardown DTN -->
+                <if>
+                    <isset property="@{site}.dtn.actionslist" />
+                    <then>
+                        <for list="${@{site}.dtn.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <dtn.disconnect
+                                        	dtn="${@{site}.dtn}"
+                                        dtn.payload.type="${dtn.payloadType}"    
+					src.port="${@{site}.dtn.action.@{anum}.sport}"
+                                            dst.port="${@{site}.dtn.action.@{anum}.dport}"
+                                            user="${dtn.user}"
+                                            password="${dtn.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to disable 6509 -->
+                <if>
+                    <isset property="@{site}.6509.actionslist" />
+                    <then>
+                        <for list="${@{site}.6509.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+										<sequential>
+										<remove.trunk.ports
+   											router="${@{site}.router}"
+											router.type="Cisco6509"
+        									vlan.tag="${unit.vlan.tag}"
+        									ports="${@{site}.6509.action.@{anum}.sport},${@{site}.6509.action.@{anum}.dport}"
+        									router.user="${router.user}"
+        									router.password="${router.password}"
+        									router.admin.password="${router.admin.password}" />
+                                        <delete.vlan 
+                                        	router="${@{site}.router}"
+											router.type="Cisco6509"
+                                            vlan.tag="${unit.vlan.tag}"
+											vlan.with.qos="${unit.vlan.with.qos}"
+                                            router.user="${router.user}"
+                                            router.password="${router.password}"
+                                            router.admin.password="${router.admin.password}" />
+										</sequential>
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Performing unmap operations" />
+        <for list="nlr dukenet dukevm rencinet rencivm"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <if>
+                    <and>
+                        <isset property="@{site}.unit.vlan.tag" />
+                        <isset property="@{site}.edge.interface" />
+                    </and>
+                    <then>
+                        <echo message="Unmapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" />
+                        <unmap.vlans 
+                        	router="${@{site}.map.router}"
+							router.type="Cisco6509"
+                            src.vlan.tag="${@{site}.unit.vlan.tag}"
+                            dst.vlan.tag="${unit.vlan.tag}"
+                            port="${@{site}.edge.interface}"
+                            router.user="${router.user}"
+                            router.password="${router.password}"
+                            router.admin.password="${router.admin.password}" />
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished performing unmap operations" />
+        <!-- FIXME: ${code} contains the exit code of only the last operation -->
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="modify" depends="resolve.configuration,ben.load.tasks">
+        <echo message="BEN HANDLER: MODIFY" />
+        <property name="shirako.target.code" value="0" />
+    </target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec8/dukenet.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec8/dukenet.xml
@@ -1,36 +1,74 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="dukenet" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <!-- <property file="../ben.properties" /> --> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<!-- <property file="../ben.properties" /> -->
+	<!-- Uncomment for handler testing
 	<property file="dukenet.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: SETUP" /> 
-        <!-- enable DUKE.NET tag on all VM interfaaces --> 
-        <sequential> 
-            <create.vlan router="${duke.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <add.trunk.ports router="${duke.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${config.interface.1},${config.interface.2}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: TEARDOWN" /> 
-        <sequential> 
-            <remove.trunk.ports router="${duke.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${config.interface.1},${config.interface.2}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <delete.vlan router="${duke.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: SETUP" />
+		<!-- enable DUKE.NET tag on all VM interfaaces -->
+		<sequential>
+    	<create.vlan 
+    		router="${duke.router}"
+			router.type="Cisco6509"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.qos.rate="${unit.vlan.qos.rate}"
+			vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+	    <add.trunk.ports 
+			router="${duke.router}"
+			router.type="Cisco6509"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.1},${config.interface.2}"
+			router.user="${router.user}"
+	    	router.password="${router.password}"
+	    	router.admin.password="${router.admin.password}" />
+		</sequential>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: TEARDOWN" />
+		<sequential>
+		<remove.trunk.ports
+			router="${duke.router}"
+			router.type="Cisco6509"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.1},${config.interface.2}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}" />
+    	<delete.vlan 
+    		router="${duke.router}"
+			router.type="Cisco6509"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.with.qos="${unit.vlan.with.qos}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+		</sequential>
+    	<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec8/renci.euca.net.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec8/renci.euca.net.xml
@@ -1,36 +1,75 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="renci.euca.net" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<property file="../ben.properties" />
+	<!-- Uncomment for handler testing
 	<property file="renci.euca.net.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="RENCI EUCA NET HANDLER: SETUP" /> 
-        <!-- enable RENCI EUCA tag on all Euca interfaaces --> 
-        <sequential> 
-            <create.vlan router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <add.trunk.ports router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" ports="${config.interface.1},${config.interface.2}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="RENCI EUCA NET HANDLER: TEARDOWN" /> 
-        <sequential> 
-            <remove.trunk.ports router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" ports="${config.interface.1},${config.interface.2}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <delete.vlan router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="RENCI EUCA NET HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="RENCI EUCA NET HANDLER: SETUP" />
+		<!-- enable RENCI EUCA tag on all Euca interfaaces -->
+		<sequential>
+    	<create.vlan 
+    		router="${renci.euca.router}"
+			router.type="ex3200"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.qos.rate="${unit.vlan.qos.rate}"
+			vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+	    <add.trunk.ports 
+			router="${renci.euca.router}"
+			router.type="ex3200"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.1},${config.interface.2}"
+			router.user="${router.user}"
+	    	router.password="${router.password}"
+	    	router.admin.password="${router.admin.password}" />
+		</sequential>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="RENCI EUCA NET HANDLER: TEARDOWN" />
+		<sequential>
+		<remove.trunk.ports
+			router="${renci.euca.router}"
+			router.type="ex3200"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.1},${config.interface.2}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}" />
+    	<delete.vlan 
+    		router="${renci.euca.router}"
+			router.type="ex3200"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.with.qos="${unit.vlan.with.qos}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+		</sequential>
+    	<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="RENCI EUCA NET HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec8/starlight.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec8/starlight.xml
@@ -1,44 +1,86 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="bencomplex" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+
     <property file="../ben.properties" /> 
     <!-- Uncomment for handler testing
     <property file="starlight.test.properties" />
-    --> 
-    <property name="unit.vlan.tag" value="533" /> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="STARLIGHT HANDLER: SETUP" /> 
-        <var name="code" value="0"></var> 
-        <echo message="Stitching NLR and STARLIGHT vlans" /> 
-        <echo message="enabling STARLIGHT vlan ${unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" /> 
-        <add.trunk.ports router="${starlight.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${nlr.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <if> 
-            <equals arg1="0" arg2="${code}" /> 
-            <then> 
-                <echo message="mapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" /> 
-                <map.vlans router="${starlight.router}" router.type="Cisco6509" src.vlan.tag="${nlr.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${nlr.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            </then> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="starlight join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="STARLIGHT HANDLER: TEARDOWN" /> 
-        <var name="code" value="0"></var> 
-        <echo message="unmapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" /> 
-        <unmap.vlans router="${starlight.router}" router.type="Cisco6509" src.vlan.tag="${nlr.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${nlr.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <echo message="disabling BEN vlan ${unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" /> 
-        <remove.trunk.ports router="${starlight.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${nlr.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="startlight leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="STARLIGHT HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+    -->
+
+    <property name="unit.vlan.tag" value="533" />
+    
+    <target name="join" depends="resolve.configuration,ben.load.tasks">
+        <echo message="STARLIGHT HANDLER: SETUP" />
+        <var name="code" value="0" />
+        <echo message="Stitching NLR and STARLIGHT vlans" />
+        <echo message="enabling STARLIGHT vlan ${unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
+        <add.trunk.ports 
+                     router="${starlight.router}"
+					 router.type="Cisco6509"
+                     vlan.tag="${unit.vlan.tag}"
+					 ports="${nlr.edge.interface}"
+                     router.user="${router.user}"
+                     router.password="${router.password}"
+                     router.admin.password="${router.admin.password}" />
+        <if>
+            <equals arg1="0" arg2="${code}" />
+            <then>
+                <echo message="mapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
+                <map.vlans 
+                     router="${starlight.router}"
+					 router.type="Cisco6509"
+                     src.vlan.tag="${nlr.unit.vlan.tag}"
+                     dst.vlan.tag="${unit.vlan.tag}"
+                     port="${nlr.edge.interface}"
+                     router.user="${router.user}"
+                     router.password="${router.password}"
+                     router.admin.password="${router.admin.password}" />
+            </then>
+        </if>   
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="starlight join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="leave" depends="resolve.configuration,ben.load.tasks">
+        <echo message="STARLIGHT HANDLER: TEARDOWN" />
+        <var name="code" value="0" />
+        <echo message="unmapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
+        <unmap.vlans 
+                     router="${starlight.router}"
+					 router.type="Cisco6509"
+                     src.vlan.tag="${nlr.unit.vlan.tag}"
+                     dst.vlan.tag="${unit.vlan.tag}"
+                     port="${nlr.edge.interface}"
+                     router.user="${router.user}"
+                     router.password="${router.password}"
+                     router.admin.password="${router.admin.password}" />
+        <echo message="disabling BEN vlan ${unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
+        <remove.trunk.ports
+                      router="${starlight.router}"
+					  router.type="Cisco6509"
+                      vlan.tag="${unit.vlan.tag}"
+                      ports="${nlr.edge.interface}"
+                      router.user="${router.user}"
+                      router.password="${router.password}"
+                      router.admin.password="${router.admin.password}" />
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="startlight leave exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="modify" depends="resolve.configuration,ben.load.tasks">
+        <echo message="STARLIGHT HANDLER: MODIFY" />
+        <property name="shirako.target.code" value="0" />
+    </target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec9/ben.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec9/ben.xml
@@ -1,59 +1,89 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="bencomplex" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+    <property file="../ben.properties" />
+	<!-- Uncomment for handler testing
 	<property file="ben.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: SETUP" /> 
-        <var name="code" value="0"></var> 
-        <!-- create the BEN vlan --> 
-        <for list="renci unc duke ncsu" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <echo message="performing settup at @{site}" /> 
-                <!-- check if we need to setup Polatis --> 
-                <if> 
-                    <isset property="@{site}.polatis.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <polatis.connect polatis="${@{site}.polatis}" src.port="${@{site}.polatis.action.@{anum}.sport}" dst.port="${@{site}.polatis.action.@{anum}.dport}" user="${polatis.user}" password="${polatis.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to setup DTN --> 
-                <if> 
-                    <isset property="@{site}.dtn.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <dtn.connect dtn="${@{site}.dtn}" dtn.payload.type="${dtn.payloadType}" src.port="${@{site}.dtn.action.@{anum}.sport}" dst.port="${@{site}.dtn.action.@{anum}.dport}" user="${dtn.user}" password="${dtn.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to setup 6509 --> 
-                <if> 
-                    <isset property="@{site}.6509.actionslist" /> 
-                    <then> 
-                        <!--
+	-->
+    
+    <target name="join" depends="resolve.configuration,ben.load.tasks">
+        <echo message="BEN HANDLER: SETUP" />
+
+        <var name="code" value="0" />
+
+        <!-- create the BEN vlan -->
+        <for list="renci unc duke ncsu"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <echo message="performing settup at @{site}" />
+                <!-- check if we need to setup Polatis -->
+                <if>
+                    <isset property="@{site}.polatis.actionslist" />
+                    <then>
+                        <for list="${@{site}.polatis.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <polatis.connect 
+                                        	polatis="${@{site}.polatis}"
+                                            src.port="${@{site}.polatis.action.@{anum}.sport}"
+                                            dst.port="${@{site}.polatis.action.@{anum}.dport}"
+                                            user="${polatis.user}"
+                                            password="${polatis.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to setup DTN -->
+                <if>
+                    <isset property="@{site}.dtn.actionslist" />
+                    <then>
+                        <for list="${@{site}.dtn.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <dtn.connect 
+                                        	dtn="${@{site}.dtn}"
+					    dtn.payload.type="${dtn.payloadType}"
+                                            src.port="${@{site}.dtn.action.@{anum}.sport}"
+                                            dst.port="${@{site}.dtn.action.@{anum}.dport}"
+                                            user="${dtn.user}"
+                                            password="${dtn.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to setup 6509 -->
+                <if>
+                    <isset property="@{site}.6509.actionslist" />
+                    <then>
+			<!--
         		<for list="nlr dukenet dukevm rencinet rencivm"
              		     param="parentsite"
              		     delimiter=" "
@@ -70,141 +100,231 @@
 				</then>
 			    </sequential>
 			</for>
-			--> 
-                        <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <sequential> 
-                                            <create.vlan router="${@{site}.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                            <add.trunk.ports router="${@{site}.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${@{site}.6509.action.@{anum}.ports}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                            <for list="nlr dukenet dukevmsite rencinet rencivmsite uncnet uncvmsite" param="parentsite" delimiter=" " parallel="false"> 
-                                                <sequential> 
-                                                    <if> 
-                                                        <and> 
-                                                            <isset property="@{parentsite}.unit.portlist" /> 
-                                                            <equals arg1="${code}" arg2="0" /> 
-                                                        </and> 
-                                                        <then> 
-                                                            <echo message="Add ports ${@{parentsite}.unit.portlist} on ${@{parentsite}.map.router} to VLAN ${unit.vlan.tag}" /> 
-                                                            <add.trunk.ports router="${@{parentsite}.map.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${@{parentsite}.unit.portlist}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                                        </then> 
-                                                    </if> 
-                                                </sequential> 
-                                            </for> 
-                                        </sequential> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished setting up BEN vlan. code=${code}" /> 
-        <echo message="Performing map operations" /> 
-        <for list="nlr dukenet dukevmsite rencinet rencivmsite uncnet uncvmsite" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <if> 
-                    <and> 
-                        <isset property="@{site}.unit.vlan.tag" /> 
-                        <isset property="@{site}.edge.interface" /> 
-                        <equals arg1="0" arg2="${code}" /> 
-                    </and> 
-                    <then> 
-                        <echo message="Mapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" /> 
-                        <map.vlans router="${@{site}.map.router}" router.type="Cisco6509" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished performing map operations" /> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: TEARDOWN" /> 
-        <var name="code" value="0"></var> 
-        <!-- disconnect the BEN vlan --> 
-        <for list="renci unc duke ncsu" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <echo message="performing settup at @{site}" /> 
-                <!-- check if we need to teardown Polatis --> 
-                <if> 
-                    <isset property="@{site}.polatis.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.polatis.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <polatis.disconnect polatis="${@{site}.polatis}" src.port="${@{site}.polatis.action.@{anum}.sport}" user="${polatis.user}" password="${polatis.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to teardown DTN --> 
-                <if> 
-                    <isset property="@{site}.dtn.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.dtn.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <dtn.disconnect dtn="${@{site}.dtn}" dtn.payload.type="${dtn.payloadType}" src.port="${@{site}.dtn.action.@{anum}.sport}" dst.port="${@{site}.dtn.action.@{anum}.dport}" user="${dtn.user}" password="${dtn.password}" /> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-                <!-- check if we need to disable 6509 --> 
-                <if> 
-                    <isset property="@{site}.6509.actionslist" /> 
-                    <then> 
-                        <for list="${@{site}.6509.actionslist}" param="anum" delimiter=" " parallel="false"> 
-                            <sequential> 
-                                <if> 
-                                    <equals arg1="${code}" arg2="0" /> 
-                                    <then> 
-                                        <sequential> 
-                                            <remove.trunk.ports router="${@{site}.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${@{site}.6509.action.@{anum}.ports}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                            <delete.vlan router="${@{site}.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                                        </sequential> 
-                                    </then> 
-                                </if> 
-                            </sequential> 
-                        </for> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Performing unmap operations" /> 
-        <for list="nlr dukenet dukevmsite rencinet rencivmsite uncnet uncvmsite" param="site" delimiter=" " parallel="false"> 
-            <sequential> 
-                <if> 
-                    <and> 
-                        <isset property="@{site}.unit.vlan.tag" /> 
-                        <isset property="@{site}.edge.interface" /> 
-                    </and> 
-                    <then> 
-                        <echo message="Unmapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" /> 
-                        <unmap.vlans router="${@{site}.map.router}" router.type="Cisco6509" src.vlan.tag="${@{site}.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${@{site}.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-                    </then> 
-                </if> 
-            </sequential> 
-        </for> 
-        <echo message="Finished performing unmap operations" /> 
-        <!-- FIXME: ${code} contains the exit code of only the last operation --> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="BEN HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+			-->
+                        <for list="${@{site}.6509.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+					<sequential>
+                                        	<create.vlan 
+                                        		router="${@{site}.router}"
+							router.type="Cisco6509"
+                                            		vlan.tag="${unit.vlan.tag}"
+							vlan.qos.rate="${unit.vlan.qos.rate}"
+							vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+                                            		router.user="${router.user}"
+                                            		router.password="${router.password}"
+                                            		router.admin.password="${router.admin.password}" />
+						<add.trunk.ports 
+                 					router="${@{site}.router}"
+		 					router.type="Cisco6509"
+                					vlan.tag="${unit.vlan.tag}"
+                					ports="${@{site}.6509.action.@{anum}.ports}"
+                					router.user="${router.user}"
+                		    			router.password="${router.password}"
+                					router.admin.password="${router.admin.password}" />
+
+                        			<for list="nlr dukenet dukevmsite rencinet rencivmsite uncnet uncvmsite"
+                             			     param="parentsite"
+                             			     delimiter=" "
+                             			     parallel="false">
+                            				<sequential>
+                                			    <if>
+                                    				<and>
+                                        			    <isset property="@{parentsite}.unit.portlist" />
+                                    				    <equals arg1="${code}" arg2="0" />
+								</and>	
+                                			    	<then>
+									<echo message = "Add ports ${@{parentsite}.unit.portlist} on ${@{parentsite}.map.router} to VLAN ${unit.vlan.tag}" /> 
+  									<add.trunk.ports 
+                 								router="${@{parentsite}.map.router}"
+				 						router.type="Cisco6509"
+                 								vlan.tag="${unit.vlan.tag}"
+                								ports="${@{parentsite}.unit.portlist}"
+                								router.user="${router.user}"
+                				    				router.password="${router.password}"
+                								router.admin.password="${router.admin.password}" />
+                                			    	</then>
+							    </if>	
+                            				</sequential>
+                        			</for>
+					</sequential>
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished setting up BEN vlan. code=${code}" />
+    
+        <echo message="Performing map operations" />
+        <for list="nlr dukenet dukevmsite rencinet rencivmsite uncnet uncvmsite"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <if>
+                    <and>
+                        <isset property="@{site}.unit.vlan.tag" />
+                        <isset property="@{site}.edge.interface" />
+                        <equals arg1="0" arg2="${code}" />
+                    </and>
+                    <then>
+                        <echo message="Mapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" />
+                        <map.vlans router="${@{site}.map.router}"
+				   router.type="Cisco6509"
+                                   src.vlan.tag="${@{site}.unit.vlan.tag}"
+                                   dst.vlan.tag="${unit.vlan.tag}"
+                                   port="${@{site}.edge.interface}"
+                                   router.user="${router.user}"
+                                   router.password="${router.password}"
+                                   router.admin.password="${router.admin.password}" />
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished performing map operations" />
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="leave" depends="resolve.configuration,ben.load.tasks">
+        <echo message="BEN HANDLER: TEARDOWN" />
+        <var name="code" value="0" />
+
+        <!-- disconnect the BEN vlan -->
+        <for list="renci unc duke ncsu"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <echo message="performing settup at @{site}" />
+                <!-- check if we need to teardown Polatis -->
+                <if>
+                    <isset property="@{site}.polatis.actionslist" />
+                    <then>
+                        <for list="${@{site}.polatis.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <polatis.disconnect 
+                                        	polatis="${@{site}.polatis}"
+                                            src.port="${@{site}.polatis.action.@{anum}.sport}"
+                                            user="${polatis.user}"
+                                            password="${polatis.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to teardown DTN -->
+                <if>
+                    <isset property="@{site}.dtn.actionslist" />
+                    <then>
+                        <for list="${@{site}.dtn.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+                                        <dtn.disconnect
+                                        	dtn="${@{site}.dtn}"
+                                        dtn.payload.type="${dtn.payloadType}"    
+					src.port="${@{site}.dtn.action.@{anum}.sport}"
+                                            dst.port="${@{site}.dtn.action.@{anum}.dport}"
+                                            user="${dtn.user}"
+                                            password="${dtn.password}" />
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+                <!-- check if we need to disable 6509 -->
+                <if>
+                    <isset property="@{site}.6509.actionslist" />
+                    <then>
+                        <for list="${@{site}.6509.actionslist}"
+                             param="anum"
+                             delimiter=" "
+                             parallel="false">
+                            <sequential>
+                                <if>
+                                    <equals arg1="${code}" arg2="0" />
+                                    <then>
+										<sequential>
+										<remove.trunk.ports
+   											router="${@{site}.router}"
+											router.type="Cisco6509"
+        									vlan.tag="${unit.vlan.tag}"
+        									ports="${@{site}.6509.action.@{anum}.ports}"
+        									router.user="${router.user}"
+        									router.password="${router.password}"
+        									router.admin.password="${router.admin.password}" />
+                                        <delete.vlan 
+                                        	router="${@{site}.router}"
+											router.type="Cisco6509"
+                                            vlan.tag="${unit.vlan.tag}"
+											vlan.with.qos="${unit.vlan.with.qos}"
+                                            router.user="${router.user}"
+                                            router.password="${router.password}"
+                                            router.admin.password="${router.admin.password}" />
+										</sequential>
+                                    </then>
+                                </if>
+                            </sequential>
+                        </for>
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Performing unmap operations" />
+        <for list="nlr dukenet dukevmsite rencinet rencivmsite uncnet uncvmsite"
+             param="site"
+             delimiter=" "
+             parallel="false">
+            <sequential>
+                <if>
+                    <and>
+                        <isset property="@{site}.unit.vlan.tag" />
+                        <isset property="@{site}.edge.interface" />
+                    </and>
+                    <then>
+                        <echo message="Unmapping BEN and @{site} vlans: ${unit.vlan.tag} ${@{site}.unit.vlan.tag} on ${@{site}.map.router}: ${@{site}.edge.interface}" />
+                        <unmap.vlans 
+                        	router="${@{site}.map.router}"
+							router.type="Cisco6509"
+                            src.vlan.tag="${@{site}.unit.vlan.tag}"
+                            dst.vlan.tag="${unit.vlan.tag}"
+                            port="${@{site}.edge.interface}"
+                            router.user="${router.user}"
+                            router.password="${router.password}"
+                            router.admin.password="${router.admin.password}" />
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <echo message="Finished performing unmap operations" />
+        <!-- FIXME: ${code} contains the exit code of only the last operation -->
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="modify" depends="resolve.configuration,ben.load.tasks">
+        <echo message="BEN HANDLER: MODIFY" />
+        <property name="shirako.target.code" value="0" />
+    </target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec9/dukenet.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec9/dukenet.xml
@@ -1,36 +1,74 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="dukenet" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <!-- <property file="../ben.properties" /> --> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<!-- <property file="../ben.properties" /> -->
+	<!-- Uncomment for handler testing
 	<property file="dukenet.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: SETUP" /> 
-        <!-- enable DUKE.NET tag on all VM interfaaces --> 
-        <sequential> 
-            <create.vlan router="${duke.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <add.trunk.ports router="${duke.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${config.interface.1},${config.interface.2}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: TEARDOWN" /> 
-        <sequential> 
-            <remove.trunk.ports router="${duke.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${config.interface.1},${config.interface.2}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <delete.vlan router="${duke.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="DUKE NET HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: SETUP" />
+		<!-- enable DUKE.NET tag on all VM interfaaces -->
+		<sequential>
+    	<create.vlan 
+    		router="${duke.router}"
+			router.type="Cisco6509"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.qos.rate="${unit.vlan.qos.rate}"
+			vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+	    <add.trunk.ports 
+			router="${duke.router}"
+			router.type="Cisco6509"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.1},${config.interface.2}"
+			router.user="${router.user}"
+	    	router.password="${router.password}"
+	    	router.admin.password="${router.admin.password}" />
+		</sequential>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: TEARDOWN" />
+		<sequential>
+		<remove.trunk.ports
+			router="${duke.router}"
+			router.type="Cisco6509"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.1},${config.interface.2}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}" />
+    	<delete.vlan 
+    		router="${duke.router}"
+			router.type="Cisco6509"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.with.qos="${unit.vlan.with.qos}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+		</sequential>
+    	<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="DUKE NET HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec9/renci.euca.net.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec9/renci.euca.net.xml
@@ -1,36 +1,75 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="renci.euca.net" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<property file="../ben.properties" />
+	<!-- Uncomment for handler testing
 	<property file="renci.euca.net.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="RENCI EUCA NET HANDLER: SETUP" /> 
-        <!-- enable RENCI EUCA tag on all Euca interfaaces --> 
-        <sequential> 
-            <create.vlan router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <add.trunk.ports router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" ports="${config.interface.1},${config.interface.2}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="RENCI EUCA NET HANDLER: TEARDOWN" /> 
-        <sequential> 
-            <remove.trunk.ports router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" ports="${config.interface.1},${config.interface.2}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <delete.vlan router="${renci.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="RENCI EUCA NET HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="RENCI EUCA NET HANDLER: SETUP" />
+		<!-- enable RENCI EUCA tag on all Euca interfaaces -->
+		<sequential>
+    	<create.vlan 
+    		router="${renci.euca.router}"
+			router.type="ex3200"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.qos.rate="${unit.vlan.qos.rate}"
+			vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+	    <add.trunk.ports 
+			router="${renci.euca.router}"
+			router.type="ex3200"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.1},${config.interface.2}"
+			router.user="${router.user}"
+	    	router.password="${router.password}"
+	    	router.admin.password="${router.admin.password}" />
+		</sequential>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="RENCI EUCA NET HANDLER: TEARDOWN" />
+		<sequential>
+		<remove.trunk.ports
+			router="${renci.euca.router}"
+			router.type="ex3200"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.1},${config.interface.2}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}" />
+    	<delete.vlan 
+    		router="${renci.euca.router}"
+			router.type="ex3200"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.with.qos="${unit.vlan.with.qos}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+		</sequential>
+    	<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="RENCI EUCA NET HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec9/starlight.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec9/starlight.xml
@@ -1,44 +1,86 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="bencomplex" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+
     <property file="../ben.properties" /> 
     <!-- Uncomment for handler testing
     <property file="starlight.test.properties" />
-    --> 
-    <property name="unit.vlan.tag" value="533" /> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="STARLIGHT HANDLER: SETUP" /> 
-        <var name="code" value="0"></var> 
-        <echo message="Stitching NLR and STARLIGHT vlans" /> 
-        <echo message="enabling STARLIGHT vlan ${unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" /> 
-        <add.trunk.ports router="${starlight.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${nlr.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <if> 
-            <equals arg1="0" arg2="${code}" /> 
-            <then> 
-                <echo message="mapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" /> 
-                <map.vlans router="${starlight.router}" router.type="Cisco6509" src.vlan.tag="${nlr.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${nlr.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            </then> 
-        </if> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="starlight join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="STARLIGHT HANDLER: TEARDOWN" /> 
-        <var name="code" value="0"></var> 
-        <echo message="unmapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" /> 
-        <unmap.vlans router="${starlight.router}" router.type="Cisco6509" src.vlan.tag="${nlr.unit.vlan.tag}" dst.vlan.tag="${unit.vlan.tag}" port="${nlr.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <echo message="disabling BEN vlan ${unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" /> 
-        <remove.trunk.ports router="${starlight.router}" router.type="Cisco6509" vlan.tag="${unit.vlan.tag}" ports="${nlr.edge.interface}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="startlight leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="STARLIGHT HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+    -->
+
+    <property name="unit.vlan.tag" value="533" />
+    
+    <target name="join" depends="resolve.configuration,ben.load.tasks">
+        <echo message="STARLIGHT HANDLER: SETUP" />
+        <var name="code" value="0" />
+        <echo message="Stitching NLR and STARLIGHT vlans" />
+        <echo message="enabling STARLIGHT vlan ${unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
+        <add.trunk.ports 
+                     router="${starlight.router}"
+					 router.type="Cisco6509"
+                     vlan.tag="${unit.vlan.tag}"
+					 ports="${nlr.edge.interface}"
+                     router.user="${router.user}"
+                     router.password="${router.password}"
+                     router.admin.password="${router.admin.password}" />
+        <if>
+            <equals arg1="0" arg2="${code}" />
+            <then>
+                <echo message="mapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
+                <map.vlans 
+                     router="${starlight.router}"
+					 router.type="Cisco6509"
+                     src.vlan.tag="${nlr.unit.vlan.tag}"
+                     dst.vlan.tag="${unit.vlan.tag}"
+                     port="${nlr.edge.interface}"
+                     router.user="${router.user}"
+                     router.password="${router.password}"
+                     router.admin.password="${router.admin.password}" />
+            </then>
+        </if>   
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="starlight join exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="leave" depends="resolve.configuration,ben.load.tasks">
+        <echo message="STARLIGHT HANDLER: TEARDOWN" />
+        <var name="code" value="0" />
+        <echo message="unmapping STARLIGHT and NLR vlans: ${unit.vlan.tag} ${nlr.unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
+        <unmap.vlans 
+                     router="${starlight.router}"
+					 router.type="Cisco6509"
+                     src.vlan.tag="${nlr.unit.vlan.tag}"
+                     dst.vlan.tag="${unit.vlan.tag}"
+                     port="${nlr.edge.interface}"
+                     router.user="${router.user}"
+                     router.password="${router.password}"
+                     router.admin.password="${router.admin.password}" />
+        <echo message="disabling BEN vlan ${unit.vlan.tag} on ${starlight.router}: ${nlr.edge.interface}" />
+        <remove.trunk.ports
+                      router="${starlight.router}"
+					  router.type="Cisco6509"
+                      vlan.tag="${unit.vlan.tag}"
+                      ports="${nlr.edge.interface}"
+                      router.user="${router.user}"
+                      router.password="${router.password}"
+                      router.admin.password="${router.admin.password}" />
+        <property name="shirako.target.code" value="${code}" />
+        <echo message="startlight leave exit code: ${shirako.target.code}" />
+    </target>
+
+    <target name="modify" depends="resolve.configuration,ben.load.tasks">
+        <echo message="STARLIGHT HANDLER: MODIFY" />
+        <property name="shirako.target.code" value="0" />
+    </target>
 </project>

--- a/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec9/unc.euca.net.xml
+++ b/plugins/ben/resources/handlers/controllers/ben-obsoleted/gec9/unc.euca.net.xml
@@ -1,36 +1,75 @@
-<!DOCTYPE project> 
-<!--ENTITY paths SYSTEM "../../../common/paths.xml"--> 
-<!--ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml"--> 
-<!--ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml"-->
- ]&gt; 
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "../../../common/core.xml">
+<!ENTITY paths SYSTEM "../../../common/paths.xml">
+<!ENTITY drivertasks SYSTEM "../../../common/drivertasks.xml">
+<!ENTITY bentasks SYSTEM "../ben.no-na.tasks.xml">
+]>
+
 <project name="unc.euca.net" basedir=".">
-     &amp;paths; &amp;core; &amp;drivertasks; &amp;bentasks; 
-    <!-- <property file="test.properties" /> --> 
-    <property file="../ben.properties" /> 
-    <!-- Uncomment for handler testing
+
+	&paths;
+	&core;
+	&drivertasks;
+	&bentasks;
+
+	<!-- <property file="test.properties" /> -->
+	<property file="../ben.properties" />
+	<!-- Uncomment for handler testing
 	<property file="unc.euca.net.test.properties" />
-	--> 
-    <target name="join" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="UNC EUCA NET HANDLER: SETUP" /> 
-        <!-- enable UNC EUCA tag on all Euca interfaaces --> 
-        <sequential> 
-            <create.vlan router="${unc.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" vlan.qos.rate="${unit.vlan.qos.rate}" vlan.qos.burst.size="${unit.vlan.qos.burst.size}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <add.trunk.ports router="${unc.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="join exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="leave" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="UNC EUCA NET HANDLER: TEARDOWN" /> 
-        <sequential> 
-            <remove.trunk.ports router="${unc.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" ports="${config.interface.ports}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-            <delete.vlan router="${unc.euca.router}" router.type="ex3200" vlan.tag="${unit.vlan.tag}" vlan.with.qos="${unit.vlan.with.qos}" router.user="${router.user}" router.password="${router.password}" router.admin.password="${router.admin.password}" /> 
-        </sequential> 
-        <property name="shirako.target.code" value="${code}" /> 
-        <echo message="leave exit code: ${shirako.target.code}" /> 
-    </target> 
-    <target name="modify" depends="resolve.configuration,ben.load.tasks"> 
-        <echo message="UNC EUCA NET HANDLER: MODIFY" /> 
-        <property name="shirako.target.code" value="0" /> 
-    </target> 
+	-->
+
+	<target name="join" depends="resolve.configuration,ben.load.tasks">
+		<echo message="UNC EUCA NET HANDLER: SETUP" />
+		<!-- enable UNC EUCA tag on all Euca interfaaces -->
+		<sequential>
+    	<create.vlan 
+    		router="${unc.euca.router}"
+			router.type="ex3200"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.qos.rate="${unit.vlan.qos.rate}"
+			vlan.qos.burst.size="${unit.vlan.qos.burst.size}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+	    <add.trunk.ports 
+			router="${unc.euca.router}"
+			router.type="ex3200"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.ports}"
+			router.user="${router.user}"
+	    	router.password="${router.password}"
+	    	router.admin.password="${router.admin.password}" />
+		</sequential>
+		<property name="shirako.target.code" value="${code}" />
+		<echo message="join exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="leave" depends="resolve.configuration,ben.load.tasks">
+		<echo message="UNC EUCA NET HANDLER: TEARDOWN" />
+		<sequential>
+		<remove.trunk.ports
+			router="${unc.euca.router}"
+			router.type="ex3200"
+			vlan.tag="${unit.vlan.tag}"
+			ports="${config.interface.ports}"
+			router.user="${router.user}"
+			router.password="${router.password}"
+			router.admin.password="${router.admin.password}" />
+    	<delete.vlan 
+    		router="${unc.euca.router}"
+			router.type="ex3200"
+        	vlan.tag="${unit.vlan.tag}"
+			vlan.with.qos="${unit.vlan.with.qos}"
+        	router.user="${router.user}"
+        	router.password="${router.password}"
+        	router.admin.password="${router.admin.password}" />
+		</sequential>
+    	<property name="shirako.target.code" value="${code}" />
+		<echo message="leave exit code: ${shirako.target.code}" />
+	</target>
+
+	<target name="modify" depends="resolve.configuration,ben.load.tasks">
+		<echo message="UNC EUCA NET HANDLER: MODIFY" />
+		<property name="shirako.target.code" value="0" />
+	</target>
 </project>

--- a/plugins/ben/resources/web/interdomain/style.css
+++ b/plugins/ben/resources/web/interdomain/style.css
@@ -1,23 +1,47 @@
-.mainTable { }
-.mainTableCell {
-    padding-right: 5px;
-    padding-left: 20px
+
+.mainTable{
+//        border: 1px solid #001A57;
+//        padding-left: 5px;
+        padding-top: 20px;
+}        
+
+.mainTableCell{
+        padding-right: 5px;
+        padding-left: 20px;
 }
-.masterTable { }
-.workerTable { }
-.batchMenu {
-    border-left: 1px solid #cc3300;
-    padding-left: 20px
+
+.masterTable{
+//        padding-left: 10px;
+        padding-bottom: 10px;
+//        border: 1px solid #CC3300;
+          padding-right: 20px;  
 }
-.batchSummary {
-    border-right: 1px solid #cc3300;
-    padding-right: 20px
+
+.workerTable{
+//        padding-left: 10px;
+        padding-bottom: 10px;
+//        border: 1px solid #CC3300;
+          padding-right: 20px;  
 }
-.batchSummaryCell {
-    color: #001a57;
-    padding-bottom: 10px
+
+
+.batchMenu{
+      border-left: 1px solid #CC3300;
+      padding-left: 20px;
 }
-.menuTable {
-    color: #cc3300;
-    padding-bottom: 10px
+
+.batchSummary{
+      border-right: 1px solid #CC3300;
+      padding-right: 20px;
 }
+
+.batchSummaryCell{
+      color: #001A57;
+      padding-bottom: 10px; 
+}
+
+.menuTable{
+      color: #CC3300;
+      padding-bottom: 10px; 
+}
+  

--- a/plugins/ben/resources/web/nlr/style.css
+++ b/plugins/ben/resources/web/nlr/style.css
@@ -1,23 +1,47 @@
-.mainTable { }
-.mainTableCell {
-    padding-right: 5px;
-    padding-left: 20px
+
+.mainTable{
+//        border: 1px solid #001A57;
+//        padding-left: 5px;
+        padding-top: 20px;
+}        
+
+.mainTableCell{
+        padding-right: 5px;
+        padding-left: 20px;
 }
-.masterTable { }
-.workerTable { }
-.batchMenu {
-    border-left: 1px solid #cc3300;
-    padding-left: 20px
+
+.masterTable{
+//        padding-left: 10px;
+        padding-bottom: 10px;
+//        border: 1px solid #CC3300;
+          padding-right: 20px;  
 }
-.batchSummary {
-    border-right: 1px solid #cc3300;
-    padding-right: 20px
+
+.workerTable{
+//        padding-left: 10px;
+        padding-bottom: 10px;
+//        border: 1px solid #CC3300;
+          padding-right: 20px;  
 }
-.batchSummaryCell {
-    color: #001a57;
-    padding-bottom: 10px
+
+
+.batchMenu{
+      border-left: 1px solid #CC3300;
+      padding-left: 20px;
 }
-.menuTable {
-    color: #cc3300;
-    padding-bottom: 10px
+
+.batchSummary{
+      border-right: 1px solid #CC3300;
+      padding-right: 20px;
 }
+
+.batchSummaryCell{
+      color: #001A57;
+      padding-bottom: 10px; 
+}
+
+.menuTable{
+      color: #CC3300;
+      padding-bottom: 10px; 
+}
+  

--- a/plugins/ben/resources/web/style.css
+++ b/plugins/ben/resources/web/style.css
@@ -1,23 +1,47 @@
-.mainTable { }
-.mainTableCell {
-    padding-right: 5px;
-    padding-left: 20px
+
+.mainTable{
+//        border: 1px solid #001A57;
+//        padding-left: 5px;
+        padding-top: 20px;
+}        
+
+.mainTableCell{
+        padding-right: 5px;
+        padding-left: 20px;
 }
-.masterTable { }
-.workerTable { }
-.batchMenu {
-    border-left: 1px solid #cc3300;
-    padding-left: 20px
+
+.masterTable{
+//        padding-left: 10px;
+        padding-bottom: 10px;
+//        border: 1px solid #CC3300;
+          padding-right: 20px;  
 }
-.batchSummary {
-    border-right: 1px solid #cc3300;
-    padding-right: 20px
+
+.workerTable{
+//        padding-left: 10px;
+        padding-bottom: 10px;
+//        border: 1px solid #CC3300;
+          padding-right: 20px;  
 }
-.batchSummaryCell {
-    color: #001a57;
-    padding-bottom: 10px
+
+
+.batchMenu{
+      border-left: 1px solid #CC3300;
+      padding-left: 20px;
 }
-.menuTable {
-    color: #cc3300;
-    padding-bottom: 10px
+
+.batchSummary{
+      border-right: 1px solid #CC3300;
+      padding-right: 20px;
 }
+
+.batchSummaryCell{
+      color: #001A57;
+      padding-bottom: 10px; 
+}
+
+.menuTable{
+      color: #CC3300;
+      padding-bottom: 10px; 
+}
+  

--- a/pom.xml
+++ b/pom.xml
@@ -520,6 +520,7 @@
                 <version>2.6.0</version>
                 <configuration>
                     <configFile>tools/build/src/main/resources/orca/orca_formatter_style.xml</configFile>
+                    <skipCssFormatting>true</skipCssFormatting>
 
                     <!-- It's annoying to have to specify the directories.
                          Might be fixed at a later date:
@@ -551,6 +552,13 @@
                         <exclude>**/target/package/**/*</exclude>
                         <exclude>**/target/classes/**/*</exclude>
                         <exclude>**/target/pom.xml</exclude>
+                        <!-- additional exclusions from https://github.com/RENCI-NRIG/orca5/issues/176 -->
+                        <exclude>**/handlers/**/*.xml</exclude>
+                        <exclude>**/handler/**/*.xml</exclude>
+                        <exclude>**/handler*.xml</exclude>
+                        <exclude>**/build.xml</exclude>
+                        <exclude>**/test.xml</exclude>
+                        <exclude>**/checkstyle.xml</exclude>
                     </excludes>
                 </configuration>
 

--- a/site/src/site/resources/css/site.css
+++ b/site/src/site/resources/css/site.css
@@ -1,32 +1,37 @@
 a.externalLink, a.externalLink:link, a.externalLink:visited, a.externalLink:active, a.externalLink:hover {
-    background: none;
-    padding-right: 0
+  background: none;
+  padding-right: 0;
 }
+
 body ul {
-    list-style-type: square
+  list-style-type: square;
 }
+
 #downloadbox {
-    float: right;
-    margin-left: 2em;
-    padding-left: 1em;
-    padding-right: 1em;
-    padding-bottom: 1em;
-    border: 1px solid #999999;
-    background-color: #eeeeee;
-    width: 17.5em
+  float: right;
+  margin-left: 2em;
+  padding-left: 1em;
+  padding-right: 1em;
+  padding-bottom: 1em;
+  border: 1px solid #999;
+  background-color: #eee;
+  width: 17.5em;
 }
+
 #downloadbox h5 {
-    color: #000000;
-    margin: 0;
-    border-bottom: 1px solid #aaaaaa;
-    font-size: smaller;
-    padding: 0;
-    margin-top: 1em
+  color: #000;
+  margin: 0;
+  border-bottom: 1px solid #aaaaaa;
+  font-size: smaller;
+  padding: 0;
+  margin-top: 1em;
 }
+
 #downloadbox p {
-    margin-top: 1em;
-    margin-bottom: 0
+  margin-top: 1em;
+  margin-bottom: 0;
 }
+
 #downloadbox li {
-    text-indent: inherit
+  text-indent: inherit;
 }

--- a/tools/build/src/main/resources/orca/checkstyle.xml
+++ b/tools/build/src/main/resources/orca/checkstyle.xml
@@ -1,113 +1,114 @@
-<?xml version="1.0" encoding="UTF-8"?> 
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     This configuration file was written by the eclipse-cs plugin configuration editor
---> 
+-->
 <!--
     Checkstyle-Configuration: orca
     Description: none
---> <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd"> 
-<module name="Checker"> 
-    <property name="severity" value="warning" /> 
-    <module name="TreeWalker"> 
-        <property name="cacheFile" value="/tmp/checkstyle" /> 
-        <module name="JavadocMethod" /> 
-        <module name="JavadocType" /> 
-        <module name="JavadocVariable" /> 
-        <module name="JavadocStyle" /> 
-        <module name="ConstantName" /> 
-        <module name="LocalFinalVariableName" /> 
-        <module name="LocalVariableName" /> 
-        <module name="MemberName" /> 
-        <module name="MethodName" /> 
-        <module name="PackageName" /> 
-        <module name="ParameterName" /> 
-        <module name="StaticVariableName" /> 
-        <module name="TypeName" /> 
-        <module name="AvoidStarImport" /> 
-        <module name="IllegalImport" /> 
-        <module name="RedundantImport" /> 
-        <module name="UnusedImports" /> 
-        <module name="FileLength" /> 
-        <module name="LineLength"> 
-            <property name="max" value="100" /> 
-        </module> 
-        <module name="MethodLength" /> 
-        <module name="ParameterNumber" /> 
-        <module name="EmptyForIteratorPad"> 
-            <property name="severity" value="ignore" /> 
-        </module> 
-        <module name="MethodParamPad"> 
-            <property name="severity" value="ignore" /> 
-        </module> 
-        <module name="NoWhitespaceAfter"> 
-            <property name="severity" value="ignore" /> 
-        </module> 
-        <module name="NoWhitespaceBefore"> 
-            <property name="severity" value="ignore" /> 
-        </module> 
-        <module name="OperatorWrap"> 
-            <property name="severity" value="ignore" /> 
-            <property name="tokens" value="BAND,BOR,BSR,BXOR,COLON,DIV,EQUAL,GE,LAND,LE,LITERAL_INSTANCEOF,LOR,MINUS,MOD,NOT_EQUAL,PLUS,QUESTION,SL,SR,STAR" /> 
-        </module> 
-        <module name="ParenPad"> 
-            <property name="severity" value="ignore" /> 
-        </module> 
-        <module name="TypecastParenPad"> 
-            <property name="severity" value="ignore" /> 
-        </module> 
-        <module name="TabCharacter"> 
-            <property name="severity" value="ignore" /> 
-        </module> 
-        <module name="WhitespaceAround"> 
-            <property name="severity" value="ignore" /> 
-            <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,EQUAL,GE,LAND,LCURLY,LE,LITERAL_ASSERT,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,PLUS_ASSIGN,QUESTION,RCURLY,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,LITERAL_ASSERT,GENERIC_START,GENERIC_END,TYPE_EXTENSION_AND,WILDCARD_TYPE" /> 
-        </module> 
-        <module name="ModifierOrder" /> 
-        <module name="RedundantModifier"> 
-            <property name="severity" value="ignore" /> 
-        </module> 
-        <module name="AvoidNestedBlocks" /> 
-        <module name="EmptyBlock" /> 
-        <module name="LeftCurly"> 
-            <property name="option" value="nl" /> 
-            <property name="tokens" value="CLASS_DEF,INTERFACE_DEF,CTOR_DEF,METHOD_DEF" /> 
-        </module> 
-        <module name="LeftCurly"> 
-            <property name="tokens" value="LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE" /> 
-        </module> 
-        <module name="NeedBraces" /> 
-        <module name="RightCurly" /> 
-        <module name="AvoidInlineConditionals" /> 
-        <module name="DoubleCheckedLocking" /> 
-        <module name="EmptyStatement" /> 
-        <module name="EqualsHashCode" /> 
-        <module name="HiddenField" /> 
-        <module name="IllegalInstantiation" /> 
-        <module name="InnerAssignment" /> 
-        <module name="MagicNumber" /> 
-        <module name="MissingSwitchDefault" /> 
-        <module name="RedundantThrows" /> 
-        <module name="SimplifyBooleanExpression" /> 
-        <module name="SimplifyBooleanReturn" /> 
-        <module name="DesignForExtension"> 
-            <property name="severity" value="ignore" /> 
-        </module> 
-        <module name="FinalClass" /> 
-        <module name="HideUtilityClassConstructor" /> 
-        <module name="InterfaceIsType" /> 
-        <module name="VisibilityModifier" /> 
-        <module name="ArrayTypeStyle" /> 
-        <module name="FinalParameters" /> 
-        <module name="GenericIllegalRegexp"> 
-            <property name="format" value="\s+$" /> 
-            <property name="message" value="Line has trailing spaces." /> 
-        </module> 
-        <module name="TodoComment" /> 
-        <module name="UpperEll" /> 
-        <module name="LineLength"> 
-            <property name="max" value="100" /> 
-        </module> 
-    </module> 
-    <module name="PackageHtml" /> 
-    <module name="Translation" /> 
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+    <property name="severity" value="warning"/>
+    <module name="TreeWalker">
+        <property name="cacheFile" value="/tmp/checkstyle"/>
+        <module name="JavadocMethod"/>
+        <module name="JavadocType"/>
+        <module name="JavadocVariable"/>
+        <module name="JavadocStyle"/>
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="MethodName"/>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+        <module name="FileLength"/>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+        </module>
+        <module name="MethodLength"/>
+        <module name="ParameterNumber"/>
+        <module name="EmptyForIteratorPad">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="MethodParamPad">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="NoWhitespaceAfter">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="NoWhitespaceBefore">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="OperatorWrap">
+            <property name="severity" value="ignore"/>
+            <property name="tokens" value="BAND,BOR,BSR,BXOR,COLON,DIV,EQUAL,GE,LAND,LE,LITERAL_INSTANCEOF,LOR,MINUS,MOD,NOT_EQUAL,PLUS,QUESTION,SL,SR,STAR"/>
+        </module>
+        <module name="ParenPad">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="TypecastParenPad">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="TabCharacter">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="severity" value="ignore"/>
+            <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,EQUAL,GE,LAND,LCURLY,LE,LITERAL_ASSERT,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,PLUS_ASSIGN,QUESTION,RCURLY,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,LITERAL_ASSERT,GENERIC_START,GENERIC_END,TYPE_EXTENSION_AND,WILDCARD_TYPE"/>
+        </module>
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock"/>
+        <module name="LeftCurly">
+            <property name="option" value="nl"/>
+            <property name="tokens" value="CLASS_DEF,INTERFACE_DEF,CTOR_DEF,METHOD_DEF"/>
+        </module>
+        <module name="LeftCurly">
+            <property name="tokens" value="LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="RightCurly"/>
+        <module name="AvoidInlineConditionals"/>
+        <module name="DoubleCheckedLocking"/>
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="HiddenField"/>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
+        <module name="MagicNumber"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="RedundantThrows"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="DesignForExtension">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InterfaceIsType"/>
+        <module name="VisibilityModifier"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="FinalParameters"/>
+        <module name="GenericIllegalRegexp">
+            <property name="format" value="\s+$"/>
+            <property name="message" value="Line has trailing spaces."/>
+        </module>
+        <module name="TodoComment"/>
+        <module name="UpperEll"/>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+        </module>
+    </module>
+    <module name="PackageHtml"/>
+    <module name="Translation"/>
 </module>

--- a/tools/cmdline/build.xml
+++ b/tools/cmdline/build.xml
@@ -1,13 +1,38 @@
-<!DOCTYPE project> 
-<!--ENTITY core SYSTEM "ant/core.xml"--> 
-<!--ENTITY packages SYSTEM "ant/packages.xml"--> 
-<!--ENTITY tests SYSTEM "ant/tests.xml"-->
- ]&gt; 
-<project name="orca.run" default="help" basedir="." xmlns:artifact="urn:maven-artifact-ant">
-     &amp;deps; &amp;core; &amp;packages; &amp;tests; 
-    <target name="help"> 
-        <echo>
-             Build file options: test.handler.prepare - prepares a handler for testing (after mvn clean package) test.handler - tests a handler -Dhandler=path_to_handler -Dtarget=target_to_invoke(join/leave/modify) Other obsolete targets: test.configuration - tests a configuration file -Dconfig=path_to_configuration_file test.reset.inventory - resets the container's inventory -Dconfig=path_to_configuration_file test.unit.reservation.emulation - runs the basic resevation test in emulation test.unit.reservation.real - runs the basic reservation test in real mode 
-        </echo> 
-    </target> 
+<!DOCTYPE project [
+<!ENTITY deps SYSTEM "ant/deps.xml">
+<!ENTITY core SYSTEM "ant/core.xml">
+<!ENTITY packages SYSTEM "ant/packages.xml">
+<!ENTITY tests SYSTEM "ant/tests.xml">
+]>
+<project name="orca.run"
+	default="help"
+	basedir="."
+	xmlns:artifact="urn:maven-artifact-ant">
+
+	&deps;
+	&core;
+	&packages;
+	&tests;
+
+	<target name="help">
+		<echo>
+Build file options:
+
+test.handler.prepare - prepares a handler for testing (after mvn clean package)
+test.handler - tests a handler
+			   -Dhandler=path_to_handler
+			   -Dtarget=target_to_invoke(join/leave/modify)
+
+Other obsolete targets:
+
+test.configuration - tests a configuration file
+			   -Dconfig=path_to_configuration_file			   	
+test.reset.inventory - resets the container's inventory
+			   -Dconfig=path_to_configuration_file			   	
+test.unit.reservation.emulation - runs the basic resevation test in emulation
+test.unit.reservation.real - runs the basic reservation test in real mode
+
+		</echo>
+	</target>
+
 </project>

--- a/tools/config/build.xml
+++ b/tools/config/build.xml
@@ -1,18 +1,80 @@
-<?xml version="1.0" encoding="utf-8"?> <!DOCTYPE project> 
-<!--ENTITY deps SYSTEM "ant/deps.xml"--> 
-<!--ENTITY drivers  SYSTEM "ant/drivers.xml"--> 
-<!--ENTITY na SYSTEM "ant/na.xml"--> 
-<!--ENTITY misc SYSTEM "ant/misc.xml"--> 
-<!--ENTITY paths SYSTEM "ant/paths.xml"--> 
-<!--ENTITY packages SYSTEM "ant/packages.xml"--> 
-<!--ENTITY taskdefs SYSTEM "ant/taskdefs.xml"--> 
-<!--ENTITY security SYSTEM "ant/security.xml"-->
- ]&gt; 
-<project name="orca.tools.config" default="help" basedir="." xmlns:artifact="urn:maven-artifact-ant">
-     &amp;deps; &amp;taskdefs; &amp;core; &amp;security; &amp;na; &amp;misc; &amp;packages; &amp;drivers; 
-    <target name="help"> 
-        <echo>
-             Orca Configuration Tool options: Package operations: get.packages - retrieves all required archives from the repository Node Agent operations: nah.install - installs the node agent host on all machines na.upgrade - upgrades the node agent service on all machines na.start - starts the node agent service on all machines na.stop - stops the node agent service on all machines na.restart - restarts the node agent service on all machines na.status - shows the status of the node agent service on all machines Security operations: security.create.admin.config - creates the admin security configuration security.create.actor.config - creates the security configuration for the given actor security.get.service.key - obtains the service key for all machines and registers the keys in the actor keystore security.register.actor.key - registers the actor key with all node agents security.unauth - unregisters all security keys from the node agent service security.prepare - generates and copies the cmdline file security.setup - registers the admin key with the node agent services Keystore operations: show.keys - shows all keys in the admin keystore show.actor.keys - shows all keys in the given actor keystore remove.key - removes the given key from the admin keystore export.actor.certificate - exports the certificate for the given key from the given actor's keystore export64.actor.certificate - exports the certificate of the specified actor in base64 format Driver operations: drivers.install - installs all drivers on all machines drivers.uninstall - uninstalls all drivers from all machines drivers.upgrade - upgrades all drivers on all machines Miscelaneous operations: guid - generates a GUID 
-        </echo> 
-    </target> 
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE project [
+<!ENTITY core SYSTEM "ant/core.xml">
+<!ENTITY deps SYSTEM "ant/deps.xml">
+<!ENTITY drivers  SYSTEM "ant/drivers.xml">
+<!ENTITY na SYSTEM "ant/na.xml">
+<!ENTITY misc SYSTEM "ant/misc.xml">
+<!ENTITY paths SYSTEM "ant/paths.xml">
+<!ENTITY packages SYSTEM "ant/packages.xml">
+<!ENTITY taskdefs SYSTEM "ant/taskdefs.xml">
+<!ENTITY security SYSTEM "ant/security.xml">
+]>
+
+<project 
+    name="orca.tools.config" 
+    default="help" 
+    basedir="."
+    xmlns:artifact="urn:maven-artifact-ant">
+
+  &deps;
+  &taskdefs;
+  &core;
+  &security;
+  &na;
+  &misc;
+  &packages;	
+  &drivers;
+    
+  <target name="help">
+    <echo>
+Orca Configuration Tool options:
+
+    Package operations:
+    	
+get.packages - retrieves all required archives from the repository
+    	
+    Node Agent operations:
+
+nah.install - installs the node agent host on all machines
+na.upgrade - upgrades the node agent service on all machines    	
+na.start - starts the node agent service on all machines
+na.stop - stops the node agent service on all machines
+na.restart - restarts the node agent service on all machines
+na.status - shows the status of the node agent service on all machines 
+
+    Security operations:
+
+security.create.admin.config - creates the admin security configuration
+security.create.actor.config - creates the security configuration for the given actor
+security.get.service.key - obtains the service key for all machines and registers the keys in the actor keystore
+security.register.actor.key - registers the actor key with all node agents 
+
+security.unauth - unregisters all security keys from the node agent service
+security.prepare - generates and copies the cmdline file
+security.setup - registers the admin key with the node agent services
+    	
+  	Keystore operations:
+
+show.keys - shows all keys in the admin keystore
+show.actor.keys - shows all keys in the given actor keystore
+remove.key - removes the given key from the admin keystore
+export.actor.certificate - exports the certificate for the given key from the given actor's keystore
+export64.actor.certificate - exports the certificate of the specified actor in base64 format
+
+    Driver operations:
+
+drivers.install - installs all drivers on all machines
+drivers.uninstall - uninstalls all drivers from all machines
+drivers.upgrade - upgrades all drivers on all machines
+   
+    Miscelaneous operations:
+
+guid - generates a GUID
+
+
+	</echo>
+  </target>
+
 </project>
+

--- a/tools/site-skin/src/main/resources/css/maven-base.css
+++ b/tools/site-skin/src/main/resources/css/maven-base.css
@@ -1,152 +1,153 @@
 body {
-    margin: 0px;
-    padding: 0px;
-    height: 100%
+  margin: 0px;
+  padding: 0px;
+  height: 100%;
 }
 img {
-    border: none
+  border:none;
 }
 table {
-    padding: 0px;
-    width: 100%;
-    margin-left: -2px;
-    margin-right: -2px
+  padding:0px;
+  width: 100%;
+  margin-left: -2px;
+  margin-right: -2px;
 }
 acronym {
-    cursor: help;
-    border-bottom: 1px dotted #ffeebb
+  cursor: help;
+  border-bottom: 1px dotted #feb;
 }
 table.bodyTable th, table.bodyTable td {
-    padding: 2px 4px 2px 4px;
-    vertical-align: top
+  padding: 2px 4px 2px 4px;
+  vertical-align: top;
 }
-div.clear {
-    clear: both;
-    visibility: hidden
+div.clear{
+  clear:both;
+  visibility: hidden;
 }
-div.clear hr {
-    display: none
+div.clear hr{
+  display: none;
 }
 #bannerLeft, #bannerRight {
-    font-size: xx-large;
-    font-weight: bold
+  font-size: xx-large;
+  font-weight: bold;
 }
 #bannerLeft img, #bannerRight img {
-    margin: 0px
+  margin: 0px;
 }
+
 .xleft, #bannerLeft img {
-    float: left;
-    text-shadow: #7cfc00
+  float:left;
+  text-shadow: #7CFC00;
 }
 .xright, #bannerRight img {
-    float: right;
-    text-shadow: #7cfc00
+  float:right;
+  text-shadow: #7CFC00;
 }
 #banner {
-    padding: 0px
+  padding: 0px;
 }
 #banner img {
-    border: none
+  border: none;
 }
 #breadcrumbs {
-    padding: 3px 10px 3px 10px
+  padding: 3px 10px 3px 10px;
 }
 #leftColumn {
-    width: 200px;
-    float: left;
-    height: 100%;
-    overflow: auto
+ width: 200px;
+ float:left;
+ height:100%;
+ overflow: auto;
 }
 #bodyColumn {
-    margin-right: 1.5em;
-    margin-left: 230px
+  margin-right: 1.5em;
+  margin-left: 230px;
 }
 #legend {
-    padding: 8px 0 8px 0
+  padding: 8px 0 8px 0;
 }
 #navcolumn {
-    padding: 8px 4px 0 8px
+  padding: 8px 4px 0 8px;
 }
 #navcolumn h5 {
-    margin: 0;
-    padding: 0;
-    font-size: small
+  margin: 0;
+  padding: 0;
+  font-size: small;
 }
 #navcolumn ul {
-    margin: 0;
-    padding: 0;
-    font-size: small
+  margin: 0;
+  padding: 0;
+  font-size: small;
 }
 #navcolumn li {
-    list-style-type: none;
-    background-image: none;
-    background-repeat: no-repeat;
-    background-position: 0 0.4em;
-    padding-left: 8px;
-    list-style-position: outside;
-    line-height: 1.2em;
-    font-size: small
+  list-style-type: none;
+  background-image: none;
+  background-repeat: no-repeat;
+  background-position: 0 0.4em;
+  padding-left: 8px;
+  list-style-position: outside;
+  line-height: 1.2em;
+  font-size: small;
 }
 #navcolumn li.expanded {
-    background-image: url(../images/expanded.gif)
+  background-image: url(../images/expanded.gif);
 }
 #navcolumn li.collapsed {
-    background-image: url(../images/collapsed.gif)
+  background-image: url(../images/collapsed.gif);
 }
 #poweredBy {
-    text-align: center;
-    display: none
+  text-align: center;
+  display: none;
 }
 #navcolumn img {
-    margin-top: 10px;
-    margin-bottom: 3px
+  margin-top: 10px;
+  margin-bottom: 3px;
 }
 #poweredBy img {
-    display: block;
-    margin: 20px 0 20px 17px;
-    border: 1px solid black;
-    width: 90px;
-    height: 30px
+  display:block;
+  margin: 20px 0 20px 17px;
+  border: 1px solid black;
+  width: 90px;
+  height: 30px;
 }
 #search img {
     margin: 0px;
-    display: block
+    display: block;
 }
 #search #q, #search #btnG {
-    border: 1px solid #999999;
-    margin-bottom: 10px
+    border: 1px solid #999;
+    margin-bottom:10px;
 }
 #search form {
-    margin: 0px
+    margin: 0px;
 }
 #lastPublished {
-    font-size: x-small
+  font-size: x-small;
 }
 .navSection {
-    margin-bottom: 2px;
-    padding: 8px
+  margin-bottom: 2px;
+  padding: 8px;
 }
 .navSectionHead {
-    font-weight: bold;
-    font-size: x-small
+  font-weight: bold;
+  font-size: x-small;
 }
 .section {
-    padding: 4px
+  padding: 4px;
 }
 #footer {
-    padding: 3px 10px 3px 10px;
-    font-size: x-small
+  padding: 3px 10px 3px 10px;
+  font-size: x-small;
 }
 #breadcrumbs {
-    font-size: x-small;
-    margin: 0pt
+  font-size: x-small;
+  margin: 0pt;
 }
 .source {
-    padding: 12px;
-    margin: 1em 7px 1em 7px
+  padding: 12px;
+  margin: 1em 7px 1em 7px;
 }
 .source pre {
-    margin: 0px;
-    padding: 0px;
-    font-size: 13px
+  margin: 0px;
+  padding: 0px;
+  font-size: 13px;
 }

--- a/tools/site-skin/src/main/resources/css/maven-theme.css
+++ b/tools/site-skin/src/main/resources/css/maven-theme.css
@@ -1,195 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 body {
-    background-color: #ffffff;
-    font-family: Verdana, Helvetica, Arial, sans-serif;
-    margin-left: auto;
-    margin-right: auto;
-    background-repeat: repeat-y;
-    font-size: small;
-    padding: 0px;
-    height: 100%
+  background-color: #fff;
+  font-family: Verdana, Helvetica, Arial, sans-serif;
+  margin-left: auto;
+  margin-right: auto;
+  background-repeat: repeat-y;
+  font-size: small;
+  padding: 0px;
+  height: 100%;
 }
-td, select, input, li {
-    font-family: Verdana, Helvetica, Arial, sans-serif;
-    font-size: small;
-    color: #333333
+
+td, select, input, li{
+  font-family: Verdana, Helvetica, Arial, sans-serif;
+  font-size: small;
+  color:#333333;
 }
-code {
-    font-size: small
+
+code{
+  font-size: small;
 }
 a {
-    text-decoration: none
+  text-decoration: none;
 }
-a:link, a:visited, a:active {
-    color: #cc3300
+a:link, a:visited, a:active{
+  color:#CC3300;
 }
 a:hover {
-    color: #3c5693
+  color: #3C5693;
 }
 #legend li.externalLink {
-    background: url(../images/external.png) left top no-repeat;
-    padding-left: 18px
+  background: url(../images/external.png) left top no-repeat;
+  padding-left: 18px;
 }
 a.externalLink, a.externalLink:link, a.externalLink:visited, a.externalLink:active, a.externalLink:hover {
-    background: url(../images/external.png) right center no-repeat;
-    padding-right: 18px
+  background: url(../images/external.png) right center no-repeat;
+  padding-right: 18px;
 }
 #legend li.newWindow {
-    background: url(../images/newwindow.png) left top no-repeat;
-    padding-left: 18px
+  background: url(../images/newwindow.png) left top no-repeat;
+  padding-left: 18px;
 }
 a.newWindow, a.newWindow:link, a.newWindow:visited, a.newWindow:active, a.newWindow:hover {
-    background: url(../images/newwindow.png) right center no-repeat;
-    padding-right: 18px
+  background: url(../images/newwindow.png) right center no-repeat;
+  padding-right: 18px;
 }
+
+
 h2 {
-    font-size: 17px;
-    color: #333333
+  font-size: 17px;
+  color: #333333;  
 }
+
 h3 {
-    padding: 4px 4px 4px 8px;
-    color: #eeeeee;
-    background-color: #9ea6bb;
-    font-weight: bold;
-    font-size: 14px
+  padding: 4px 4px 4px 8px;
+  color:#eeeeee;
+  background-color: #9ea6bb;
+  font-weight: bold;
+  font-size: 14px;
+  
+/*  background-image: url(../images/h3.jpg);
+  background-repeat: no-repeat;
+  background-position: left bottom;
+*/  
 }
-h3 a:hover {
-    color: #eeeeee
+
+h3 a:hover{
+	color: #eeeeee;
 }
 p {
-    font-size: small;
-    color: #000000
+  font-size: small;
+  color: #000;
 }
 #breadcrumbs {
-    height: 5px;
-    color: white;
-    background-color: #3c5693
+  height: 5px;
+  color: white;
+  background-color: #3C5693; //#9EA6BB; //#EDFAC2;
+  /*background-image: url(../images/breadcrumbs.jpg);*/
+  padding: 5px 10px 14px 20px;
 }
 * html #breadcrumbs {
-    padding-bottom: 8px
+  padding-bottom: 8px;
 }
-#leftColumn {
-    margin: 10px 0 10px 0;
-    border-top-color: #cccccc;
-    border-top-style: solid;
-    border-top-width: 1px;
-    border-right-color: #cccccc;
-    border-right-style: solid;
-    border-right-width: 1px;
-    border-bottom-color: #cccccc;
-    border-bottom-style: solid;
-    border-bottom-width: 1px;
-    padding-right: 5px;
-    padding-left: 5px;
-    background-color: #ffd9c2;
-    height: 100%
+#leftColumn {  
+  margin: 10px 0 10px 0;
+  border-top-color: #ccc;
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-right-color: #ccc;
+  border-right-style: solid;
+  border-right-width: 1px;
+  border-bottom-color: #ccc;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  padding-right: 5px;
+  padding-left: 5px;
+  background-color: #FFD9C2;
+  height: 100%;
 }
 #navcolumn h5 {
-    font-size: small;
-    border-bottom: 1px solid #aaaaaa;
-    padding-top: 2px;
-    color: #001a57
+  font-size: small;
+  border-bottom: 1px solid #aaaaaa;
+  padding-top: 2px;
+  color: #001A57;
 }
-table.bodyTable {
-    border: 1px solid #cccccc;
-    border-spacing: 0px 0px
+
+table.bodyTable{
+	border: 1px solid #ccc;
+	border-spacing: 0px 0px;
 }
+
 table.bodyTable th {
-    text-align: left;
-    font-weight: bold
+  color: #333333
+  background-color: white;
+  text-align: left;
+  font-weight: bold;
 }
+
 table.bodyTable th {
-    font-size: small;
-    background-color: #e6ed8a
+  font-size: small;
+  background-color: #e6ed8a;  
 }
+
 table.bodyTable tr.a:first-child {
-    background-color: #e6ed8a
+  background-color: #e6ed8a;
+  color: #333333
+  font-weight: bold;
 }
+
 table.bodyTable tr.a {
-    background-color: #eeeeee
+  background-color: #eee;
 }
+
 table.bodyTable tr.b {
-    background-color: white
+  background-color: white;
 }
+
 .source {
-    border: 1px solid #cccccc;
-    overflow: auto
+  border: 1px solid #ccc;
+  overflow:auto
 }
 dt {
-    padding: 4px 4px 4px 24px;
-    color: #333333;
-    background-color: #cccccc;
-    font-weight: bold;
-    font-size: 14px;
-    background-image: url(../images/h3.jpg);
-    background-repeat: no-repeat;
-    background-position: left bottom
+  padding: 4px 4px 4px 24px;
+  color: #333333;
+  background-color: #ccc;
+  font-weight: bold;
+  font-size: 14px;
+  background-image: url(../images/h3.jpg);
+  background-repeat: no-repeat;
+  background-position: left bottom;
 }
 .subsectionTitle {
-    font-size: 13px;
-    font-weight: bold;
-    color: #666666
+  font-size: 13px;
+  font-weight: bold;
+  color: #666;
+
 }
+
 table {
-    font-size: small
+  font-size: small;
 }
-.xright {
-    color: white
+.xright{
+  color: white;
 }
 .xright a:link, .xright a:visited, .xright a:active {
-    color: #666666
+  color: #666;
 }
 .xright a:hover {
-    color: #003300
+  color: #003300;
 }
+
+
 .xleft a:link, .xleft a:visited, .xleft a:active {
-    color: white
+  color: white;
 }
 .xleft a:hover {
-    color: #ff8f70
+  color: #FF8F70;
 }
+
 #banner {
-    height: 40px;
-    color: white;
-    background-color: #ff8f70;
-    padding-left: 17px;
-    padding-top: 5px
+  height: 40px;
+  color: white;
+  background-color: #FF8F70;
+  padding-left: 17px;
+  padding-top: 5px;
+  /*background: url(../images/banner.jpg);*/
 }
 #navcolumn ul {
-    margin: 5px 0 15px 0em
+  margin: 5px 0 15px -0em;
 }
 #navcolumn ul a {
-    color: black
+  color: black;
 }
 #navcolumn ul a:hover {
-    color: #cc3300
+  color: #CC3300;
 }
 #intro {
-    border: solid #cccccc 1px;
-    margin: 6px 0px 0px 0px;
-    padding: 10px 40px 10px 40px
+  border: solid #ccc 1px;
+  margin: 6px 0px 0px 0px;
+  padding: 10px 40px 10px 40px;
 }
 .subsection {
-    margin-left: 3px;
-    color: #333333
+  margin-left: 3px;
+  color: #333333;
 }
+
 .subsection p {
-    font-size: small
+  font-size: small;
 }
 #footer {
-    padding: 10px;
-    margin: 20px 0px 20px 0px;
-    border-top: solid #cccccc 1px;
-    color: #333333
+  padding: 10px;
+  margin: 20px 0px 20px 0px;
+  border-top: solid #ccc 1px; 
+  color: #333333;
 }
+
 .errormark, .warningmark, .donemark, .infomark {
-    background: url(../images/icon_error_sml.gif) no-repeat
+  background: url(../images/icon_error_sml.gif) no-repeat;
 }
+
 .warningmark {
-    background-image: url(../images/icon_warning_sml.gif)
+  background-image: url(../images/icon_warning_sml.gif);
 }
+
 .donemark {
-    background-image: url(../images/icon_success_sml.gif)
+  background-image: url(../images/icon_success_sml.gif);
 }
+
 .infomark {
-    background-image: url(../images/icon_info_sml.gif)
+  background-image: url(../images/icon_info_sml.gif);
 }
+
+

--- a/tools/site-skin/src/main/resources/css/print.css
+++ b/tools/site-skin/src/main/resources/css/print.css
@@ -1,7 +1,7 @@
 #banner, #footer, #leftcol, #breadcrumbs, .docs #toc, .docs .courtesylinks, #leftColumn, #navColumn {
-    display: none !important
+	display: none !important;
 }
 #bodyColumn, body.docs div.docs {
-    margin: 0 !important;
-    border: none !important
+	margin: 0 !important;
+	border: none !important
 }


### PR DESCRIPTION
Fixes #176 

Reverts specifically XML files that contained DOCTYPE statements.  The formatter plugin uses Jsoup for XML formatting, and Jsoup seems to have a [known issue with DOCTYPE statements](https://stackoverflow.com/questions/31164415/how-to-preserve-doctype-declarations-when-manipulating-xml-with-jsoup).

Also reverted formatting to CSS files -- the formatter didn't seem to be correctly handling "skip declaration" statements (using `//`, which look like comments, and are probably being used as comments, but that aren't actually comments).

Made some changes to the pom file containing the formatter configuration, to:
1. Skip formatting for _all_ CSS files
1. Skip formatting for _some_ XML files. I would prefer to let `pom.xml` files continue to be cleaned up, but there isn't a good way to exclude XML files that contain DOCTYPE statements.  I wrote some `exclude` directives that include all current XML files that contain DOCTYPE statements (and probably exclude additional XML files as well).