### PR TITLE
changed version number for jackson-databind

### DIFF
--- a/core/shirako/pom.xml
+++ b/core/shirako/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.4.1</version>
+			<version>2.8.11.1</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
Fix for https://github.com/RENCI-NRIG/orca5/issues/234

Changed version number for jackson-databind to address security vulnerability