### PR TITLE
changes to fix closure of stuck redeeming tickets and increase wrapper shutdown time

### DIFF
--- a/controllers/xmlrpc/pom.xml
+++ b/controllers/xmlrpc/pom.xml
@@ -164,6 +164,14 @@
                                                 </property> 
                                                 <property> 
                                                     <name>
+                                                         wrapper.shutdown.timeout 
+                                                    </name> 
+                                                    <value>
+                                                         300 
+                                                    </value> 
+                                                </property> 
+                                                <property> 
+                                                    <name>
                                                          wrapper.ping.timeout 
                                                     </name> 
                                                     <value>

--- a/core/shirako/src/main/java/orca/shirako/kernel/ReservationClient.java
+++ b/core/shirako/src/main/java/orca/shirako/kernel/ReservationClient.java
@@ -784,6 +784,15 @@ class ReservationClient extends Reservation implements IKernelClientReservation,
                 // delay the close until the redeem comes back
                 logger.info("Received close for a redeeming reservation. Deferring close until redeem completes.");
                 closedDuringRedeem = true;
+                if(term != null) {
+                    Date now = new Date();
+                    if(term.expired(now)) {
+                        logger.info("Ticket has expired, closing a redeeming reservations");
+                        transition("close", ReservationStates.Closed, pending);
+                        // tell the broker we do not need the resources anymore
+                        doRelinquish();
+                    }
+                }
             }
             break;
         case ReservationStates.Active:


### PR DESCRIPTION
- Force close expired ticketed redeeming tickets
- Increase wrapper shutdown time

Addresses: https://github.com/RENCI-NRIG/orca5/issues/264