### PR TITLE
178 nodegroup interface sameas

### DIFF
--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
@@ -24,6 +24,9 @@ public class OrcaRegressionModifyTest {
                 { "src/test/resources/122_request.rdf", "src/test/resources/122_nodegroups_increase_modify_request.rdf",
                         23 }, // we don't even have 23, but apparently the controller doesn't check
                 // NodeGroup modify
+                { "src/test/resources/122_with_autoip_request.rdf",
+                        "src/test/resources/122_nodegroups_increase_modify_request.rdf",
+                        23 }, // we don't even have 23
                 { "src/test/resources/122_request.rdf",
                         "src/test/resources/137_nodegroups_increase_by_two_modify_request.rdf", 5 },
                 // NodeGroup modify
@@ -134,6 +137,7 @@ public class OrcaRegressionModifyTest {
             // #122
             System.out.println("Checking for requested Resource Constraints");
             assertReservationsHaveResourceConstraints(computedReservations);
+            assertReservationsHaveCorrectInterfaceParent(slice);
         } else if (requestFilename.contains("137_")) {
             System.out.println("Checking for Network Interfaces");
             // Nodes added in NodeGroup Increase need to have a Network interface

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
@@ -137,7 +137,7 @@ public class OrcaRegressionModifyTest {
             // #122
             System.out.println("Checking for requested Resource Constraints");
             assertReservationsHaveResourceConstraints(computedReservations);
-            assertReservationsHaveCorrectInterfaceParent(slice);
+            assertNodeGroupReservationsHaveCorrectInterfaceNames(slice);
         } else if (requestFilename.contains("137_")) {
             System.out.println("Checking for Network Interfaces");
             // Nodes added in NodeGroup Increase need to have a Network interface

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcAssertions.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcAssertions.java
@@ -377,8 +377,12 @@ public class OrcaXmlrpcAssertions {
                 // Not OK: http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup0/0
                 assertFalse("Invalid parent URI name for " + element.getName() + " " + parentUri,
                         parentUri.matches(".*NodeGroup\\d+/\\d+.*"));
+
+                // OK: http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup0/1/intf
+                // OK: http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup0/021a98a79-b840-432e-9ee7-4ed15a9be83f/intf
+                // Not OK: http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup0/0/1/intf
                 assertTrue("Invalid interface name for " + element.getName() + " " + clientInterface.getName(),
-                        clientInterface.getName().matches(".*NodeGroup\\d+/\\d+/intf"));
+                        clientInterface.getName().matches(".*NodeGroup\\d+/[\\w-]+/intf"));
             }
         }
 

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcAssertions.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcAssertions.java
@@ -354,7 +354,7 @@ public class OrcaXmlrpcAssertions {
      *
      * @param slice
      */
-    protected static void assertReservationsHaveCorrectInterfaceParent(XmlrpcControllerSlice slice) {
+    protected static void assertNodeGroupReservationsHaveCorrectInterfaceNames(XmlrpcControllerSlice slice) {
         Logger logger = Globals.getLogger(OrcaXmlrpcAssertions.class.getSimpleName());
 
         final RequestWorkflow workflow = slice.getWorkflow();
@@ -377,6 +377,8 @@ public class OrcaXmlrpcAssertions {
                 // Not OK: http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup0/0
                 assertFalse("Invalid parent URI name for " + element.getName() + " " + parentUri,
                         parentUri.matches(".*NodeGroup\\d+/\\d+.*"));
+                assertTrue("Invalid interface name for " + element.getName() + " " + clientInterface.getName(),
+                        clientInterface.getName().matches(".*NodeGroup\\d+/\\d+/intf"));
             }
         }
 

--- a/controllers/xmlrpc/src/test/resources/122_with_autoip_request.rdf
+++ b/controllers/xmlrpc/src/test/resources/122_with_autoip_request.rdf
@@ -1,0 +1,94 @@
+<rdf:RDF
+    xmlns:ec2="http://geni-orca.renci.org/owl/ec2.owl#"
+    xmlns:kansei="http://geni-orca.renci.org/owl/kansei.owl#"
+    xmlns:app-color="http://geni-orca.renci.org/owl/app-color.owl#"
+    xmlns:geni="http://geni-orca.renci.org/owl/geni.owl#"
+    xmlns:domain="http://geni-orca.renci.org/owl/domain.owl#"
+    xmlns:eucalyptus="http://geni-orca.renci.org/owl/eucalyptus.owl#"
+    xmlns:collections="http://geni-orca.renci.org/owl/collections.owl#"
+    xmlns:openflow="http://geni-orca.renci.org/owl/openflow.owl#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:exogeni="http://geni-orca.renci.org/owl/exogeni.owl#"
+    xmlns:request="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#"
+    xmlns:layer="http://geni-orca.renci.org/owl/layer.owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:request-schema="http://geni-orca.renci.org/owl/request.owl#"
+    xmlns:ip4="http://geni-orca.renci.org/owl/ip4.owl#"
+    xmlns:planetlab="http://geni-orca.renci.org/owl/planetlab.owl#"
+    xmlns:ethernet="http://geni-orca.renci.org/owl/ethernet.owl#"
+    xmlns:dtn="http://geni-orca.renci.org/owl/dtn.owl#"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:modify-schema="http://geni-orca.renci.org/owl/modify.owl#"
+    xmlns:compute="http://geni-orca.renci.org/owl/compute.owl#"
+    xmlns:topology="http://geni-orca.renci.org/owl/topology.owl#"
+    xmlns:orca="http://geni-orca.renci.org/owl/orca.rdf#" > 
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup1-ip-172-16-100-1">
+    <ip4:netmask>255.255.255.0</ip4:netmask>
+    <layer:label_ID>172.16.100.1</layer:label_ID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/ip4.owl#IPAddress"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup0-ip-172-16-100-2">
+    <ip4:netmask>255.255.255.0</ip4:netmask>
+    <layer:label_ID>172.16.100.2</layer:label_ID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/ip4.owl#IPAddress"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#Term">
+    <time:hasDurationDescription rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#TermDuration"/>
+    <rdf:type rdf:resource="http://www.w3.org/2006/time#Interval"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup0"/>
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup1"/>
+    <layer:atLayer rdf:resource="http://geni-orca.renci.org/owl/ethernet.owl#EthernetNetworkElement"/>
+    <layer:bandwidth rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10000000</layer:bandwidth>
+    <topology:hasGUID>86fac7f8-e0a2-493a-907b-e40ccb0d2814</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#BroadcastConnection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#">
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#NodeGroup0"/>
+    <collections:element rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#NodeGroup1"/>
+    <request-schema:hasTerm rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#Term"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/request.owl#Reservation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#TermDuration">
+    <time:days rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1</time:days>
+    <rdf:type rdf:resource="http://www.w3.org/2006/time#DurationDescription"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup1">
+    <ip4:localIPAddress rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup1-ip-172-16-100-1"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup0">
+    <ip4:localIPAddress rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup0-ip-172-16-100-2"/>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/topology.owl#Interface"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#Centos+6.7+v1.1.0">
+    <topology:hasName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Centos 6.7 v1.1.0</topology:hasName>
+    <topology:hasURL>http://geni-images.renci.org/images/standard/centos/centos6.7-v1.1.0/centos6.7-v1.1.0.xml</topology:hasURL>
+    <topology:hasGUID>0c22c525b8a4f0f480f17587557b57a7a111d198</topology:hasGUID>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#DiskImage"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#NodeGroup0">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup0"/>
+    <topology:hasGUID>ca5da007-e748-405a-961f-e86b3efdfd64</topology:hasGUID>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#Centos+6.7+v1.1.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOXlarge"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <layer:numCE rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</layer:numCE>
+    <request-schema:groupName>NodeGroup0</request-schema:groupName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ServerCloud"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#NodeGroup1">
+    <topology:hasInterface rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#VLAN0-NodeGroup1"/>
+    <topology:hasGUID>47c44496-c03a-474c-ac7b-991dd5ae435a</topology:hasGUID>
+    <compute:diskImage rdf:resource="http://geni-orca.renci.org/owl/713280a5-582a-4b8f-ba31-d03cebf8ba58#Centos+6.7+v1.1.0"/>
+    <compute:specificCE rdf:resource="http://geni-orca.renci.org/owl/exogeni.owl#XOXlarge"/>
+    <domain:hasResourceType rdf:resource="http://geni-orca.renci.org/owl/compute.owl#VM"/>
+    <layer:numCE rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</layer:numCE>
+    <request-schema:groupName>NodeGroup1</request-schema:groupName>
+    <rdf:type rdf:resource="http://geni-orca.renci.org/owl/compute.owl#ServerCloud"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/embed/src/main/java/orca/embed/cloudembed/controller/CloudHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/CloudHandler.java
@@ -729,9 +729,6 @@ public class CloudHandler extends MappingHandler {
         Resource intf_ont = current_intf.getResource();
         if (null != NdlCommons.getSameAsResource(intf_ont)){
             intf_ont = NdlCommons.getSameAsResource(intf_ont);
-
-            // probably should change the current_intf too? but i'm not sure how to find that from the intf_ont
-            //current_intf =
         }
 
         OntModel device_model = element.getModel();
@@ -764,7 +761,8 @@ public class CloudHandler extends MappingHandler {
         netmask = base_ip.netmask;
         String url = null;
         try {
-            new_ip = base_ip.getNewIpAddress(device_model, network_str, netmask, base_ip.getURI(), hole);
+            // #178 use the Ontology Resource URI for the name, since it might have been updated to the `sameAs` interface
+            new_ip = base_ip.getNewIpAddress(device_model, network_str, netmask, intf_ont.getURI(), hole);
 
             // #137, when IPs are not assigned, duplicate interfaces can be created
             if (-1 == hole) {


### PR DESCRIPTION
Fixes #178 

When creating interfaces, the "reference" interface being used to create the new interface must be checked to see if it has a `sameAs` property.  The sameAs interface should be used instead of the original reference interface when creating the new interface.

There were originally two separate `createInterface` functions, with nearly identical operation.  These have been merged into one.

I'll let you guys resolve this pull request after the holidays, and create the newest point release :)