### PR TITLE
178 nodegroup interface sameas

### DIFF
--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
@@ -1,6 +1,9 @@
 package orca.controllers.xmlrpc;
 
 import orca.manage.beans.TicketReservationMng;
+import orca.ndl.NdlCommons;
+
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -18,6 +21,7 @@ public class OrcaRegressionModifyTest {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
+        	/*
                 // Bootscripts need Velocity templating on Modify
                 { "src/test/resources/112_velocityRequest.rdf", "src/test/resources/112_velocityModifyRequest.rdf", 5 },
                 // NodeGroup modify
@@ -82,6 +86,7 @@ public class OrcaRegressionModifyTest {
                 { "../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_request.rdf",
                         "../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_B2_C1_modify_request.rdf",
                         17 },
+                        */
                 // Interdomain modify
                 { "../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_request.rdf",
                         "../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_to_B2_modify_request.rdf",
@@ -145,6 +150,12 @@ public class OrcaRegressionModifyTest {
             assertSliceHasNoDuplicateInterfaces(slice);
         }
 
+    }
+    
+    @BeforeClass
+    public static void setupTests() {
+    	System.out.println("Initializing NDL");
+    	NdlCommons.init();
     }
 
 }

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionModifyTest.java
@@ -21,7 +21,6 @@ public class OrcaRegressionModifyTest {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-        	/*
                 // Bootscripts need Velocity templating on Modify
                 { "src/test/resources/112_velocityRequest.rdf", "src/test/resources/112_velocityModifyRequest.rdf", 5 },
                 // NodeGroup modify
@@ -86,7 +85,6 @@ public class OrcaRegressionModifyTest {
                 { "../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_request.rdf",
                         "../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_B2_C1_modify_request.rdf",
                         17 },
-                        */
                 // Interdomain modify
                 { "../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_request.rdf",
                         "../../embed/src/test/resources/orca/embed/161_interdomain_A1_B1_to_B2_modify_request.rdf",

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionTest.java
@@ -91,11 +91,11 @@ public class OrcaRegressionTest {
                 { "../../embed/src/test/resources/orca/embed/158_mp_one_domain_one_unbound_request.rdf", true, 4 + 0 },
                 { "../../embed/src/test/resources/orca/embed/158_mp_two_domain_one_unbound_request.rdf", true, 4 + 4 },
                 { "../../embed/src/test/resources/orca/embed/158_mp_three_domain_one_unbound_request.rdf", false,
-                        4 + 6 } /*,
+                        4 + 6 },
                 { "../../embed/src/test/resources/orca/embed/41_single_large_nodegroup_unbound_request.rdf", true,
                         133 },
                 { "../../embed/src/test/resources/orca/embed/41_mp_unbound_request.rdf", true, 134 }
-                */
+                
                 // TS8 really only tests Post-boot Scripts. Not useful in Unit tests
                 /*
                  * { "../../embed/src/test/resources/orca/embed/TS8/TS8-1.rdf", true, 12}, {

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaRegressionTest.java
@@ -1,16 +1,21 @@
 package orca.controllers.xmlrpc;
 
-import orca.manage.beans.TicketReservationMng;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.assertEc2InstanceTypePresent;
+import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.assertManifestHasNumberOfComputeElements;
+import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.assertManifestWillProcess;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.*;
-import static org.junit.Assert.assertNotNull;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import orca.manage.beans.TicketReservationMng;
+import orca.ndl.NdlCommons;
 
 @RunWith(Parameterized.class)
 public class OrcaRegressionTest {
@@ -86,10 +91,11 @@ public class OrcaRegressionTest {
                 { "../../embed/src/test/resources/orca/embed/158_mp_one_domain_one_unbound_request.rdf", true, 4 + 0 },
                 { "../../embed/src/test/resources/orca/embed/158_mp_two_domain_one_unbound_request.rdf", true, 4 + 4 },
                 { "../../embed/src/test/resources/orca/embed/158_mp_three_domain_one_unbound_request.rdf", false,
-                        4 + 6 },
+                        4 + 6 } /*,
                 { "../../embed/src/test/resources/orca/embed/41_single_large_nodegroup_unbound_request.rdf", true,
                         133 },
                 { "../../embed/src/test/resources/orca/embed/41_mp_unbound_request.rdf", true, 134 }
+                */
                 // TS8 really only tests Post-boot Scripts. Not useful in Unit tests
                 /*
                  * { "../../embed/src/test/resources/orca/embed/TS8/TS8-1.rdf", true, 12}, {
@@ -158,6 +164,12 @@ public class OrcaRegressionTest {
         }
 
         assertManifestWillProcess(slice);
+    }
+    
+    @BeforeClass
+    public static void setupTests() {
+    	System.out.println("Initializing NDL");
+    	NdlCommons.init();
     }
 
 }

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -491,6 +491,7 @@ public class OrcaXmlrpcHandlerTest {
      *
      * @throws Exception
      */
+    /*
     @Test
     public void testNodeWithTwoInterfacesInterdomainDeleteAdd() throws Exception {
         // Create Request
@@ -537,7 +538,7 @@ public class OrcaXmlrpcHandlerTest {
 
         // can't check that Link Parent and IP address matches very easily in Interdomain
     }
-
+	*/
     /**
      * Start with five nodes, with four nodes each connected to the central node (Node0). Of these starting nodes, three
      * nodes are all bound to RCI (including Node0). The remaining two nodes are bound at UH, for Inter-Domain
@@ -638,6 +639,7 @@ public class OrcaXmlrpcHandlerTest {
      *
      * @throws Exception
      */
+    /*
     @Test
     public void testMixedDomainMultiStepModify() throws Exception {
         // Create Request
@@ -723,7 +725,7 @@ public class OrcaXmlrpcHandlerTest {
         input.close();
         assertExpectedPropertyValues(computedReservations, reservationProperties);
     }
-
+*/
     /**
      * Remove an existing Node, and the inter-domain links. This is not a clean process, because the inter-domain links
      * are not known ahead of time.

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -951,7 +951,7 @@ public class OrcaXmlrpcHandlerTest {
             }
 
             result = orcaXmlrpcHandler.modifySlice(slice_urn, credentials, modReq);
-            Thread.sleep(5000);
+            Thread.sleep(10000);
 
             // verify results of modifySlice()
             assertNotNull(result);

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -1,6 +1,45 @@
 package orca.controllers.xmlrpc;
 
+import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.assertExpectedPropertyCounts;
+import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.assertExpectedPropertyValues;
+import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.assertLinkMatchesIPProperty;
+import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.assertNetmaskPropertyPresent;
+import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.assertReservationsHaveNetworkInterface;
+import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.assertSliceHasNoDuplicateInterfaces;
+import static orca.controllers.xmlrpc.OrcaXmlrpcHandler.ERR_RET_FIELD;
+import static orca.controllers.xmlrpc.OrcaXmlrpcHandler.MSG_RET_FIELD;
+import static orca.controllers.xmlrpc.OrcaXmlrpcHandler.MaxReservationDuration;
+import static orca.controllers.xmlrpc.OrcaXmlrpcHandler.PropertyXmlrpcControllerUrl;
+import static orca.controllers.xmlrpc.OrcaXmlrpcHandler.RET_RET_FIELD;
+import static orca.controllers.xmlrpc.OrcaXmlrpcHandler.TERM_END_FIELD;
+import static orca.controllers.xmlrpc.OrcaXmlrpcHandler.TICKETED_ENTITIES_FIELD;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.log4j.Logger;
+import org.junit.Test;
+
 import com.hp.hpl.jena.ontology.Individual;
+
 import orca.controllers.OrcaController;
 import orca.embed.policyhelpers.DomainResourcePools;
 import orca.embed.policyhelpers.SystemNativeError;
@@ -19,19 +58,6 @@ import orca.ndl.elements.NetworkElement;
 import orca.shirako.common.ReservationID;
 import orca.shirako.common.SliceID;
 import orca.shirako.container.Globals;
-import org.apache.log4j.Logger;
-import org.junit.Test;
-
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.text.SimpleDateFormat;
-import java.util.*;
-
-import static orca.controllers.xmlrpc.OrcaXmlrpcAssertions.*;
-import static orca.controllers.xmlrpc.OrcaXmlrpcHandler.*;
-import static org.junit.Assert.*;
 
 public class OrcaXmlrpcHandlerTest {
 
@@ -491,7 +517,6 @@ public class OrcaXmlrpcHandlerTest {
      *
      * @throws Exception
      */
-    /*
     @Test
     public void testNodeWithTwoInterfacesInterdomainDeleteAdd() throws Exception {
         // Create Request
@@ -538,7 +563,7 @@ public class OrcaXmlrpcHandlerTest {
 
         // can't check that Link Parent and IP address matches very easily in Interdomain
     }
-	*/
+    
     /**
      * Start with five nodes, with four nodes each connected to the central node (Node0). Of these starting nodes, three
      * nodes are all bound to RCI (including Node0). The remaining two nodes are bound at UH, for Inter-Domain
@@ -639,7 +664,6 @@ public class OrcaXmlrpcHandlerTest {
      *
      * @throws Exception
      */
-    /*
     @Test
     public void testMixedDomainMultiStepModify() throws Exception {
         // Create Request
@@ -725,7 +749,7 @@ public class OrcaXmlrpcHandlerTest {
         input.close();
         assertExpectedPropertyValues(computedReservations, reservationProperties);
     }
-*/
+
     /**
      * Remove an existing Node, and the inter-domain links. This is not a clean process, because the inter-domain links
      * are not known ahead of time.
@@ -927,6 +951,7 @@ public class OrcaXmlrpcHandlerTest {
             }
 
             result = orcaXmlrpcHandler.modifySlice(slice_urn, credentials, modReq);
+            Thread.sleep(1000);
 
             // verify results of modifySlice()
             assertNotNull(result);

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -951,7 +951,6 @@ public class OrcaXmlrpcHandlerTest {
             }
 
             result = orcaXmlrpcHandler.modifySlice(slice_urn, credentials, modReq);
-            Thread.sleep(10000);
 
             // verify results of modifySlice()
             assertNotNull(result);

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/OrcaXmlrpcHandlerTest.java
@@ -951,7 +951,7 @@ public class OrcaXmlrpcHandlerTest {
             }
 
             result = orcaXmlrpcHandler.modifySlice(slice_urn, credentials, modReq);
-            Thread.sleep(1000);
+            Thread.sleep(5000);
 
             // verify results of modifySlice()
             assertNotNull(result);

--- a/embed/src/main/java/orca/embed/cloudembed/controller/CloudHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/CloudHandler.java
@@ -797,11 +797,11 @@ public class CloudHandler extends MappingHandler {
         ncByInterface = element.getConnectionByInterfaceName(current_intf);
         ce.setInterfaceName(ncByInterface, new_intf);
 
-        System.out.println("SETTING NEIGHBORHOOD" );
-        System.out.println("  Edge Device " + edge_device.getName());
-        System.out.println("  Link Device " + link_device.getName());
-        System.out.println("  New Intf " + new_intf.getName());
-        System.out.println("  ncByInterface " + ncByInterface.getName());
+        //System.out.println("SETTING NEIGHBORHOOD" );
+        //System.out.println("  Edge Device " + edge_device.getName());
+        //System.out.println("  Link Device " + link_device.getName());
+        //System.out.println("  New Intf " + new_intf.getName());
+        //System.out.println("  ncByInterface " + ncByInterface.getName());
         setEdgeNeighbourhood(edge_device, link_device, new_intf, ncByInterface);
     }
 
@@ -820,30 +820,26 @@ public class CloudHandler extends MappingHandler {
                     if (new_intf.getResource() == null) {
                         logger.error("setEdgeNeighborhood new_intf.getResource() is null - this will cause errors");
                     }
-                    System.out.println("DIRECT");
                     link_device.setFollowedBy(edge_device, new_intf.getResource());
                     edge_device.setPrecededBy(link_device, new_intf.getResource());
                 } else { // Inter-site topology request: link=the neighboring domain; connection = requestconnection
-                	System.out.println("BEFORE LOOP");
                     for (Object de : ce.getDependencies().toArray()) {
                         if (de instanceof NetworkConnection) {
-                        	System.out.println("NetworkConnection");
                             NetworkConnection ne = (NetworkConnection) de;
                             // this IF doesn't fire sometimes for #180
-                            System.out.println("Before IF: ne=" + ne.getName() + " ncByInterface=" + ncByInterface.getName());
                             if (ne.getName().equals(ncByInterface.getName())) {
                                 if (ne.getFirstConnectionElement() != null)
                                     link_device = (DomainElement) ne.getFirstConnectionElement();
-                                System.out.println("LOOP");
                                 link_device.setFollowedBy(edge_device, new_intf.getResource());
                                 edge_device.setPrecededBy(link_device, new_intf.getResource());
+                                // break;
                             }
+                            // break statement must be moved into the if above, however even better not to have it /ib 01/23/18
                             //break;
                         }
                     }
                 }
             } else {
-            	System.out.println("LAST");
                 link_device.setFollowedBy(edge_device, new_intf.getResource());
                 edge_device.setPrecededBy(link_device, new_intf.getResource());
             }

--- a/embed/src/main/java/orca/embed/cloudembed/controller/CloudHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/CloudHandler.java
@@ -341,7 +341,8 @@ public class CloudHandler extends MappingHandler {
         logger.info("CloudHandler.IPAddressRange: domain name=" + domainName);
         // BitSet bSet = this.controllerAssignedLabel.get(domainName);
         BitSet bSet = getAvailableBitSet(domainName);
-        // System.out.println("1. CloudHandler domain="+domainName+";bSet="+bSet);
+        if (debugOn)
+        	System.out.println("1. CloudHandler domain="+domainName+";bSet="+bSet);
         IPAddressRange ip_range = null;
         for (Interface action_intf : intf_list) {
             action_intf_ont = action_intf.getResource();
@@ -369,12 +370,12 @@ public class CloudHandler extends MappingHandler {
                         if (ip_range == null) {
                             ip_range = new IPAddressRange(ip_addr, ip_netmask, ip_addr_ont);
                             ip_range.setbSet(bSet);
-                            // System.out.println("2. CloudHandler controller label
-                            // bSet="+this.controllerAssignedLabel.get(domainName));
+                            if (debugOn)
+                            	System.out.println("2. CloudHandler controller label bSet="+this.controllerAssignedLabel.get(domainName));
                         } else {
                             ip_range.modify(ip_addr, ip_netmask, ip_addr_ont);
-                            // System.out.println("3. CloudHandler controller label
-                            // bSet="+this.controllerAssignedLabel.get(domainName));
+                            if (debugOn) 
+                            	System.out.println("3. CloudHandler controller label bSet="+this.controllerAssignedLabel.get(domainName));
                         }
                     }
                 }
@@ -797,11 +798,13 @@ public class CloudHandler extends MappingHandler {
         ncByInterface = element.getConnectionByInterfaceName(current_intf);
         ce.setInterfaceName(ncByInterface, new_intf);
 
-        //System.out.println("SETTING NEIGHBORHOOD" );
-        //System.out.println("  Edge Device " + edge_device.getName());
-        //System.out.println("  Link Device " + link_device.getName());
-        //System.out.println("  New Intf " + new_intf.getName());
-        //System.out.println("  ncByInterface " + ncByInterface.getName());
+        if (debugOn) {
+        	System.out.println("SETTING NEIGHBORHOOD" );
+        	System.out.println("  Edge Device " + edge_device.getName());
+        	System.out.println("  Link Device " + link_device.getName());
+        	System.out.println("  New Intf " + new_intf.getName());
+        	System.out.println("  ncByInterface " + ncByInterface.getName());
+        }
         setEdgeNeighbourhood(edge_device, link_device, new_intf, ncByInterface);
     }
 
@@ -826,16 +829,18 @@ public class CloudHandler extends MappingHandler {
                     for (Object de : ce.getDependencies().toArray()) {
                         if (de instanceof NetworkConnection) {
                             NetworkConnection ne = (NetworkConnection) de;
-                            // this IF doesn't fire sometimes for #180
+                            // this IF caused problems firing sometimes for #178 due to random order of traversal of array above /ib 01/24/18
                             if (ne.getName().equals(ncByInterface.getName())) {
                                 if (ne.getFirstConnectionElement() != null)
                                     link_device = (DomainElement) ne.getFirstConnectionElement();
                                 link_device.setFollowedBy(edge_device, new_intf.getResource());
                                 edge_device.setPrecededBy(link_device, new_intf.getResource());
-                                // break;
+                                // Ultimately the cause of #178 was the break statement below living outside the enclosing
+                                // IF statement. Now it is in the right place, however we must note that if somehow more
+                                // than one ne matches the enclosing if (due to a bug), the results of this function become
+                                // random. /ib 01/24/18
+                                break;
                             }
-                            // break statement must be moved into the if above, however even better not to have it /ib 01/23/18
-                            //break;
                         }
                     }
                 }

--- a/embed/src/main/java/orca/embed/cloudembed/controller/CloudHandler.java
+++ b/embed/src/main/java/orca/embed/cloudembed/controller/CloudHandler.java
@@ -797,6 +797,11 @@ public class CloudHandler extends MappingHandler {
         ncByInterface = element.getConnectionByInterfaceName(current_intf);
         ce.setInterfaceName(ncByInterface, new_intf);
 
+        System.out.println("SETTING NEIGHBORHOOD" );
+        System.out.println("  Edge Device " + edge_device.getName());
+        System.out.println("  Link Device " + link_device.getName());
+        System.out.println("  New Intf " + new_intf.getName());
+        System.out.println("  ncByInterface " + ncByInterface.getName());
         setEdgeNeighbourhood(edge_device, link_device, new_intf, ncByInterface);
     }
 
@@ -815,23 +820,30 @@ public class CloudHandler extends MappingHandler {
                     if (new_intf.getResource() == null) {
                         logger.error("setEdgeNeighborhood new_intf.getResource() is null - this will cause errors");
                     }
+                    System.out.println("DIRECT");
                     link_device.setFollowedBy(edge_device, new_intf.getResource());
                     edge_device.setPrecededBy(link_device, new_intf.getResource());
                 } else { // Inter-site topology request: link=the neighboring domain; connection = requestconnection
+                	System.out.println("BEFORE LOOP");
                     for (Object de : ce.getDependencies().toArray()) {
                         if (de instanceof NetworkConnection) {
+                        	System.out.println("NetworkConnection");
                             NetworkConnection ne = (NetworkConnection) de;
+                            // this IF doesn't fire sometimes for #180
+                            System.out.println("Before IF: ne=" + ne.getName() + " ncByInterface=" + ncByInterface.getName());
                             if (ne.getName().equals(ncByInterface.getName())) {
                                 if (ne.getFirstConnectionElement() != null)
                                     link_device = (DomainElement) ne.getFirstConnectionElement();
+                                System.out.println("LOOP");
                                 link_device.setFollowedBy(edge_device, new_intf.getResource());
                                 edge_device.setPrecededBy(link_device, new_intf.getResource());
                             }
-                            break;
+                            //break;
                         }
                     }
                 }
             } else {
+            	System.out.println("LAST");
                 link_device.setFollowedBy(edge_device, new_intf.getResource());
                 edge_device.setPrecededBy(link_device, new_intf.getResource());
             }


### PR DESCRIPTION
This is a fix for a unit test failure in removing/adding nodes. There are minor changes to unit test code to ensure that it e.g. uses built-in RDF files instead of going out on the web. The main fix is in CloudHandler, where a break statement has been removed. According to @YufengXin this break statement was misplaced and really belongs in the if statement above, however i feel it is better not to have it at all. 