### PR TITLE
fix to extract slice name from urn for slices created via geni portal

### DIFF
--- a/controllers/xmlrpc/src/main/java/orca/controllers/OrcaController.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/OrcaController.java
@@ -35,6 +35,8 @@ public class OrcaController {
     public static final String ControllerServiceManager = "controller.sm.guid";
     public static final String CometPubKeysEnabled = "orca.comet.pubkeys.enabled";
     public static final String CometHostNamesEnabled = "orca.comet.hosts.enabled";
+    public static final String SliceNameRegex = "orca.slicename.regex";
+
 
     public OrcaConnectionFactory orca;
     protected boolean fresh = true;

--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/OrcaXmlrpcHandler.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/OrcaXmlrpcHandler.java
@@ -88,6 +88,10 @@ public class OrcaXmlrpcHandler extends XmlrpcHandlerHelper implements IOrcaXmlrp
     public static final String TERM_END_FIELD = "termEnd";
     public static final int BASE_RESERVATION_BUILDER_SIZE = 100;
     public static final int PER_RESERVATION_BUILDER_SIZE = 180;
+    private static final int MAX_NUMBER_OF_CHARS_TO_USE_FROM_SLICE_NAME_FOR_PROJECT_NAME = 40;
+    private static final String sliceIdentifier = "+slice+";
+
+
 
     protected final Logger logger = OrcaController.getLogger(this.getClass().getSimpleName());
 
@@ -416,8 +420,21 @@ public class OrcaXmlrpcHandler extends XmlrpcHandlerHelper implements IOrcaXmlrp
         String readToken = RandomStringUtils.random(10, true, true);
         String sliceUserPwd = RandomStringUtils.random(10, true, true);
         String suffix = RandomStringUtils.random(10, true, true);
-        String projectName = "tenant-" + s.getSliceUrn() + "-" + suffix;
-        String userName = "owner-" + s.getSliceUrn() + "-" + suffix;
+
+        int index = s.getSliceUrn().lastIndexOf(sliceIdentifier);
+        String sliceName = s.getSliceUrn();
+        if(index >= 0) {
+            index = index + sliceIdentifier.length();
+            sliceName = sliceName.substring(index);
+        }
+
+        // This is done to ensure project name is < 64 characters; max number of chars allowed for project name
+        if(sliceName.length() > MAX_NUMBER_OF_CHARS_TO_USE_FROM_SLICE_NAME_FOR_PROJECT_NAME) {
+            sliceName = sliceName.substring(0,MAX_NUMBER_OF_CHARS_TO_USE_FROM_SLICE_NAME_FOR_PROJECT_NAME);
+        }
+
+        String projectName = "tenant-" + sliceName + "-" + suffix;
+        String userName = "owner-" + sliceName + "-" + suffix;
 
         while (it.hasNext()) {
             TicketReservationMng currRes = it.next();

--- a/core/shirako/pom.xml
+++ b/core/shirako/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.9</version>
+			<version>2.9.9.2</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/core/shirako/src/main/java/orca/shirako/container/OrcaConfiguration.java
+++ b/core/shirako/src/main/java/orca/shirako/container/OrcaConfiguration.java
@@ -64,6 +64,11 @@ public class OrcaConfiguration implements IOrcaConfiguration
     public static final String CometClientKey = "comet.clientkey";
 
     /**
+     * Slice Name Regex
+     */
+    public static final String SliceNameRegex = "orca.slicename.regex";
+
+    /**
      * Are we using secure communication with the node agent service: true|false.
      */
     public static final String PropertySecureCommunication = "secure.communication";
@@ -129,6 +134,8 @@ public class OrcaConfiguration implements IOrcaConfiguration
     protected String cometClientCertKeyStorePwd;
     protected String cometClientCert;
     protected String cometClientKey;
+    protected String sliceNameRegex;
+
 
     /**
      * Class name for the ticket factory implementation.
@@ -221,6 +228,12 @@ public class OrcaConfiguration implements IOrcaConfiguration
     {
         return cometClientKey;
     }
+
+    public String getSliceNameRegex() 
+    { 
+        return sliceNameRegex; 
+    }
+
 
     /**
      * Returns the object stored under the given key.
@@ -353,6 +366,10 @@ public class OrcaConfiguration implements IOrcaConfiguration
 
         if (properties.containsKey(OrcaConfiguration.CometClientKey)) {
             cometClientKey = properties.getProperty(OrcaConfiguration.CometClientKey);
+        }
+
+        if(properties.contains(OrcaConfiguration.SliceNameRegex)) {
+            sliceNameRegex = properties.getProperty(OrcaConfiguration.SliceNameRegex);
         }
 
         if (properties.containsKey(TicketFactoryClass)){

--- a/embed/pom.xml
+++ b/embed/pom.xml
@@ -81,13 +81,13 @@
         </dependency> 
         <dependency> 
             <groupId>
-                 velocity 
+                 org.apache.velocity 
             </groupId> 
             <artifactId>
                  velocity 
             </artifactId> 
             <version>
-                 1.4 
+                 1.7
             </version> 
         </dependency> 
     </dependencies> 

--- a/handlers/ec2/resources/handlers/ec2/handler.xml
+++ b/handlers/ec2/resources/handlers/ec2/handler.xml
@@ -85,7 +85,7 @@
         <sequential>
             <echo message="Deleting Openstack Project" />
             <var name="delete.project.output" unset="true" />
-            <var name="code" unset="true" />
+            <var name="delcode" unset="true" />
             <var name="message" unset="true" />
             <echo message="EC2_HOME=${ec2.home}" />
             <echo message="EUCA_KEY_DIR=${ec2.keys}" />
@@ -94,7 +94,7 @@
             <echo message="EC2_LOG_LEVEL=${ec2.log.level}" />
             <echo message="PROJECT_NAME=${unit.ec2.slice.project.name}" />
             <echo message="USER_NAME=${unit.ec2.slice.user.name}" />
-            <exec executable="${ec2.scripts}/nova-project-delete" resultproperty="code" outputproperty="delete.project.output">
+            <exec executable="${ec2.scripts}/nova-project-delete" resultproperty="delcode" outputproperty="delete.project.output">
                 <env key="EC2_HOME" value="${ec2.home}" />
                 <env key="EC2_DIR" value="${ec2.dir}" />
                 <env key="EC2_LOG_DIR" value="${ec2.log.dir}" />
@@ -104,14 +104,14 @@
                 <env key="USER_NAME" value="${unit.ec2.slice.user.name}" />
                 <env key="EUCA_KEY_DIR" value="${ec2.keys}" />
             </exec>
-            <echo message="exit code ${code}, ${delete.project.output}" />
+            <echo message="exit code ${delcode}, ${delete.project.output}" />
             <if>
                 <not>
-                    <equals arg1="${code}" arg2="0" />
+                    <equals arg1="${delcode}" arg2="0" />
                 </not>
                 <then>
-                    <echo message="unable to delete openstack project: exit code ${code}, ${delete.project.output}" />
-                    <property name="message" value="unable to delete openstack project: exit code ${code}, ${delete.project.output}" />
+                    <echo message="unable to delete openstack project: exit code ${delcode}, ${delete.project.output}" />
+                    <property name="message" value="unable to delete openstack project: exit code ${delcode}, ${delete.project.output}" />
                 </then>
             </if>
         </sequential>
@@ -494,6 +494,9 @@
                                 <property name="shirako.save.unit.ec2.consolelog" value="${create.instance.output}" />
                                 <property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" />
                                 <echo message="console-log: ${shirako.save.unit.ec2.consolelog} "/>
+                                <atomic.sequence.start.macro device="${unit.ec2.slice.project.name}" />
+                                    <delete.project/>
+                                <atomic.sequence.stop.macro device="${unit.ec2.slice.project.name}" />
                             </then>
                             <else>
                                 <var name="shirako.save.unit.ec2.instance" unset="true" />

--- a/handlers/ec2/resources/scripts/nova-essex-start
+++ b/handlers/ec2/resources/scripts/nova-essex-start
@@ -73,24 +73,20 @@ try:
     print (instance_uuid)
 
 except VM_Broken_Unsshable as e:
-    Project().cleanup(os.environ['PROJECT_NAME'], os.environ['USER_NAME'])
     LOG.error("nova-essex-start: VM_Unsshable: " + str(e.get_vm_id()) + " : " + str(e.get_console_log()))
     print (e.get_console_log())
     sys.exit(3)
 except VM_Broken_Unpingable as e:
-    Project().cleanup(os.environ['PROJECT_NAME'], os.environ['USER_NAME'])
     # LOG.error("nova-essex-start: VM_Unpingable: " + str(type(e)) + " : " + str(e) + "\n" + str(traceback.format_exc()))
     LOG.error("nova-essex-start: VM_Unpingable: " + str(e.get_vm_id()) + " : " + str(e.get_console_log()))
     print (e.get_console_log())
     sys.exit(2)
 except VM_Broken as e:
-    Project().cleanup(os.environ['PROJECT_NAME'], os.environ['USER_NAME'])
     LOG.error("nova-essex-start: VM_Broken: " + str(e.get_vm_id()) + " : " + str(e.get_console_log()))
     # LOG.error("nova-essex-start: " + str(type(e)) + " : " + str(e) + "\n" + str(traceback.format_exc()))
     print (e.get_console_log())
     sys.exit(1)
 except Exception as e:
-    Project().cleanup(os.environ['PROJECT_NAME'], os.environ['USER_NAME'])
     LOG.error("nova-essex-start: " + str(type(e)) + " : " + str(e) + "\n" + str(traceback.format_exc()))
     sys.exit(1)
 

--- a/handlers/ec2/resources/scripts/nova-essex-stop
+++ b/handlers/ec2/resources/scripts/nova-essex-stop
@@ -67,7 +67,6 @@ try:
 
 except Exception as e:
     LOG.error("nova-essex-stop: " + str(type(e)) + " : " + str(e) + "\n" + str(traceback.format_exc()))
-    Project().cleanup(os.environ['PROJECT_NAME'], os.environ['USER_NAME'])
     sys.exit(1)
 
 sys.exit(0)

--- a/handlers/ec2/resources/scripts/nova_essex_common.py
+++ b/handlers/ec2/resources/scripts/nova_essex_common.py
@@ -553,8 +553,7 @@ class Project:
         cmd = ["openstack", "security", "group", "rule", "create",
                "--ingress",
                "--ethertype", "IPv6",
-               "--protocol", "tcp",
-               "--remote-ip", "::/0",
+               "--protocol", "any",
                "default",
                "-fjson"]
         rtncode, data_stdout, data_stderr = Commands.run(cmd, timeout=60 * 30)
@@ -570,8 +569,7 @@ class Project:
         cmd = ["openstack", "security", "group", "rule", "create",
                "--ingress",
                "--ethertype", "IPv6",
-               "--protocol", "udp",
-               "--remote-ip", "::/0",
+               "--protocol", "any",
                "default",
                "-fjson"]
         rtncode, data_stdout, data_stderr = Commands.run(cmd, timeout=60 * 30)

--- a/handlers/ec2/resources/scripts/nova_essex_common.py
+++ b/handlers/ec2/resources/scripts/nova_essex_common.py
@@ -552,7 +552,7 @@ class Project:
 
         cmd = ["openstack", "security", "group", "rule", "create",
                "--ingress",
-               "--ethertype", "IPv6",
+               "--ethertype", "IPv4",
                "--protocol", "any",
                "default",
                "-fjson"]

--- a/handlers/ec2/resources/scripts/nova_essex_common.py
+++ b/handlers/ec2/resources/scripts/nova_essex_common.py
@@ -517,42 +517,6 @@ class Project:
         cmd = ["openstack", "security", "group", "rule", "create",
                "--ingress",
                "--ethertype", "IPv4",
-               "--protocol", "icmp",
-               "--remote-ip", "0.0.0.0/0",
-               "default",
-               "-fjson"]
-
-        rtncode, data_stdout, data_stderr = Commands.run(cmd, timeout=60 * 30)
-        if rtncode != 0:
-            LOG.warning("openstack security group rule create command with non-zero rtncode " +
-                        ": " + str(cmd) +
-                        ", rtncode: " + str(rtncode) +
-                        ", data_stdout: " + str(data_stdout) +
-                        ", data_stderr: " + str(data_stderr))
-            if data_stdout.find("SecurityGroupRuleExists") == -1:
-                raise Openstack_Command_Fail(str(cmd))
-
-        cmd = ["openstack", "security", "group", "rule", "create",
-               "--ingress",
-               "--ethertype", "IPv4",
-               "--protocol", "tcp",
-               "--dst-port", "22",
-               "--remote-ip", "0.0.0.0/0",
-               "default",
-               "-fjson"]
-        rtncode, data_stdout, data_stderr = Commands.run(cmd, timeout=60 * 30)
-        if rtncode != 0:
-            LOG.warning("openstack security group rule create command with non-zero rtncode " +
-                        ": " + str(cmd) +
-                        ", rtncode: " + str(rtncode) +
-                        ", data_stdout: " + str(data_stdout) +
-                        ", data_stderr: " + str(data_stderr))
-            if data_stdout.find("SecurityGroupRuleExists") == -1:
-                raise Openstack_Command_Fail(str(cmd))
-
-        cmd = ["openstack", "security", "group", "rule", "create",
-               "--ingress",
-               "--ethertype", "IPv4",
                "--protocol", "any",
                "default",
                "-fjson"]

--- a/handlers/ec2/src/main/java/orca/handlers/ec2/tasks/NEucaGenerateCometData.java
+++ b/handlers/ec2/src/main/java/orca/handlers/ec2/tasks/NEucaGenerateCometData.java
@@ -117,6 +117,7 @@ class NEucaGenerateCometData extends NEucaCometDataProcessor{
         System.out.println("Processing interfaces section");
 
         Integer[] eths = getEths();
+        System.out.println("interfaces count=" + eths.length);
 
         for (int i = 0; i < eths.length; i++) {
             Integer eth = eths[i];

--- a/handlers/providers/resources/handler/providers/euca-sites/unified.euca.net.xml
+++ b/handlers/providers/resources/handler/providers/euca-sites/unified.euca.net.xml
@@ -208,6 +208,9 @@
                             <then>
                                 <echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" />
                                 <property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" />
+                                <atomic.sequence.start.macro device="${unit.ec2.slice.project.name}" />
+                                     <delete.project/>
+                                <atomic.sequence.stop.macro device="${unit.ec2.slice.project.name}" />
                             </then>
                             <else>
                                 <var name="shirako.save.unit.quantum.net.uuid" unset="true" />
@@ -299,8 +302,8 @@
                                 <equals arg1="${code}" arg2="0" />
                             </not>
                             <then>
-                                <echo message="unable to create quantum network: exit code ${code}, ${create.instance.output}" />
-                                <property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" />
+                                <echo message="unable to delete quantum network: exit code ${code}, ${create.instance.output}" />
+                                <property name="message" value="unable to delete instance: exit code ${code}, ${create.instance.output}" />
                             </then>
                             <else>
                                 <atomic.sequence.start.macro device="${unit.ec2.slice.project.name}" />

--- a/handlers/providers/resources/handler/providers/quantum-vlan/handler.xml
+++ b/handlers/providers/resources/handler/providers/quantum-vlan/handler.xml
@@ -388,6 +388,9 @@ in a *hybrid* or OF only rack switch /ib -->
                             <then>
                                 <echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" />
                                 <property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" />
+                                <atomic.sequence.start.macro device="${unit.ec2.slice.project.name}" />
+                                    <delete.project/>
+                                <atomic.sequence.stop.macro device="${unit.ec2.slice.project.name}" />
                             </then>
                             <else>
                                 <var name="shirako.save.unit.quantum.net.uuid" unset="true" />

--- a/handlers/providers/resources/handler/providers/quantum/handler.xml
+++ b/handlers/providers/resources/handler/providers/quantum/handler.xml
@@ -184,6 +184,9 @@
                     <then>
                         <echo message="unable to create quantum network: exit code ${code}, ${create.network.output}" />
                         <property name="message" value="unable to create instance: exit code ${code}, ${create.network.output}" />
+                        <atomic.sequence.start.macro device="${unit.ec2.slice.project.name}" />
+                             <delete.project/>
+                        <atomic.sequence.stop.macro device="${unit.ec2.slice.project.name}" />
                     </then>
                     <else>
                         <var name="shirako.save.unit.quantum.net.uuid" unset="true" />
@@ -258,8 +261,8 @@
                         <equals arg1="${code}" arg2="0" />
                     </not>
                     <then>
-                        <echo message="unable to create quantum network: exit code ${code}, ${create.instance.output}" />
-                        <property name="message" value="unable to create instance: exit code ${code}, ${create.instance.output}" />
+                        <echo message="unable to delete quantum network: exit code ${code}, ${create.instance.output}" />
+                        <property name="message" value="unable to delete instance: exit code ${code}, ${create.instance.output}" />
                     </then>
                     <else>
                         <atomic.sequence.start.macro device="${unit.ec2.slice.project.name}" />

--- a/handlers/providers/resources/scripts/neuca-quantum-create-net
+++ b/handlers/providers/resources/scripts/neuca-quantum-create-net
@@ -75,7 +75,6 @@ try:
     
 except Exception as e:
     LOG.error("neuca-quantum-create-net: " + str(type(e)) + " : " + str(e) + "\n" + str(traceback.format_exc()))
-    Project().cleanup(os.environ['PROJECT_NAME'], os.environ['USER_NAME'])
     sys.exit(1)
 
 sys.exit(0)

--- a/handlers/providers/resources/scripts/nova_essex_common.py
+++ b/handlers/providers/resources/scripts/nova_essex_common.py
@@ -553,8 +553,7 @@ class Project:
         cmd = ["openstack", "security", "group", "rule", "create",
                "--ingress",
                "--ethertype", "IPv6",
-               "--protocol", "tcp",
-               "--remote-ip", "::/0",
+               "--protocol", "any",
                "default",
                "-fjson"]
         rtncode, data_stdout, data_stderr = Commands.run(cmd, timeout=60 * 30)
@@ -570,8 +569,7 @@ class Project:
         cmd = ["openstack", "security", "group", "rule", "create",
                "--ingress",
                "--ethertype", "IPv6",
-               "--protocol", "udp",
-               "--remote-ip", "::/0",
+               "--protocol", "any",
                "default",
                "-fjson"]
         rtncode, data_stdout, data_stderr = Commands.run(cmd, timeout=60 * 30)

--- a/handlers/providers/resources/scripts/nova_essex_common.py
+++ b/handlers/providers/resources/scripts/nova_essex_common.py
@@ -552,7 +552,7 @@ class Project:
 
         cmd = ["openstack", "security", "group", "rule", "create",
                "--ingress",
-               "--ethertype", "IPv6",
+               "--ethertype", "IPv4",
                "--protocol", "any",
                "default",
                "-fjson"]

--- a/handlers/providers/resources/scripts/nova_essex_common.py
+++ b/handlers/providers/resources/scripts/nova_essex_common.py
@@ -517,42 +517,6 @@ class Project:
         cmd = ["openstack", "security", "group", "rule", "create",
                "--ingress",
                "--ethertype", "IPv4",
-               "--protocol", "icmp",
-               "--remote-ip", "0.0.0.0/0",
-               "default",
-               "-fjson"]
-
-        rtncode, data_stdout, data_stderr = Commands.run(cmd, timeout=60 * 30)
-        if rtncode != 0:
-            LOG.warning("openstack security group rule create command with non-zero rtncode " +
-                        ": " + str(cmd) +
-                        ", rtncode: " + str(rtncode) +
-                        ", data_stdout: " + str(data_stdout) +
-                        ", data_stderr: " + str(data_stderr))
-            if data_stdout.find("SecurityGroupRuleExists") == -1:
-                raise Openstack_Command_Fail(str(cmd))
-
-        cmd = ["openstack", "security", "group", "rule", "create",
-               "--ingress",
-               "--ethertype", "IPv4",
-               "--protocol", "tcp",
-               "--dst-port", "22",
-               "--remote-ip", "0.0.0.0/0",
-               "default",
-               "-fjson"]
-        rtncode, data_stdout, data_stderr = Commands.run(cmd, timeout=60 * 30)
-        if rtncode != 0:
-            LOG.warning("openstack security group rule create command with non-zero rtncode " +
-                        ": " + str(cmd) +
-                        ", rtncode: " + str(rtncode) +
-                        ", data_stdout: " + str(data_stdout) +
-                        ", data_stderr: " + str(data_stderr))
-            if data_stdout.find("SecurityGroupRuleExists") == -1:
-                raise Openstack_Command_Fail(str(cmd))
-
-        cmd = ["openstack", "security", "group", "rule", "create",
-               "--ingress",
-               "--ethertype", "IPv4",
                "--protocol", "any",
                "default",
                "-fjson"]

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -147,13 +147,13 @@
         </dependency> 
         <dependency> 
             <groupId>
-                 velocity 
+                 org.apache.velocity 
             </groupId> 
             <artifactId>
                  velocity 
             </artifactId> 
             <version>
-                 1.4 
+                 2.0 
             </version> 
         </dependency> 
         <dependency> 

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.10</version>
+                <version>1.4.11</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
@@ -254,14 +254,14 @@
                 <version>3.0.0.v201112011016</version>
             </dependency>
             <dependency>
-                <groupId>velocity</groupId>
+                <groupId>org.apache.velocity</groupId>
                 <artifactId>velocity</artifactId>
-                <version>1.4</version>
+                <version>1.7</version>
             </dependency>
             <dependency>
-                <groupId>velocity-tools</groupId>
-                <artifactId>velocity-tools-view</artifactId>
-                <version>1.2</version>
+                <groupId>org.apache.velocity</groupId>
+                <artifactId>velocity-tools</artifactId>
+                <version>2.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-digester</groupId>


### PR DESCRIPTION
Slice created from portal have slice urn of the form "urn:publicid:IDN+ch.geni.net:<GENIPROJECT>+slice+<SLICENAME>-<RANDOMSTRING>"

In current implementation Slice URN was used to construct the openstack project name. Openstack does not allow more than 64 characters in name and also throws error for + character in urn. Modified the controller to extract the slice name from URN and use a max of 40 characters from name for constructing project and user name.

Also addresses other issues indicated in : https://github.com/RENCI-NRIG/orca5/issues/250