### PR TITLE
Fix handler files for 8700 switch

### DIFF
--- a/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNCreateCRS.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNCreateCRS.xml
@@ -1,13 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/CreateCRS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateCRS CreateCRS.xsd"> 
-    <action name="CreateCRS"> 
-        <exchange> 
-            <send>
-                 ENT-CRS::{$srcPort},{$dstPort}:{$ctag}::2way:PAYLOAD={$payloadType}; 
-            </send> 
-            <expect>
-                 COMPLD 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/CreateCRS"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/CreateCRS CreateCRS.xsd">
+	<action name="CreateCRS">
+		<exchange>
+			<send>ENT-CRS::{$srcPort},{$dstPort}:{$ctag}::2way:PAYLOAD={$payloadType};</send>
+			<expect>COMPLD</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNCreateCRSRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNCreateCRSRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request payloadType="" ctag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateCRSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateCRSRequest CreateCRSRequest.xsd "> 
-    <script>DTNLog_on</script> 
-    <script>DTNCreateCRS</script> 
-    <script>DTNLog_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request payloadType="" ctag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateCRSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateCRSRequest CreateCRSRequest.xsd ">
+  <script>DTNLog_on</script>
+  <script>DTNCreateCRS</script>
+  <script>DTNLog_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNDeleteCRS.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNDeleteCRS.xml
@@ -1,13 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/DeleteCRS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteCRS DeleteCRS.xsd"> 
-    <action name="DeleteCRS"> 
-        <exchange> 
-            <send>
-                 DLT-CRS::{$srcPort},{$dstPort}:{$ctag}; 
-            </send> 
-            <expect>
-                 COMPLD 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/DeleteCRS"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/DeleteCRS DeleteCRS.xsd">
+	<action name="DeleteCRS">
+		<exchange>
+			<send>DLT-CRS::{$srcPort},{$dstPort}:{$ctag};</send>
+			<expect>COMPLD</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNDeleteCRSRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNDeleteCRSRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcPort="" dstPort="" ctag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteCRSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteCRSRequest DeleteCRSRequest.xsd "> 
-    <script>DTNLog_on</script> 
-    <script>DTNDeleteCRS</script> 
-    <script>DTNLog_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcPort="" dstPort="" ctag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteCRSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteCRSRequest DeleteCRSRequest.xsd ">
+  <script>DTNLog_on</script>
+  <script>DTNDeleteCRS</script>
+  <script>DTNLog_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNLog_off.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNLog_off.xml
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/Log_off" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_off Log_off.xsd "> 
-    <action name="Disconnect"> 
-        <exchange> 
-            <send>
-                 canc-user::{$UID}:1:; 
-            </send> 
-            <expect>
-                 COMPLD 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+
+<script xmlns="http://geni-orca.renci.org/Log_off"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://geni-orca.renci.org/Log_off Log_off.xsd ">
+    <action name="Disconnect">
+        <exchange>
+            <send>canc-user::{$UID}:1:;</send>
+            <expect>COMPLD</expect>
+        </exchange>
+    </action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNLog_on.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/dtn/InfineraDTN/DTNLog_on.xml
@@ -1,20 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/Log_on" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd "> 
-    <action name="Connect"> 
-        <exchange> 
-            <send>
-                 ; 
-            </send> 
-            <expect> 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 act-user::{$UID}:1::{$PWD}; 
-            </send> 
+<?xml version="1.0" encoding="UTF-8"?>
+
+<script xmlns="http://geni-orca.renci.org/Log_on"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd ">
+    <action name="Connect">
+        <exchange>
+            <send>;</send>
             <expect>
-                 COMPLD 
-            </expect> 
-        </exchange> 
-    </action> 
+            </expect>
+        </exchange>
+        <exchange>
+            <send>act-user::{$UID}:1::{$PWD};</send>
+            <expect>COMPLD</expect>
+        </exchange>
+    </action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisCreatePatch.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisCreatePatch.xml
@@ -1,13 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/CreatePatch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreatePatch CreatePatch.xsd"> 
-    <action name="CreatePatch"> 
-        <exchange> 
-            <send>
-                 ENT-PATCH::{$inputPort},{$outputPort}:{$ctag}:; 
-            </send> 
-            <expect>
-                 COMPLD 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/CreatePatch"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/CreatePatch CreatePatch.xsd">
+	<action name="CreatePatch">
+		<exchange>
+			<send>ENT-PATCH::{$inputPort},{$outputPort}:{$ctag}:;</send>
+			<expect>COMPLD</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisCreatePatchRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisCreatePatchRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request UID="" PWD="" targetAddr="" ctag="" inputPort="" outputPort="" xmlns="http://geni-orca.renci.org/CreatePatchRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreatePatchRequest CreatePatchRequest.xsd "> 
-    <script>PolatisLog_on</script> 
-    <script>PolatisCreatePatch</script> 
-    <script>PolatisLog_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request UID="" PWD="" targetAddr="" ctag="" inputPort="" outputPort="" xmlns="http://geni-orca.renci.org/CreatePatchRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreatePatchRequest CreatePatchRequest.xsd ">
+  <script>PolatisLog_on</script>
+  <script>PolatisCreatePatch</script>
+  <script>PolatisLog_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisDeletePatch.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisDeletePatch.xml
@@ -1,13 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/DeletePatch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeletePatch DeletePatch.xsd"> 
-    <action name="DeletePatch"> 
-        <exchange> 
-            <send>
-                 DLT-PATCH::{$port}:{$ctag}:; 
-            </send> 
-            <expect>
-                 COMPLD 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/DeletePatch"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/DeletePatch DeletePatch.xsd">
+	<action name="DeletePatch">
+		<exchange>
+			<send>DLT-PATCH::{$port}:{$ctag}:;</send>
+			<expect>COMPLD</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisDeletePatchRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisDeletePatchRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request UID="" PWD="" targetAddr="" ctag="" port="" xmlns="http://geni-orca.renci.org/DeletePatchRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeletePatchRequest DeletePatchRequest.xsd "> 
-    <script>PolatisLog_on</script> 
-    <script>PolatisDeletePatch</script> 
-    <script>PolatisLog_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request UID="" PWD="" targetAddr="" ctag="" port="" xmlns="http://geni-orca.renci.org/DeletePatchRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeletePatchRequest DeletePatchRequest.xsd ">
+  <script>PolatisLog_on</script>
+  <script>PolatisDeletePatch</script>
+  <script>PolatisLog_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisLog_off.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisLog_off.xml
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/Log_off" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_off Log_off.xsd "> 
-    <action name="Disconnect"> 
-        <exchange> 
-            <send>
-                 canc-user::{$UID}:1:; 
-            </send> 
-            <expect>
-                 COMPLD 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/Log_off" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_off Log_off.xsd ">
+	<action name="Disconnect">
+		<exchange>
+		<send>canc-user::{$UID}:1:;</send>
+		<expect>COMPLD</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisLog_on.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/os/polatis/PolatisLog_on.xml
@@ -1,13 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/Log_on" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd "> 
-    <action name="Connect"> 
-        <exchange> 
-            <send>
-                 act-user::{$UID}:1::{$PWD}; 
-            </send> 
-            <expect>
-                 COMPLD 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+
+<script xmlns="http://geni-orca.renci.org/Log_on" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd ">
+	<action name="Connect">
+	  <exchange>
+	    <send>act-user::{$UID}:1::{$PWD};</send>
+	    <expect>COMPLD</expect>
+	  </exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddAccessPort.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddAccessPort.xml
@@ -2,24 +2,16 @@
 <script xmlns="http://geni-orca.renci.org/AddAccessPort" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPort AddAccessPort.xsd"> 
     <action name="AddAccessPort"> 
         <exchange> 
-            <send>
-                 sub-port create sub-port {$subPort} parent-port {$AccessPorts} classifier-precedence {$VLANTagName} 
-            </send> 
+            <send>sub-port create sub-port {$subPort} parent-port {$AccessPorts} classifier-precedence {$VLANTagName}</send> 
         </exchange> 
         <exchange> 
-            <send>
-                 sub-port add sub-port {$subPort} vlan-untagged-data 
-            </send> 
+            <send>sub-port add sub-port {$subPort} vlan-untagged-data</send> 
         </exchange> 
         <exchange> 
-            <send>
-                 sub-port set sub-port {$subPort} ingress-l2-transform push-*.{$VLANTagName}.0 egress-l2-transform pop 
-            </send> 
+            <send>sub-port set sub-port {$subPort} ingress-l2-transform push-*.{$VLANTagName}.0 egress-l2-transform pop</send> 
         </exchange> 
         <exchange> 
-            <send>
-                 virtual-switch interface attach sub-port {$subPort} vs {$virtualSwitch} 
-            </send> 
+            <send>virtual-switch interface attach sub-port {$subPort} vs {$virtualSwitch}</send> 
         </exchange> 
     </action> 
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddAccessPort.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddAccessPort.xml
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/AddAccessPort" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPort AddAccessPort.xsd"> 
-    <action name="AddAccessPort"> 
-        <exchange> 
-            <send>sub-port create sub-port {$subPort} parent-port {$AccessPorts} classifier-precedence {$VLANTagName}</send> 
-        </exchange> 
-        <exchange> 
-            <send>sub-port add sub-port {$subPort} vlan-untagged-data</send> 
-        </exchange> 
-        <exchange> 
-            <send>sub-port set sub-port {$subPort} ingress-l2-transform push-*.{$VLANTagName}.0 egress-l2-transform pop</send> 
-        </exchange> 
-        <exchange> 
-            <send>virtual-switch interface attach sub-port {$subPort} vs {$virtualSwitch}</send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/AddAccessPort" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPort AddAccessPort.xsd">
+	<action name="AddAccessPort">
+		<exchange>
+			<send>sub-port create sub-port {$subPort} parent-port {$AccessPorts} classifier-precedence {$VLANTagName}</send>
+		</exchange>
+		<exchange>
+			<send>sub-port add sub-port {$subPort} vlan-untagged-data</send>
+		</exchange>
+		<exchange>
+			<send>sub-port set sub-port {$subPort} ingress-l2-transform push-*.{$VLANTagName}.0 egress-l2-transform pop</send>
+		</exchange>
+		<exchange>
+			<send>virtual-switch interface attach sub-port {$subPort} vs {$virtualSwitch}</send>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddAccessPortRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddAccessPortRequest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd "> 
-    <script>AddAccessPort</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd ">
+    <script>AddAccessPort</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddAccessQoSPortRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddAccessQoSPortRequest.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd "> 
-    <script>AddAccessPort</script> 
-    <script>AddQoSPort</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd ">
+    <script>AddAccessPort</script>
+    <script>AddQoSPort</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddQoSPort.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddQoSPort.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/AddTrunkPort" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPort AddTrunkPort.xsd "> 
-    <action name="AddTrunkPort"> 
-        <exchange> 
-            <send>
-                 qos-flow create qos-flow-sub-port {$qosPort} parent-sub-port {$subPort} classifier-precedence 1800 ingress-meter-profile {$QoSPolicyName} 
-            </send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/AddTrunkPort" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPort AddTrunkPort.xsd ">
+    <action name="AddTrunkPort">
+        <exchange>
+            <send>qos-flow create qos-flow-sub-port {$qosPort} parent-sub-port {$subPort} classifier-precedence 1800 ingress-meter-profile {$QoSPolicyName}</send>
+        </exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddTrunkPort.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddTrunkPort.xml
@@ -2,19 +2,13 @@
 <script xmlns="http://geni-orca.renci.org/AddTrunkPort" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPort AddTrunkPort.xsd "> 
     <action name="AddTrunkPort"> 
         <exchange> 
-            <send>
-                 sub-port create sub-port {$subPort} parent-port {$TrunkPorts} classifier-precedence {$VLANTagName} 
-            </send> 
+            <send>sub-port create sub-port {$subPort} parent-port {$TrunkPorts} classifier-precedence {$VLANTagName}</send> 
         </exchange> 
         <exchange> 
-            <send>
-                 sub-port add sub-port {$subPort} class-element {$VLANTagName} vtag-stack {$VLANTagName} 
-            </send> 
+            <send>sub-port add sub-port {$subPort} class-element {$VLANTagName} vtag-stack {$VLANTagName}</send> 
         </exchange> 
         <exchange> 
-            <send>
-                 virtual-switch interface attach sub-port {$subPort} vs {$virtualSwitch} 
-            </send> 
+            <send>virtual-switch interface attach sub-port {$subPort} vs {$virtualSwitch}</send> 
         </exchange> 
     </action> 
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddTrunkPort.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddTrunkPort.xml
@@ -1,14 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/AddTrunkPort" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPort AddTrunkPort.xsd "> 
-    <action name="AddTrunkPort"> 
-        <exchange> 
-            <send>sub-port create sub-port {$subPort} parent-port {$TrunkPorts} classifier-precedence {$VLANTagName}</send> 
-        </exchange> 
-        <exchange> 
-            <send>sub-port add sub-port {$subPort} class-element {$VLANTagName} vtag-stack {$VLANTagName}</send> 
-        </exchange> 
-        <exchange> 
-            <send>virtual-switch interface attach sub-port {$subPort} vs {$virtualSwitch}</send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/AddTrunkPort" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPort AddTrunkPort.xsd ">
+    <action name="AddTrunkPort">
+        <exchange>
+            <send>sub-port create sub-port {$subPort} parent-port {$TrunkPorts} classifier-precedence {$VLANTagName}</send>
+        </exchange>
+        <exchange>
+            <send>sub-port add sub-port {$subPort} class-element {$VLANTagName} vtag-stack {$VLANTagName}</send>
+        </exchange>
+        <exchange>
+            <send>virtual-switch interface attach sub-port {$subPort} vs {$virtualSwitch}</send>
+        </exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddTrunkPortRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddTrunkPortRequest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd "> 
-    <script>AddTrunkPort</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd ">
+    <script>AddTrunkPort</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddTrunkQoSPortRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/AddTrunkQoSPortRequest.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd "> 
-    <script>AddTrunkPort</script> 
-    <script>AddQoSPort</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd ">
+    <script>AddTrunkPort</script>
+    <script>AddQoSPort</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/CreateQoSPolicy.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/CreateQoSPolicy.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/CreateQoSPolicy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateQoSPolicy CreateQoSPolicy.xsd"> 
-    <action name="CreateQoSPolicy"> 
-        <exchange> 
-            <send>
-                 traffic-services metering meter-profile create profile {$QoSPolicyName} cir {$QoSRate} cbs {$QoSBurstSize} 
-            </send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/CreateQoSPolicy"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/CreateQoSPolicy CreateQoSPolicy.xsd">
+	<action name="CreateQoSPolicy">
+		<exchange>
+			<send>traffic-services metering meter-profile create profile {$QoSPolicyName} cir {$QoSRate} cbs {$QoSBurstSize}</send>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/CreateVLAN.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/CreateVLAN.xml
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/CreateVLAN" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLAN CreateVLAN.xsd"> 
-    <action name="CreateVLAN"> 
-        <exchange> 
-            <send>virtual-switch create vs {$virtualSwitch}</send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/CreateVLAN"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/CreateVLAN CreateVLAN.xsd">
+	<action name="CreateVLAN">
+        <exchange>
+            <send>virtual-switch create vs {$virtualSwitch}</send>
+        </exchange>
+    </action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/CreateVLAN.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/CreateVLAN.xml
@@ -2,9 +2,7 @@
 <script xmlns="http://geni-orca.renci.org/CreateVLAN" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLAN CreateVLAN.xsd"> 
     <action name="CreateVLAN"> 
         <exchange> 
-            <send>
-                 virtual-switch create vs {$virtualSwitch} 
-            </send> 
+            <send>virtual-switch create vs {$virtualSwitch}</send> 
         </exchange> 
     </action> 
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/CreateVLANRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/CreateVLANRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLANRequest CreateVLANRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>CreateVLAN</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLANRequest CreateVLANRequest.xsd ">
+  <script>Log_on</script>
+  <script>CreateVLAN</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/DeleteQoSPolicy.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/DeleteQoSPolicy.xml
@@ -1,35 +1,25 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/DeleteQoSPolicy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteQoSPolicy DeleteQoSPolicy.xsd"> 
-    <action name="DeleteQoSPolicy"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 policy-map {$QoSPolicyName} 
-            </send> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no class class-default 
-            </send> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 exit 
-            </send> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no policy-map {$QoSPolicyName} 
-            </send> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/DeleteQoSPolicy"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/DeleteQoSPolicy DeleteQoSPolicy.xsd">
+	<action name="DeleteQoSPolicy">
+		<exchange>
+			<send>config t</send>
+		</exchange>
+		<exchange>
+			<send>policy-map {$QoSPolicyName}</send>
+		</exchange>
+		<exchange>
+			<send>no class class-default</send>
+		</exchange>
+		<exchange>
+			<send>exit</send>
+		</exchange>
+		<exchange>
+			<send>no policy-map {$QoSPolicyName}</send>
+		</exchange>
+		<exchange>
+			<send>end</send>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/DeleteVLAN.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/DeleteVLAN.xml
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/DeleteVLAN" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLAN DeleteVLAN.xsd"> 
-    <action name="DeleteVLAN"> 
-        <exchange> 
-            <send>virtual-switch delete vs {$virtualSwitch}</send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/DeleteVLAN"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLAN DeleteVLAN.xsd">
+	<action name="DeleteVLAN">
+        <exchange>
+            <send>virtual-switch delete vs {$virtualSwitch}</send>
+        </exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/DeleteVLAN.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/DeleteVLAN.xml
@@ -2,9 +2,7 @@
 <script xmlns="http://geni-orca.renci.org/DeleteVLAN" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLAN DeleteVLAN.xsd"> 
     <action name="DeleteVLAN"> 
         <exchange> 
-            <send>
-                 virtual-switch delete vs {$virtualSwitch} 
-            </send> 
+            <send>virtual-switch delete vs {$virtualSwitch}</send> 
         </exchange> 
     </action> 
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/DeleteVLANRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/DeleteVLANRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>DeleteVLAN</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd ">
+  <script>Log_on</script>
+  <script>DeleteVLAN</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/Log_off.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/Log_off.xml
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request xmlns="http://geni-orca.renci.org/Log_off" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_off Log_off.xsd "> 
-    <action name="Disconnect"> 
-        <exchange> 
-            <send>
-                 exit 
-            </send> 
-            <expect>
-                 eof 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request xmlns="http://geni-orca.renci.org/Log_off" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_off Log_off.xsd ">
+	<action name="Disconnect">
+		<exchange>
+		<send>exit</send>
+		<expect>eof</expect>
+		</exchange>
+	</action>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/Log_on.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/Log_on.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request xmlns="http://geni-orca.renci.org/Log_on" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd "> 
-    <action name="Connect"> 
-        <exchange> 
-            <send>system show host-name</send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+
+<request xmlns="http://geni-orca.renci.org/Log_on" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd ">
+	<action name="Connect">
+	  <exchange>
+	    <send>system show host-name</send>
+	  </exchange>
+	</action>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/Log_on.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/Log_on.xml
@@ -2,9 +2,7 @@
 <request xmlns="http://geni-orca.renci.org/Log_on" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd "> 
     <action name="Connect"> 
         <exchange> 
-            <send>
-                 system show host-name 
-            </send> 
+            <send>system show host-name</send> 
         </exchange> 
     </action> 
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/MapVLANS.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/MapVLANS.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/MapVLANS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/MapVLANS MapVLANS.xsd"> 
-    <action name="MapVLANS"> 
-        <exchange> 
-            <send>
-                 sub-port set sub-port {$subPort} ingress-l2-transform stamp-*.{$dstVLAN}.* egress-l2-transform stamp-*.{$srcVLAN}.* 
-            </send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/MapVLANS"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/MapVLANS MapVLANS.xsd">
+	<action name="MapVLANS">
+		<exchange>
+			<send>sub-port set sub-port {$subPort} ingress-l2-transform stamp-*.{$dstVLAN}.* egress-l2-transform stamp-*.{$srcVLAN}.*</send>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/MapVLANSRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/MapVLANSRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/MapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/MapVLANSRequest MapVLANSRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>MapVLANS</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/MapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/MapVLANSRequest MapVLANSRequest.xsd ">
+  <script>Log_on</script>
+  <script>MapVLANS</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/RemoveAccessPortsRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/RemoveAccessPortsRequest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveAccessPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveAccessPortsRequest RemoveAccessPortsRequest.xsd "> 
-    <script>RemoveSubPort</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveAccessPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveAccessPortsRequest RemoveAccessPortsRequest.xsd ">
+  <script>RemoveSubPort</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/RemoveSubPort.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/RemoveSubPort.xml
@@ -1,15 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/RemoveTrunkPorts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPorts RemoveTrunkPorts.xsd"> 
-    <action name="RemoveSubPort" parameter="subPort"> 
-        <exchange> 
-            <send>
-                 virtual-switch interface detach sub-port {$subPort} 
-            </send> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 sub-port delete sub-port {$subPort} 
-            </send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/RemoveTrunkPorts"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPorts RemoveTrunkPorts.xsd">
+    <action name="RemoveSubPort" parameter="subPort">
+        <exchange>
+            <send>virtual-switch interface detach sub-port {$subPort}</send>
+        </exchange>
+        <exchange>
+            <send>sub-port delete sub-port {$subPort}</send>
+        </exchange>
+    </action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/RemoveTrunkPortsRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/RemoveTrunkPortsRequest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveTrunkPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPortsRequest RemoveTrunkPortsRequest.xsd "> 
-    <script>RemoveSubPort</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveTrunkPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPortsRequest RemoveTrunkPortsRequest.xsd ">
+  <script>RemoveSubPort</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/UnmapVLANS.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/UnmapVLANS.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/UnmapVLANS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANS UnmapVLANS.xsd"> 
-    <action name="UnmapVLANS"> 
-        <exchange> 
-            <send>
-                 sub-port unset sub-port {$subPort} ingress-l2-transform egress-l2-transform 
-            </send> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/UnmapVLANS"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANS UnmapVLANS.xsd">
+	<action name="UnmapVLANS">
+        <exchange>
+            <send>sub-port unset sub-port {$subPort} ingress-l2-transform egress-l2-transform</send>
+        </exchange>
+    </action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/UnmapVLANSRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/ciena/8700/UnmapVLANSRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/UnmapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANSRequest UnmapVLANSRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>UnmapVLANS</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/UnmapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANSRequest UnmapVLANSRequest.xsd ">
+  <script>Log_on</script>
+  <script>UnmapVLANS</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/AddAccessPorts.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/AddAccessPorts.xml
@@ -1,61 +1,35 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/AddAccessPorts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPorts AddAccessPorts.xsd"> 
-    <action name="AddAccessPorts" parameter="AccessPorts"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface range {$AccessPorts} 
-            </send> 
-            <expect timeout="4000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport mode access 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport access vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no shut 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/AddAccessPorts"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPorts AddAccessPorts.xsd">
+	<action name="AddAccessPorts" parameter="AccessPorts">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface range {$AccessPorts}</send>
+			<expect timeout="4000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport mode access</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport access vlan {$VLANTagName}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no shut</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/AddAccessPortsRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/AddAccessPortsRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/AddAccessPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPortsRequest AddAccessPortsRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>AddAccessPorts</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/AddAccessPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPortsRequest AddAccessPortsRequest.xsd ">
+  <script>Log_on</script>
+  <script>AddAccessPorts</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/AddTrunkPorts.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/AddTrunkPorts.xml
@@ -1,77 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/AddTrunkPorts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPorts AddTrunkPorts.xsd"> 
-    <action name="AddTrunkPorts" parameter="TrunkPorts"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface range {$TrunkPorts} 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport trunk encapsulation dot1q 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport trunk allowed vlan add {$VLANTagName} 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport mode trunk 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 mls qos vlan-based 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no shut 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/AddTrunkPorts"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPorts AddTrunkPorts.xsd">
+	<action name="AddTrunkPorts" parameter="TrunkPorts">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface range {$TrunkPorts}</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport trunk encapsulation dot1q</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport trunk allowed vlan add {$VLANTagName}</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport mode trunk</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>mls qos vlan-based</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no shut</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/AddTrunkPortsRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/AddTrunkPortsRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/AddTrunkPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPortsRequest AddTrunkPortsRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>AddTrunkPorts</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/AddTrunkPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPortsRequest AddTrunkPortsRequest.xsd ">
+  <script>Log_on</script>
+  <script>AddTrunkPorts</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/CreateQoSPolicy.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/CreateQoSPolicy.xml
@@ -1,77 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/CreateQoSPolicy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateQoSPolicy CreateQoSPolicy.xsd"> 
-    <action name="CreateQoSPolicy"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 policy-map {$QoSPolicyName} 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 class class-default 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 police {$QoSRate} {$QoSBurstSize} {$QoSBurstSize} conform-action transmit exceed-action drop 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 exit 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 service-policy input {$QoSPolicyName} 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 service-policy output {$QoSPolicyName} 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/CreateQoSPolicy"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/CreateQoSPolicy CreateQoSPolicy.xsd">
+	<action name="CreateQoSPolicy">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>policy-map {$QoSPolicyName}</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>class class-default</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>police {$QoSRate} {$QoSBurstSize} {$QoSBurstSize} conform-action transmit exceed-action drop</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>exit</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface vlan {$VLANTagName}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>service-policy input {$QoSPolicyName}</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>service-policy output {$QoSPolicyName}</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/CreateQoSVLANRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/CreateQoSVLANRequest.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLANRequest CreateVLANRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>CreateVLAN</script> 
-    <script>CreateQoSPolicy</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLANRequest CreateVLANRequest.xsd ">
+  <script>Log_on</script>
+  <script>CreateVLAN</script>
+  <script>CreateQoSPolicy</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/CreateVLAN.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/CreateVLAN.xml
@@ -1,69 +1,39 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/CreateVLAN" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLAN CreateVLAN.xsd"> 
-    <action name="CreateVLAN"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 name "{$VLANName}" 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 exit 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 logging event link-status 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no shut 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/CreateVLAN"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/CreateVLAN CreateVLAN.xsd">
+	<action name="CreateVLAN">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>vlan {$VLANTagName}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>name "{$VLANName}"</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>exit</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface vlan {$VLANTagName}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>logging event link-status</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no shut</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/CreateVLANRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/CreateVLANRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLANRequest CreateVLANRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>CreateVLAN</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLANRequest CreateVLANRequest.xsd ">
+  <script>Log_on</script>
+  <script>CreateVLAN</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/DeleteQoSPolicy.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/DeleteQoSPolicy.xml
@@ -1,53 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/DeleteQoSPolicy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteQoSPolicy DeleteQoSPolicy.xsd"> 
-    <action name="DeleteQoSPolicy"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 policy-map {$QoSPolicyName} 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no class class-default 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 exit 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no policy-map {$QoSPolicyName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/DeleteQoSPolicy"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/DeleteQoSPolicy DeleteQoSPolicy.xsd">
+	<action name="DeleteQoSPolicy">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>policy-map {$QoSPolicyName}</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no class class-default</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>exit</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no policy-map {$QoSPolicyName}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/DeleteQoSVLANRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/DeleteQoSVLANRequest.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>DeleteQoSPolicy</script> 
-    <script>DeleteVLAN</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd ">
+  <script>Log_on</script>
+  <script>DeleteQoSPolicy</script>
+  <script>DeleteVLAN</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/DeleteVLAN.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/DeleteVLAN.xml
@@ -1,29 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/DeleteVLAN" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLAN DeleteVLAN.xsd"> 
-    <action name="DeleteVLAN"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="4000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/DeleteVLAN"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLAN DeleteVLAN.xsd">
+	<action name="DeleteVLAN">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no vlan {$VLANTagName}</send>
+			<expect timeout="4000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/DeleteVLANRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/DeleteVLANRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>DeleteVLAN</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd ">
+  <script>Log_on</script>
+  <script>DeleteVLAN</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/Log_off.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/Log_off.xml
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/Log_off" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_off Log_off.xsd "> 
-    <action name="Disconnect"> 
-        <exchange> 
-            <send>
-                 exit 
-            </send> 
-            <expect>
-                 eof 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/Log_off" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_off Log_off.xsd ">
+	<action name="Disconnect">
+		<exchange>
+		<send>exit</send>
+		<expect>eof</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/Log_on.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/Log_on.xml
@@ -1,21 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/Log_on" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd "> 
-    <action name="Connect"> 
-        <exchange> 
-            <send>
-                 en 
-            </send> 
-            <expect timeout="2000">
-                 Password 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 {$adminPWD} 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+
+<script xmlns="http://geni-orca.renci.org/Log_on" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd ">
+	<action name="Connect">
+	  <exchange>
+	    <send>en</send>
+	    <expect timeout="2000">Password</expect>
+	  </exchange>
+	  <exchange>
+	    <send>{$adminPWD}</send>
+	    <expect>{$DefaultPrompt}</expect>
+	  </exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/MapVLANS.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/MapVLANS.xml
@@ -1,61 +1,35 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/MapVLANS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/MapVLANS MapVLANS.xsd"> 
-    <action name="MapVLANS"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface {$port} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport vlan mapping enable 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport vlan mapping {$srcVLAN} {$dstVLAN} 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no shut 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/MapVLANS"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/MapVLANS MapVLANS.xsd">
+	<action name="MapVLANS">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface {$port}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport vlan mapping enable</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport vlan mapping {$srcVLAN} {$dstVLAN}</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no shut</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/MapVLANSRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/MapVLANSRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/MapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/MapVLANSRequest MapVLANSRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>MapVLANS</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/MapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/MapVLANSRequest MapVLANSRequest.xsd ">
+  <script>Log_on</script>
+  <script>MapVLANS</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/RemoveAccessPorts.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/RemoveAccessPorts.xml
@@ -1,37 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/RemoveAccessPorts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveAccessPorts RemoveAccessPorts.xsd"> 
-    <action name="RemoveAccessPorts" parameter="AccessPorts"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface range {$AccessPorts} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no switchport access vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="4000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/RemoveAccessPorts"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://geni-orca.renci.org/RemoveAccessPorts RemoveAccessPorts.xsd">
+    <action name="RemoveAccessPorts" parameter="AccessPorts">
+        <exchange>
+            <send>config t</send>
+            <expect>{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>interface range {$AccessPorts}</send>
+            <expect timeout="3000">{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>no switchport access vlan {$VLANTagName}</send>
+            <expect timeout="4000">{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>end</send>
+            <expect>{$DefaultPrompt}</expect>
+        </exchange>
+    </action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/RemoveAccessPortsRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/RemoveAccessPortsRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveAccessPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveAccessPortsRequest RemoveAccessPortsRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>RemoveAccessPorts</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveAccessPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveAccessPortsRequest RemoveAccessPortsRequest.xsd ">
+  <script>Log_on</script>
+  <script>RemoveAccessPorts</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/RemoveTrunkPorts.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/RemoveTrunkPorts.xml
@@ -1,37 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/RemoveTrunkPorts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPorts RemoveTrunkPorts.xsd"> 
-    <action name="RemoveTrunkPorts" parameter="TrunkPorts"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface range {$TrunkPorts} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport trunk allowed vlan remove {$VLANTagName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/RemoveTrunkPorts"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPorts RemoveTrunkPorts.xsd">
+    <action name="RemoveTrunkPorts" parameter="TrunkPorts">
+        <exchange>
+            <send>config t</send>
+            <expect>{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>interface range {$TrunkPorts}</send>
+            <expect timeout="3000">{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>switchport trunk allowed vlan remove {$VLANTagName}</send>
+            <expect timeout="3000">{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>end</send>
+            <expect>{$DefaultPrompt}</expect>
+        </exchange>
+    </action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/RemoveTrunkPortsRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/RemoveTrunkPortsRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveTrunkPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPortsRequest RemoveTrunkPortsRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>RemoveTrunkPorts</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveTrunkPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPortsRequest RemoveTrunkPortsRequest.xsd ">
+  <script>Log_on</script>
+  <script>RemoveTrunkPorts</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/UnmapVLANS.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/UnmapVLANS.xml
@@ -1,37 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/UnmapVLANS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANS UnmapVLANS.xsd"> 
-    <action name="UnmapVLANS"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface {$port} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no switchport vlan mapping {$srcVLAN} {$dstVLAN} 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/UnmapVLANS"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANS UnmapVLANS.xsd">
+	<action name="UnmapVLANS">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface {$port}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no switchport vlan mapping {$srcVLAN} {$dstVLAN}</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/UnmapVLANSRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/3400/UnmapVLANSRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/UnmapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANSRequest UnmapVLANSRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>UnmapVLANS</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/UnmapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANSRequest UnmapVLANSRequest.xsd ">
+  <script>Log_on</script>
+  <script>UnmapVLANS</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/AddAccessPorts.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/AddAccessPorts.xml
@@ -1,61 +1,35 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/AddAccessPorts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPorts AddAccessPorts.xsd"> 
-    <action name="AddAccessPorts" parameter="AccessPorts"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface range {$AccessPorts} 
-            </send> 
-            <expect timeout="4000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport mode access 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport access vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no shut 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/AddAccessPorts"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPorts AddAccessPorts.xsd">
+	<action name="AddAccessPorts" parameter="AccessPorts">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface range {$AccessPorts}</send>
+			<expect timeout="4000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport mode access</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport access vlan {$VLANTagName}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no shut</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/AddAccessPortsRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/AddAccessPortsRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/AddAccessPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPortsRequest AddAccessPortsRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>AddAccessPorts</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/AddAccessPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddAccessPortsRequest AddAccessPortsRequest.xsd ">
+  <script>Log_on</script>
+  <script>AddAccessPorts</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/AddTrunkPorts.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/AddTrunkPorts.xml
@@ -1,77 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/AddTrunkPorts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPorts AddTrunkPorts.xsd"> 
-    <action name="AddTrunkPorts" parameter="TrunkPorts"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface range {$TrunkPorts} 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport trunk encapsulation dot1q 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport trunk allowed vlan add {$VLANTagName} 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport mode trunk 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 mls qos vlan-based 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no shut 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/AddTrunkPorts"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPorts AddTrunkPorts.xsd">
+	<action name="AddTrunkPorts" parameter="TrunkPorts">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface range {$TrunkPorts}</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport trunk encapsulation dot1q</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport trunk allowed vlan add {$VLANTagName}</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport mode trunk</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>mls qos vlan-based</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no shut</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/AddTrunkPortsRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/AddTrunkPortsRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/AddTrunkPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPortsRequest AddTrunkPortsRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>AddTrunkPorts</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/AddTrunkPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/AddTrunkPortsRequest AddTrunkPortsRequest.xsd ">
+  <script>Log_on</script>
+  <script>AddTrunkPorts</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/CreateQoSPolicy.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/CreateQoSPolicy.xml
@@ -1,77 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/CreateQoSPolicy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateQoSPolicy CreateQoSPolicy.xsd"> 
-    <action name="CreateQoSPolicy"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 policy-map {$QoSPolicyName} 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 class class-default 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 police {$QoSRate} {$QoSBurstSize} {$QoSBurstSize} conform-action transmit exceed-action drop 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 exit 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 service-policy input {$QoSPolicyName} 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 service-policy output {$QoSPolicyName} 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/CreateQoSPolicy"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/CreateQoSPolicy CreateQoSPolicy.xsd">
+	<action name="CreateQoSPolicy">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>policy-map {$QoSPolicyName}</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>class class-default</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>police {$QoSRate} {$QoSBurstSize} {$QoSBurstSize} conform-action transmit exceed-action drop</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>exit</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface vlan {$VLANTagName}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>service-policy input {$QoSPolicyName}</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>service-policy output {$QoSPolicyName}</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/CreateQoSVLANRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/CreateQoSVLANRequest.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLANRequest CreateVLANRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>CreateVLAN</script> 
-    <script>CreateQoSPolicy</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLANRequest CreateVLANRequest.xsd ">
+  <script>Log_on</script>
+  <script>CreateVLAN</script>
+  <script>CreateQoSPolicy</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/CreateVLAN.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/CreateVLAN.xml
@@ -1,69 +1,39 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/CreateVLAN" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLAN CreateVLAN.xsd"> 
-    <action name="CreateVLAN"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 name "{$VLANName}" 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 exit 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 logging event link-status 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no shut 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/CreateVLAN"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/CreateVLAN CreateVLAN.xsd">
+	<action name="CreateVLAN">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>vlan {$VLANTagName}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>name "{$VLANName}"</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>exit</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface vlan {$VLANTagName}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>logging event link-status</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no shut</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/CreateVLANRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/CreateVLANRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLANRequest CreateVLANRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>CreateVLAN</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/CreateVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/CreateVLANRequest CreateVLANRequest.xsd ">
+  <script>Log_on</script>
+  <script>CreateVLAN</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/DeleteQoSPolicy.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/DeleteQoSPolicy.xml
@@ -1,53 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/DeleteQoSPolicy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteQoSPolicy DeleteQoSPolicy.xsd"> 
-    <action name="DeleteQoSPolicy"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 policy-map {$QoSPolicyName} 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no class class-default 
-            </send> 
-            <expect timeout="2000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 exit 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no policy-map {$QoSPolicyName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/DeleteQoSPolicy"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/DeleteQoSPolicy DeleteQoSPolicy.xsd">
+	<action name="DeleteQoSPolicy">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>policy-map {$QoSPolicyName}</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no class class-default</send>
+			<expect timeout="2000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>exit</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no policy-map {$QoSPolicyName}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/DeleteQoSVLANRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/DeleteQoSVLANRequest.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>DeleteQoSPolicy</script> 
-    <script>DeleteVLAN</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd ">
+  <script>Log_on</script>
+  <script>DeleteQoSPolicy</script>
+  <script>DeleteVLAN</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/DeleteVLAN.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/DeleteVLAN.xml
@@ -1,29 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/DeleteVLAN" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLAN DeleteVLAN.xsd"> 
-    <action name="DeleteVLAN"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="4000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/DeleteVLAN"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLAN DeleteVLAN.xsd">
+	<action name="DeleteVLAN">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no vlan {$VLANTagName}</send>
+			<expect timeout="4000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/DeleteVLANRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/DeleteVLANRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>DeleteVLAN</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request VLAN_Tag="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/DeleteVLANRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/DeleteVLANRequest DeleteVLANRequest.xsd ">
+  <script>Log_on</script>
+  <script>DeleteVLAN</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/Log_off.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/Log_off.xml
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/Log_off" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_off Log_off.xsd "> 
-    <action name="Disconnect"> 
-        <exchange> 
-            <send>
-                 exit 
-            </send> 
-            <expect>
-                 eof 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/Log_off" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_off Log_off.xsd ">
+	<action name="Disconnect">
+		<exchange>
+		<send>exit</send>
+		<expect>eof</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/Log_on.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/Log_on.xml
@@ -1,21 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/Log_on" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd "> 
-    <action name="Connect"> 
-        <exchange> 
-            <send>
-                 en 
-            </send> 
-            <expect timeout="2000">
-                 Password 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 {$adminPWD} 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+
+<script xmlns="http://geni-orca.renci.org/Log_on" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/Log_on Log_on.xsd ">
+	<action name="Connect">
+	  <exchange>
+	    <send>en</send>
+	    <expect timeout="2000">Password</expect>
+	  </exchange>
+	  <exchange>
+	    <send>{$adminPWD}</send>
+	    <expect>{$DefaultPrompt}</expect>
+	  </exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/MapVLANS.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/MapVLANS.xml
@@ -1,61 +1,35 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/MapVLANS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/MapVLANS MapVLANS.xsd"> 
-    <action name="MapVLANS"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface {$port} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport vlan mapping enable 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport vlan mapping {$srcVLAN} {$dstVLAN} 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no shut 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/MapVLANS"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/MapVLANS MapVLANS.xsd">
+	<action name="MapVLANS">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface {$port}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport vlan mapping enable</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>switchport vlan mapping {$srcVLAN} {$dstVLAN}</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no shut</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/MapVLANSRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/MapVLANSRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/MapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/MapVLANSRequest MapVLANSRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>MapVLANS</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/MapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/MapVLANSRequest MapVLANSRequest.xsd ">
+  <script>Log_on</script>
+  <script>MapVLANS</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/RemoveAccessPorts.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/RemoveAccessPorts.xml
@@ -1,37 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/RemoveAccessPorts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveAccessPorts RemoveAccessPorts.xsd"> 
-    <action name="RemoveAccessPorts" parameter="AccessPorts"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface range {$AccessPorts} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no switchport access vlan {$VLANTagName} 
-            </send> 
-            <expect timeout="4000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/RemoveAccessPorts"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://geni-orca.renci.org/RemoveAccessPorts RemoveAccessPorts.xsd">
+    <action name="RemoveAccessPorts" parameter="AccessPorts">
+        <exchange>
+            <send>config t</send>
+            <expect>{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>interface range {$AccessPorts}</send>
+            <expect timeout="3000">{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>no switchport access vlan {$VLANTagName}</send>
+            <expect timeout="4000">{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>end</send>
+            <expect>{$DefaultPrompt}</expect>
+        </exchange>
+    </action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/RemoveAccessPortsRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/RemoveAccessPortsRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveAccessPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveAccessPortsRequest RemoveAccessPortsRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>RemoveAccessPorts</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveAccessPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveAccessPortsRequest RemoveAccessPortsRequest.xsd ">
+  <script>Log_on</script>
+  <script>RemoveAccessPorts</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/RemoveTrunkPorts.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/RemoveTrunkPorts.xml
@@ -1,37 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/RemoveTrunkPorts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPorts RemoveTrunkPorts.xsd"> 
-    <action name="RemoveTrunkPorts" parameter="TrunkPorts"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface range {$TrunkPorts} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 switchport trunk allowed vlan remove {$VLANTagName} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/RemoveTrunkPorts"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPorts RemoveTrunkPorts.xsd">
+    <action name="RemoveTrunkPorts" parameter="TrunkPorts">
+        <exchange>
+            <send>config t</send>
+            <expect>{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>interface range {$TrunkPorts}</send>
+            <expect timeout="3000">{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>switchport trunk allowed vlan remove {$VLANTagName}</send>
+            <expect timeout="3000">{$DefaultPrompt}</expect>
+        </exchange>
+        <exchange>
+            <send>end</send>
+            <expect>{$DefaultPrompt}</expect>
+        </exchange>
+    </action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/RemoveTrunkPortsRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/RemoveTrunkPortsRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveTrunkPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPortsRequest RemoveTrunkPortsRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>RemoveTrunkPorts</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/RemoveTrunkPortsRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/RemoveTrunkPortsRequest RemoveTrunkPortsRequest.xsd ">
+  <script>Log_on</script>
+  <script>RemoveTrunkPorts</script>
+  <script>Log_off</script>
 </request>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/UnmapVLANS.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/UnmapVLANS.xml
@@ -1,37 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<script xmlns="http://geni-orca.renci.org/UnmapVLANS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANS UnmapVLANS.xsd"> 
-    <action name="UnmapVLANS"> 
-        <exchange> 
-            <send>
-                 config t 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 interface {$port} 
-            </send> 
-            <expect timeout="3000">
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 no switchport vlan mapping {$srcVLAN} {$dstVLAN} 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-        <exchange> 
-            <send>
-                 end 
-            </send> 
-            <expect>
-                 {$DefaultPrompt} 
-            </expect> 
-        </exchange> 
-    </action> 
+<?xml version="1.0" encoding="UTF-8"?>
+<script xmlns="http://geni-orca.renci.org/UnmapVLANS"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANS UnmapVLANS.xsd">
+	<action name="UnmapVLANS">
+		<exchange>
+			<send>config t</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>interface {$port}</send>
+			<expect timeout="3000">{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>no switchport vlan mapping {$srcVLAN} {$dstVLAN}</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+		<exchange>
+			<send>end</send>
+			<expect>{$DefaultPrompt}</expect>
+		</exchange>
+	</action>
 </script>

--- a/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/UnmapVLANSRequest.xml
+++ b/handlers/network/src/main/resources/orca/handlers/network/router/cisco/6509/UnmapVLANSRequest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/UnmapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANSRequest UnmapVLANSRequest.xsd "> 
-    <script>Log_on</script> 
-    <script>UnmapVLANS</script> 
-    <script>Log_off</script> 
+<?xml version="1.0" encoding="UTF-8"?>
+<request srcVLAN="" dstVLAN="" admin_password="" password="" target="" username="" xmlns="http://geni-orca.renci.org/UnmapVLANSRequest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geni-orca.renci.org/UnmapVLANSRequest UnmapVLANSRequest.xsd ">
+  <script>Log_on</script>
+  <script>UnmapVLANS</script>
+  <script>Log_off</script>
 </request>


### PR DESCRIPTION
Handler files that were formatted by the commits below cause errors on switch configuration. These files are modified (reverted).  
- code formatted using formatter-maven-plugin        db21e1cee68e9bdaa5897e1bf578c4fa9918ce62
- more? code formatted using formatter-maven-plugin  0ff070ee9df1293f74b9f16e26f2b33f0f38a71e
