### PR TITLE
Take 2 of fix; use SO_LINGER and allow GC to run sooner.

### DIFF
--- a/core/shirako/src/main/java/orca/shirako/container/ActorLiveness.java
+++ b/core/shirako/src/main/java/orca/shirako/container/ActorLiveness.java
@@ -112,8 +112,10 @@ public class ActorLiveness {
                 params.addElement(act_guid);
 
                 SimpleHttpConnectionManager connMgr = new SimpleHttpConnectionManager(true);
+                // Connect timeout, 10 seconds; Read timeout, 30 seconds; Close timeout, 1 second.
                 connMgr.getParams().setConnectionTimeout(10*1000);
                 connMgr.getParams().setSoTimeout(30*1000);
+                connMgr.getParams().setLinger(1);
                 HttpClient httpClient = new HttpClient(connMgr);
 
                 try {
@@ -153,6 +155,11 @@ public class ActorLiveness {
             	 */
                 //timer.cancel();
                 Globals.Log.error("Registry1: An error occurred while attempting to send heartbeats for actor: " + act_guid + " to external registry", e);
+            }
+            finally {
+                // Release references, allow GC to clean up ASAP.
+                httpClient = null;
+                connMgr = null;
             }
         }
     }


### PR DESCRIPTION
We set SO_LINGER, in order to force abortive close() if the ActorRegistry isn't responding in a timely fashion. We also force the allocated HttpClient and SimpleHttpConnectionManager out of scope (and maybe allow the GC to collect them sooner).

connMgr.closeIdleConnections(0) was a no-op (in our case), after closely examining the code in commons-httpclient. connMgr.shutdown() does the right thing.