### PR TITLE
Need to close down connections manually, to avoid CLOSE_WAIT...

### DIFF
--- a/core/shirako/src/main/java/orca/shirako/container/ActorLiveness.java
+++ b/core/shirako/src/main/java/orca/shirako/container/ActorLiveness.java
@@ -145,6 +145,7 @@ public class ActorLiveness {
                     Globals.Log.error("Could not connect to the registry server; registry server may be down", ex);
                 }
                 finally {
+                    connMgr.closeIdleConnections(0);
                     connMgr.shutdown();
                 }
             } catch (Exception e) {


### PR DESCRIPTION
ActorLiveness.TalkToRegistry() is minting SimpleHttpConnectionManager and HttpClient objects all the time - but not properly closing the underlying sockets.

Hence - we get random CLOSE_WAITs hanging around on the actors, pointing to geni.renci.org:15443 (the actor registry).

This *should* resolve the issue.