### PR TITLE
fix for null exception in labelSyncThread

### DIFF
--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/XmlrpcOrcaState.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/XmlrpcOrcaState.java
@@ -636,7 +636,12 @@ public final class XmlrpcOrcaState implements Serializable {
             }
             for(String sId: sliceIds){
                 XmlrpcControllerSlice s = getSlice(new SliceID(sId));
-                s.getWorkflow().clearControllerAssignedLabel();
+                if(s != null) {
+                    RequestWorkflow workflow =  s.getWorkflow();
+                    if(workflow != null) {
+                        workflow.clearControllerAssignedLabel();
+                    }
+                }
             }
 
             // build a list of slices we need to restore

--- a/embed/src/main/java/orca/embed/workflow/RequestWorkflow.java
+++ b/embed/src/main/java/orca/embed/workflow/RequestWorkflow.java
@@ -335,7 +335,9 @@ public class RequestWorkflow {
     }
 
     public void clearControllerAssignedLabel() {
-        controllerAssignedLabel.clear();
+        if(controllerAssignedLabel !=  null) {
+            controllerAssignedLabel.clear();
+        }
     }
 
     protected void modifyGlobalControllerAssignedLabel() {


### PR DESCRIPTION
The below exception is being thrown by the following code which I added to clear slice local controller Label at the highlighted line. The failure occurs for slice which has active reservations but is not active itself and has null workflow pointer.