### PR TITLE
changes to handle geni-api w.r.t ticketreview and comet cert validati…

### DIFF
--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/OrcaXmlrpcHandler.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/OrcaXmlrpcHandler.java
@@ -2119,17 +2119,17 @@ public class OrcaXmlrpcHandler extends XmlrpcHandlerHelper implements IOrcaXmlrp
                 // lock the slice
                 ndlSlice.lock();
 
-                if (!ndlSlice.isStableOK() && !ndlSlice.isStableError()) {
-                    logger.info("deleteSlice(): unable to delete slice that is not yet stable, try again later");
-                    return setError("unable to delete slice that is not yet stable, try again later");
-                }
-
                 if (ndlSlice.isDeadOrClosing())
                     return setError("slice already closed");
 
                 if (!ndlSlice.matchUserDN(userDN)) {
                     logger.error("deleteSlice(): user " + userDN + " is not owner of slice " + slice_urn);
                     return setError("user " + userDN + " is not owner of slice " + slice_urn);
+                }
+
+                if (!ndlSlice.isStableOK() && !ndlSlice.isStableError()) {
+                    logger.info("deleteSlice(): unable to delete slice that is not yet stable, try again later");
+                    return setError("unable to delete slice that is not yet stable, try again later");
                 }
 
                 List<ReservationMng> allRes = ndlSlice.getAllReservations(sm);

--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
@@ -158,6 +158,14 @@ public class GeniAmV2Handler extends XmlrpcHandlerHelper implements IGeniAmV2Int
                             "ERROR: slice " + slice_urn + " contains no reservations");
                 }
 
+                for (ReservationMng reservationMng : allRes) {
+                    String notice = reservationMng.getNotices();
+                    if (reservationMng.getState() == OrcaConstants.ReservationStateClosed &&
+                            notice != null && notice.toLowerCase().contains("insufficient") ) {
+                        reservationMng.setState(OrcaConstants.ReservationStateFailed);
+                    }
+                }
+
                 String ndlMan = null;
                 GeniStates geniStates = GeniAmV2Handler.getSliceGeniState(instance, slice_urn);
                 try {
@@ -184,6 +192,7 @@ public class GeniAmV2Handler extends XmlrpcHandlerHelper implements IGeniAmV2Int
                 } else {
                     result = (String) convRes.get("ret");
                 }
+
                 if (compressed)
                     result = CompressEncode.compressEncode(result);
             }

--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
@@ -804,14 +804,18 @@ public class GeniAmV2Handler extends XmlrpcHandlerHelper implements IGeniAmV2Int
                             NdlToRSpecHelper.getControllerForUrl(baseUrl));
                     en.put(ApiReturnFields.GENI_URN.name, resUrn);
                     en.put(ApiReturnFields.GENI_STATUS.name, getSliverGeniState(r).name);
+                    String errorDetail = r.getNotices();
+                    if (errorDetail == null) {
+                        errorDetail = "no further information available";
+                    }
+                    String errorMessage = "ERROR: unable to provision requested resource (" + errorDetail + ")";
+
                     if (r.getState() == OrcaConstants.ReservationStateFailed) {
-                        en.put(ApiReturnFields.GENI_ERROR.name, (r.getNotices() != null ? r.getNotices()
-                                : "ERROR: no detailed error message available"));
+                        en.put(ApiReturnFields.GENI_ERROR.name, errorMessage);
                     } 
-                    else if (r.getState() == OrcaConstants.ReservationStateClosed && r.getNotices() != null &&
-                            r.getNotices().toLowerCase().contains("insufficient")) {
-                        en.put(ApiReturnFields.GENI_ERROR.name, (r.getNotices() != null ? r.getNotices()
-                                : "ERROR: no detailed error message available"));
+                    else if (r.getState() == OrcaConstants.ReservationStateClosed && errorDetail != null &&
+                            errorDetail.toLowerCase().contains("insufficient")) {
+                        en.put(ApiReturnFields.GENI_ERROR.name, errorMessage);
                         en.put(ApiReturnFields.GENI_STATUS.name, GeniStates.FAILED.name);
                     }
                     else {

--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
@@ -847,7 +847,7 @@ public class GeniAmV2Handler extends XmlrpcHandlerHelper implements IGeniAmV2Int
                 ss.put(ApiReturnFields.GENI_RESOURCES.name, resourceList);
                 if (reservationsClosedDueToInsuffificentResources) {
                     ss.put(ApiReturnFields.GENI_STATUS.name, GeniStates.FAILED.name);
-                    return getStandardApiReturn(ApiReturnCodes.SUCCESS.code, ss, "Not sufficient resources available!");
+                    return getStandardApiReturn(ApiReturnCodes.SUCCESS.code, ss, "Insufficient resources at the aggregate!");
                 }
                 else {
                     ss.put(ApiReturnFields.GENI_STATUS.name, getSliceGeniState(instance, slice_urn).name);

--- a/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
+++ b/controllers/xmlrpc/src/main/java/orca/controllers/xmlrpc/geni/GeniAmV2Handler.java
@@ -807,7 +807,14 @@ public class GeniAmV2Handler extends XmlrpcHandlerHelper implements IGeniAmV2Int
                     if (r.getState() == OrcaConstants.ReservationStateFailed) {
                         en.put(ApiReturnFields.GENI_ERROR.name, (r.getNotices() != null ? r.getNotices()
                                 : "ERROR: no detailed error message available"));
-                    } else {
+                    } 
+                    else if (r.getState() == OrcaConstants.ReservationStateClosed && r.getNotices() != null &&
+                            r.getNotices().toLowerCase().contains("insufficient")) {
+                        en.put(ApiReturnFields.GENI_ERROR.name, (r.getNotices() != null ? r.getNotices()
+                                : "ERROR: no detailed error message available"));
+                        en.put(ApiReturnFields.GENI_STATUS.name, GeniStates.FAILED.name);
+                    }
+                    else {
                         en.put(ApiReturnFields.GENI_ERROR.name, "");
                     }
                     // en.put(ApiReturnFields.ORCA_EXPIRES.name, (new Date(r.getEnd())).toString()); //ORCA reservation

--- a/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/geni/GeniAmV2HandlerTest.java
+++ b/controllers/xmlrpc/src/test/java/orca/controllers/xmlrpc/geni/GeniAmV2HandlerTest.java
@@ -90,4 +90,63 @@ public class GeniAmV2HandlerTest {
         return geniReturn;
     }
 
+    @Test
+    public void sliceStatus() throws Exception {
+
+        final Map<String, Object> geniReturn = doSliverStatus();
+
+        // check for success
+        final Object output = geniReturn.get(IGeniAmV2Interface.ApiReturnFields.VALUE.name);
+        System.out.println(output);
+
+        assertTrue("Geni Status Api returns error for reservations closed with insufficient resources", output.toString().toLowerCase().contains("insufficient"));
+        assertTrue("Geni Status Api returns error for reservations closed with insufficient resources", output.toString().toLowerCase().contains("geni_status=failed"));
+
+    }
+
+    protected Map<String, Object> doSliverStatus() throws Exception {
+        // use our Mock controller
+        final MockXmlRpcController controller = new MockXmlRpcController();
+        controller.setProperty(XmlRpcController.PropertyOrcaCredentialVerification, "false");
+        controller.start();
+
+        // create a slice
+        final XmlrpcControllerSlice slice = OrcaXmlrpcHandlerTest.doTestCreateSlice(controller,
+                "src/test/resources/20_create_with_netmask.rdf", "geniSliceStatus", true, 3);
+
+        int count = 0;
+
+        // need to force the slice reservations to be active
+        for (TicketReservationMng reservation : slice.getComputedReservations()) {
+            reservation.setState(OrcaConstants.ReservationStateClosed);
+            if (count == 0) {
+                count++;
+                reservation.setNotices("urn:publicid:IDN+ch.geni.net:GENI-Enter+slice+Komal3) is in state [Closed,None]\n" +
+                        "\n" +
+                        "Last ticket update: java.lang.RuntimeException: Insufficient <memoryCapacity,0> to meet request:12000");
+            }
+
+        }
+
+        // Start the Renew via Geni API
+        GeniAmV2Handler geniHandler = new GeniAmV2Handler();
+        geniHandler.verifyCredentials = false;
+        geniHandler.controller = controller;
+
+        Object[] credentials = new Object[0];
+
+        final Map<String, Object> geniReturn = geniHandler.SliverStatus(slice.getSliceUrn(), credentials,
+                null);
+
+        // check for success
+        final Map<String, Object> codes = (Map<String, Object>) geniReturn
+                .get(IGeniAmV2Interface.ApiReturnFields.CODE.name);
+        final int code = (int) codes.get(IGeniAmV2Interface.ApiReturnFields.CODE_GENI_CODE.name);
+        final Object output = geniReturn.get(IGeniAmV2Interface.ApiReturnFields.OUTPUT.name);
+
+        assertEquals("Geni API returned error! " + output, IGeniAmV2Interface.ApiReturnCodes.SUCCESS.code, code);
+
+        return geniReturn;
+    }
+
 }

--- a/handlers/ec2/resources/scripts/comet_common_iface.py
+++ b/handlers/ec2/resources/scripts/comet_common_iface.py
@@ -62,10 +62,7 @@ class CometInterface:
             'Key':rId,
             'readToken':readToken
         }
-        if self._verify == False:
-            response = requests.get((host + '/readScope'), headers=self._headers(), params=params, verify=False)
-        else:
-            response = requests.get((host + '/readScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
+        response = requests.get((host + '/readScope'), headers=self._headers(), params=params, verify=False)
         self._log.debug ("get_family: Received Response Status Code: " + str(response.status_code))
         if response.status_code == 200 :
             self._log.debug ("get_family: Received Response Message: " + response.json()["message"])
@@ -105,7 +102,7 @@ class CometInterface:
         if self._verify == False:
             response = requests.delete((host +'/deleteScope'), headers=self._headers(), params=params, verify=False)
         else:
-            response = requests.delete((host +'/deleteScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
+            response = requests.delete((host +'/deleteScope'), headers=self._headers(), params=params, cert= self._cert, verify=self._verify)
         self._log.debug ("delete_family: Received Response Status Code: " + str(response.status_code))
         if response.status_code == 200 :
             self._log.debug ("delete_family: Received Response Message: " + response.json()["message"])
@@ -128,10 +125,7 @@ class CometInterface:
                'family':family,
             }
 
-        if self._verify == False:
-            response = requests.get((host +'/enumerateScope'), headers=self._headers(), params=params, verify=False)
-        else:
-            response = requests.get((host +'/enumerateScope'), headers=self._headers(), params=params, cert= self._cert, verify=False)
+        response = requests.get((host +'/enumerateScope'), headers=self._headers(), params=params, verify=False)
         self._log.debug ("enumerate_families: Received Response Status Code: " + str(response.status_code))
         if response.status_code == 200 :
             self._log.debug ("enumerate_families: Received Response Message: " + response.json()["message"])

--- a/handlers/ec2/resources/scripts/nova_essex_common.py
+++ b/handlers/ec2/resources/scripts/nova_essex_common.py
@@ -6,6 +6,8 @@ import json
 import signal
 import time
 import traceback
+import stat
+import tempfile
 from os import kill
 from signal import alarm, signal, SIGALRM, SIGKILL
 from subprocess import *
@@ -290,6 +292,53 @@ class Project:
 
         return new_project_id
 
+    @classmethod
+    def atomic_output(self, file_contents, output_fname):
+        """
+        Take a Python object and attempt to serialize it to JSON and write
+        the resulting bytes to an output file atomically.
+
+        This function does not return a value and throws an exception on failure.
+
+        :param output_object: A Python object to be serialized into JSON.
+        :param output_fname: A filename to write the object into.
+        :type output_fname: string
+        """
+
+        dir_name, file_name = os.path.split(output_fname)
+    
+        tmp_fd, tmp_file_name = tempfile.mkstemp(dir = dir_name, prefix=file_name)
+        try:
+            with os.fdopen(tmp_fd, 'w') as fp:
+                fp.write(file_contents)
+
+            # atomically move new tokens in place
+            self.atomic_rename(tmp_file_name, output_fname)
+
+        finally:
+            try:
+                os.unlink(tmp_file_name)
+            except OSError:
+                pass
+
+
+    @classmethod
+    def atomic_rename(self, tmp_file, target_file, mode=stat.S_IRUSR):
+        """
+        If successful Credmgr will only be dealing with fully prepared and
+        usable credential cache files.
+
+        :param tmp_file: The temp file path containing
+            the TGT acquired from the ngbauth service.
+        :type tmp_file: string
+        :param target_file: The target file.
+        :return: Whether the chmod/rename was successful.
+        :rtype: bool
+        """
+
+        os.chmod(tmp_file, mode)
+        os.rename(tmp_file, target_file)
+
 
     @classmethod
     def generate_user_keystone_file(self, project_name, user_name, user_pwd, ec2_auth_url):
@@ -569,13 +618,8 @@ class Project:
             time.sleep(4)
             return key_file
 
-        fd = None
         try:
-            fd = open(key_file, 'a+')
-            fd.seek(0)
-            fd.truncate()
-            fd.write(ssh_key)
-            fd.close
+            self.atomic_output(ssh_key, key_file)
         except Exception as e:
             LOG.error("Exception occured e=" + str(e))
             raise Openstack_Command_Fail('failed to write to key file ' + key_file)


### PR DESCRIPTION
- Updated GeniV2AmHandler to look for closed reservations which failed because of insufficient resources. Mark them as failed instead of closed for Portal
- Updated Comet Interface Python code to not verify with certificate for read and enumerate operations.
- Updated Nova Essex python script to ensure only single keys are written to the credential files when generating key pairs